### PR TITLE
NewsLens v2: enhancement program — backend lenses, search, Gemini, copy governance, v2 UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,7 @@ cd backend && pytest -x                           # Run tests, stop on first fai
 # Frontend validation
 cd frontend && npm run build                      # Full production build (uses --webpack)
 cd frontend && npx vitest run                     # Run unit tests
+cd frontend && npm run lint:copy                  # Copy guard — blocks internal jargon in UI (see docs/content/COPY-GUIDELINES.md)
 
 # Full stack validation
 docker-compose up -d db                           # Ensure DB is running

--- a/README.md
+++ b/README.md
@@ -1,0 +1,89 @@
+# NewsLens
+
+An AI-powered news intelligence platform. NewsLens ingests articles from RSS feeds and the GDELT API, deduplicates them, embeds them with OpenAI, and clusters related coverage into single **stories** — so you read one multi-source briefing instead of ten near-identical headlines.
+
+> Two-language stack: a Python **FastAPI** backend (data pipeline + ML) and a TypeScript **Next.js** frontend (UI), talking over REST JSON. Mobile ships as a native Android app via **Capacitor** wrapping the Next.js static export.
+
+## Features
+
+- **Daily briefing** — top story clusters with AI-generated summaries, free sources surfaced first.
+- **Discover deck** — swipe through randomized cards; swipes adjust your topic weights.
+- **Deep dive** — every cluster expands to all its source articles with a confidence score (`src:N · coh:0.XX`).
+- **Explore/exploit feed** — 70% your topics, 30% new ones; the ratio adapts to your feedback.
+- **Bring your own key** — per-user OpenAI API key, Fernet-encrypted, with an env-var fallback.
+- **Graceful degradation** — if OpenAI is down, articles still ingest and the UI shows snippets instead of AI summaries.
+
+## Stack
+
+| Layer | Tech |
+|-------|------|
+| Frontend | Next.js 16 (App Router), React 19, Tailwind CSS 4, Framer Motion |
+| Backend | Python, FastAPI, APScheduler |
+| Database | PostgreSQL + pgvector |
+| ML | OpenAI `text-embedding-3-small`, pgvector cosine clustering |
+| Mobile | Capacitor (Android) |
+
+## Quick start
+
+Requires Docker (recommended for the DB + backend) and Node.js for the frontend.
+
+```bash
+# 1. Configure environment
+cp .env.example .env        # then fill in DATABASE_URL, OPENAI_API_KEY, ENCRYPTION_KEY
+
+# 2. Start the database + backend
+docker-compose up -d db      # PostgreSQL + pgvector
+cd backend && alembic upgrade head
+uvicorn app.main:app --reload   # http://localhost:8000
+
+# 3. Start the frontend (separate terminal)
+cd frontend && npm install
+npm run dev                  # http://localhost:3000
+```
+
+Open http://localhost:3000 and the briefing should load. The frontend proxies `/api/*` to the backend via Next.js rewrites, so no CORS setup is needed in web mode.
+
+> **Windows ARM note:** the backend's `greenlet` dependency fails to load natively — run the backend in Docker. Next.js Turbopack is also unsupported on ARM, so all scripts use the `--webpack` flag. See [CLAUDE.md](CLAUDE.md) for the full list of platform caveats.
+
+## Data pipeline
+
+Four APScheduler jobs run inside the FastAPI process:
+
+1. **RSS fetcher** (every 10 min) → feedparser → dedup → `articles`
+2. **GDELT fetcher** (every 15 min) → trafilatura extraction → dedup → `articles`
+3. **Embedding backfill** (every 5 min) → OpenAI embeddings → pgvector
+4. **Clustering** (every 10 min) → pgvector cosine distance (threshold 0.15) → `story_clusters`
+
+## Mobile (Android)
+
+```bash
+cd frontend
+npm run build:android   # static export + Capacitor sync
+npm run apk:debug       # build debug APK via Gradle
+# Output: frontend/android/app/build/outputs/apk/debug/app-debug.apk
+```
+
+`npm run build:android:prod` points the APK at the deployed backend instead of localhost. Requires JDK 21. The Android emulator does not work on Windows ARM — test on a physical device.
+
+## Testing
+
+```bash
+cd backend && pytest          # backend API + encryption tests
+cd frontend && npx vitest run # frontend unit tests
+cd frontend && npx playwright test  # E2E
+```
+
+## Documentation
+
+| Doc | What's in it |
+|-----|--------------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | System, pipeline, and DB diagrams; decision log |
+| [DEPLOY.md](DEPLOY.md) | Deploying to Render or Fly.io; env var reference |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Developer onboarding |
+| [design-system.md](design-system.md) | Colors, typography, spacing — read before any UI change |
+| [ROADMAP.md](ROADMAP.md) / [PRODUCT_ROADMAP.md](PRODUCT_ROADMAP.md) | Feature roadmap + known limitations |
+| [CLAUDE.md](CLAUDE.md) | Commands, architecture notes, platform caveats |
+
+## License
+
+No license file is present — all rights reserved by default. Add a `LICENSE` if you intend this to be open source.

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -14,6 +14,7 @@ from app.models import (
     Source,
     StoryCluster,
     Topic,
+    User,
     UserFeedback,
     UserPreference,
     UserSetting,
@@ -28,8 +29,11 @@ from app.schemas import (
     FeedbackCreate,
     FeedbackOut,
     FeedResponse,
+    GeminiKeyUpdate,
     HealthResponse,
     KeyTestResult,
+    ProfileOut,
+    ProfileUpdate,
     SavedArticleOut,
     SavedListResponse,
     SourceOut,
@@ -948,3 +952,192 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
         stories_saved=stories_saved,
         topics_explored=topics_explored,
     )
+
+
+# ════════════════════════════════════════════════════════════════════
+# Enhancement program endpoints (E1 / E3 / E5 / E6 / E7 / E8)
+# ════════════════════════════════════════════════════════════════════
+
+async def _user_profession_locale(db: AsyncSession):
+    u = (
+        await db.execute(select(User).where(User.id == DEFAULT_USER_ID))
+    ).scalar_one_or_none()
+    return (u.profession if u else None), (u.locale if u and u.locale else "IN")
+
+
+# ── E3: profile (profession + locale + interests) ──
+@router.get("/profile", response_model=ProfileOut)
+async def get_profile(db: AsyncSession = Depends(get_db)):
+    u = (
+        await db.execute(select(User).where(User.id == DEFAULT_USER_ID))
+    ).scalar_one_or_none()
+    prefs = (
+        await db.execute(
+            select(Topic.name)
+            .join(UserPreference, UserPreference.topic_id == Topic.id)
+            .where(UserPreference.user_id == DEFAULT_USER_ID)
+        )
+    ).all()
+    return ProfileOut(
+        profession=u.profession if u else None,
+        locale=(u.locale if u and u.locale else "IN"),
+        interests=[r[0] for r in prefs],
+    )
+
+
+@router.put("/profile", response_model=ProfileOut)
+async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)):
+    u = (
+        await db.execute(select(User).where(User.id == DEFAULT_USER_ID))
+    ).scalar_one_or_none()
+    if not u:
+        u = User(id=DEFAULT_USER_ID)
+        db.add(u)
+    if body.profession is not None:
+        u.profession = body.profession.strip() or None
+    if body.locale is not None:
+        u.locale = body.locale.strip() or "IN"
+    if body.interests is not None:
+        await db.execute(
+            UserPreference.__table__.delete().where(
+                UserPreference.user_id == DEFAULT_USER_ID
+            )
+        )
+        for raw in body.interests:
+            name = raw.strip()
+            if not name:
+                continue
+            topic = (
+                await db.execute(select(Topic).where(Topic.name == name))
+            ).scalar_one_or_none()
+            if not topic:
+                topic = Topic(name=name)
+                db.add(topic)
+                await db.flush()
+            db.add(
+                UserPreference(user_id=DEFAULT_USER_ID, topic_id=topic.id, weight=1.0)
+            )
+    await db.commit()
+    return await get_profile(db)
+
+
+# ── E1: per-user Gemini key ──
+@router.put("/settings/gemini-key")
+async def set_gemini_key(body: GeminiKeyUpdate, db: AsyncSession = Depends(get_db)):
+    from app.services.encryption import encrypt_value
+
+    # ensure the (single) user row exists (prod seeds it; tests use create_all only)
+    u = (
+        await db.execute(select(User).where(User.id == DEFAULT_USER_ID))
+    ).scalar_one_or_none()
+    if not u:
+        db.add(User(id=DEFAULT_USER_ID))
+        await db.flush()
+
+    setting = (
+        await db.execute(select(UserSetting).where(UserSetting.user_id == DEFAULT_USER_ID))
+    ).scalar_one_or_none()
+    if not setting:
+        setting = UserSetting(user_id=DEFAULT_USER_ID)
+        db.add(setting)
+    if body.gemini_api_key:
+        setting.gemini_api_key_encrypted = encrypt_value(body.gemini_api_key.strip())
+        setting.gemini_key_verified = False
+        setting.gemini_key_verified_at = None
+    else:
+        setting.gemini_api_key_encrypted = None
+        setting.gemini_key_verified = False
+    await db.commit()
+    return {"has_gemini_key": bool(setting.gemini_api_key_encrypted)}
+
+
+@router.post("/settings/test-gemini-key", response_model=KeyTestResult)
+async def test_gemini_key(db: AsyncSession = Depends(get_db)):
+    from app.services.encryption import decrypt_value
+
+    setting = (
+        await db.execute(select(UserSetting).where(UserSetting.user_id == DEFAULT_USER_ID))
+    ).scalar_one_or_none()
+    if not setting or not setting.gemini_api_key_encrypted:
+        return KeyTestResult(success=False, error="No Gemini key saved")
+    try:
+        key = decrypt_value(setting.gemini_api_key_encrypted)
+        import google.generativeai as genai
+
+        genai.configure(api_key=key)
+        models = list(genai.list_models())
+        setting.gemini_key_verified = True
+        setting.gemini_key_verified_at = datetime.now(timezone.utc)
+        await db.commit()
+        return KeyTestResult(success=True, models_available=len(models))
+    except Exception as e:  # noqa: BLE001
+        return KeyTestResult(success=False, error=str(e)[:200])
+
+
+# ── E5/E6/E7/E8: cluster lenses ──
+@router.get("/clusters/{cluster_id}/analysis")
+async def cluster_analysis(
+    cluster_id: int, lens: str = "key_facts", db: AsyncSession = Depends(get_db)
+):
+    from fastapi import HTTPException
+
+    from app.services import lenses
+
+    if lens not in ("key_facts", "5ws", "profession"):
+        raise HTTPException(status_code=400, detail="invalid lens")
+    profession, _ = await _user_profession_locale(db)
+    return await lenses.analysis(db, cluster_id, lens, profession=profession)
+
+
+@router.get("/clusters/{cluster_id}/impact")
+async def cluster_impact(cluster_id: int, db: AsyncSession = Depends(get_db)):
+    from app.services import lenses
+
+    profession, locale = await _user_profession_locale(db)
+    return await lenses.impact(db, cluster_id, profession, locale)
+
+
+@router.get("/clusters/{cluster_id}/strategic")
+async def cluster_strategic(cluster_id: int, db: AsyncSession = Depends(get_db)):
+    from app.services import lenses
+
+    return await lenses.strategic(db, cluster_id)
+
+
+@router.get("/clusters/{cluster_id}/trivia")
+async def cluster_trivia(
+    cluster_id: int, difficulty: str = "medium", db: AsyncSession = Depends(get_db)
+):
+    from fastapi import HTTPException
+
+    from app.services import lenses
+
+    if difficulty not in ("easy", "medium", "hard"):
+        raise HTTPException(status_code=400, detail="invalid difficulty")
+    return await lenses.trivia(db, cluster_id, difficulty)
+
+
+@router.get("/trivia/daily")
+async def trivia_daily(
+    topic: str = "world news", difficulty: str = "medium",
+    db: AsyncSession = Depends(get_db),
+):
+    from fastapi import HTTPException
+
+    from app.services import llm
+
+    if difficulty not in ("easy", "medium", "hard"):
+        raise HTTPException(status_code=400, detail="invalid difficulty")
+    prompt = (
+        f"Write 3 {difficulty}-difficulty multiple-choice quiz questions about recent "
+        f"developments in {topic}. Each has exactly 4 options, one correct. "
+        'Respond ONLY as JSON: {"questions": [{"question": "...", '
+        '"options": ["a","b","c","d"], "answer_index": 0, "explanation": "...", '
+        '"difficulty": "' + difficulty + '"}]}'
+    )
+    try:
+        return await llm.generate(prompt, schema={"questions": []})
+    except llm.LLMUnavailable:
+        return {"unavailable": True, "reason": "no_llm_key"}
+    except Exception:  # noqa: BLE001 — graceful degradation, never 500
+        return {"unavailable": True, "reason": "llm_error"}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1141,3 +1141,123 @@ async def trivia_daily(
         return {"unavailable": True, "reason": "no_llm_key"}
     except Exception:  # noqa: BLE001 — graceful degradation, never 500
         return {"unavailable": True, "reason": "llm_error"}
+
+
+# ── E2: admin sources ──
+@router.get("/admin/sources")
+async def list_sources(db: AsyncSession = Depends(get_db)):
+    rows = (await db.execute(select(Source).order_by(Source.name))).scalars().all()
+    return [
+        {
+            "id": s.id, "name": s.name, "url": s.url, "rss_url": s.rss_url,
+            "region": s.region, "category": s.category,
+            "is_paywalled": s.is_paywalled,
+            "source_type": s.source_type.value if s.source_type else None,
+        }
+        for s in rows
+    ]
+
+
+@router.post("/admin/sources")
+async def create_source(body: dict, db: AsyncSession = Depends(get_db)):
+    from fastapi import HTTPException
+
+    name = (body.get("name") or "").strip()
+    url = (body.get("url") or "").strip()
+    if not name or not url:
+        raise HTTPException(status_code=400, detail="name and url are required")
+    existing = (
+        await db.execute(select(Source).where(Source.url == url))
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="source url already exists")
+    s = Source(
+        name=name, url=url, rss_url=(body.get("rss_url") or "").strip() or None,
+        is_paywalled=bool(body.get("is_paywalled", False)),
+        source_type=body.get("source_type", "other"),
+        region=body.get("region", "global"), category=body.get("category"),
+    )
+    db.add(s)
+    await db.commit()
+    return {"id": s.id, "name": s.name}
+
+
+# ── E4: hybrid search (semantic + keyword; keyword ranks above semantic-only) ──
+@router.get("/search")
+async def search(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(20, ge=1, le=50),
+    db: AsyncSession = Depends(get_db),
+):
+    from fastapi import HTTPException
+
+    query_str = q.strip()
+    if not query_str:
+        raise HTTPException(status_code=400, detail="empty query")
+
+    results: dict[int, dict] = {}
+
+    # Semantic (pgvector NN) — lower priority than exact keyword.
+    from app.services.embeddings import generate_embedding
+
+    try:
+        emb = await generate_embedding(query_str)
+    except Exception:  # noqa: BLE001
+        emb = None
+    if emb is not None:
+        rows = (
+            await db.execute(
+                text(
+                    "SELECT id FROM articles WHERE embedding IS NOT NULL "
+                    "ORDER BY embedding <=> :v LIMIT :k"
+                ),
+                {"v": str(emb), "k": limit},
+            )
+        ).all()
+        for i, (aid,) in enumerate(rows):
+            results[aid] = {"id": aid, "matched_on": "meaning", "rank": 100 + i}
+
+    # Keyword (exact substring) — promote to the top.
+    kw_rows = (
+        await db.execute(
+            select(Article.id).where(Article.title.ilike(f"%{query_str}%")).limit(limit)
+        )
+    ).all()
+    for (aid,) in kw_rows:
+        if aid in results:
+            results[aid]["matched_on"] = "topic+meaning"
+            results[aid]["rank"] = 0
+        else:
+            results[aid] = {"id": aid, "matched_on": "topic", "rank": 0}
+
+    ids = list(results.keys())
+    if not ids:
+        return {"query": query_str, "results": []}
+
+    arts = (
+        await db.execute(
+            select(Article).options(selectinload(Article.source)).where(Article.id.in_(ids))
+        )
+    ).scalars().all()
+    art_map = {a.id: a for a in arts}
+    ca = (
+        await db.execute(
+            select(ClusterArticle.article_id, ClusterArticle.cluster_id).where(
+                ClusterArticle.article_id.in_(ids)
+            )
+        )
+    ).all()
+    art_to_cluster = {aid: cid for aid, cid in ca}
+
+    out = []
+    for aid, meta in sorted(results.items(), key=lambda kv: kv[1]["rank"]):
+        a = art_map.get(aid)
+        if not a:
+            continue
+        out.append({
+            "id": a.id, "title": a.title, "snippet": a.snippet, "url": a.url,
+            "source": SourceOut.model_validate(a.source).model_dump(),
+            "cluster_id": art_to_cluster.get(a.id),
+            "matched_on": meta["matched_on"],
+        })
+    return {"query": query_str, "results": out}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -104,19 +104,44 @@ async def get_feed(
     results = await db.execute(query.offset(offset).limit(per_page))
     articles = results.scalars().all()
 
+    # Resolve cluster membership + per-cluster source count in aggregate (no N+1).
+    article_ids = [a.id for a in articles]
+    art_to_cluster: dict[int, int] = {}
+    cluster_source_count: dict[int, int] = {}
+    clusters_with_summary: set[int] = set()
+    if article_ids:
+        ca_rows = (
+            await db.execute(
+                select(ClusterArticle.article_id, ClusterArticle.cluster_id).where(
+                    ClusterArticle.article_id.in_(article_ids)
+                )
+            )
+        ).all()
+        for art_id, cl_id in ca_rows:
+            art_to_cluster[art_id] = cl_id
+        cluster_ids = list(set(art_to_cluster.values()))
+        if cluster_ids:
+            cnt_rows = (
+                await db.execute(
+                    select(ClusterArticle.cluster_id, func.count(ClusterArticle.id))
+                    .where(ClusterArticle.cluster_id.in_(cluster_ids))
+                    .group_by(ClusterArticle.cluster_id)
+                )
+            ).all()
+            cluster_source_count = {cl_id: cnt for cl_id, cnt in cnt_rows}
+            sum_rows = (
+                await db.execute(
+                    select(StoryCluster.id).where(
+                        StoryCluster.id.in_(cluster_ids),
+                        StoryCluster.summary.isnot(None),
+                    )
+                )
+            ).all()
+            clusters_with_summary = {row[0] for row in sum_rows}
+
     article_outs = []
     for a in articles:
-        # Count how many sources cover this story (via clusters)
-        cluster_count_q = (
-            select(func.count(ClusterArticle.id))
-            .join(ClusterArticle.cluster)
-            .join(
-                ClusterArticle,
-                ClusterArticle.cluster_id == StoryCluster.id,
-            )
-            .where(ClusterArticle.article_id == a.id)
-        )
-
+        cl_id = art_to_cluster.get(a.id)
         article_outs.append(
             ArticleOut(
                 id=a.id,
@@ -126,9 +151,9 @@ async def get_feed(
                 source=SourceOut.model_validate(a.source),
                 published_at=a.published_at,
                 embedding_status=a.embedding_status,
-                source_count=1,
-                cluster_id=None,
-                has_ai_summary=False,
+                source_count=cluster_source_count.get(cl_id, 1) if cl_id else 1,
+                cluster_id=cl_id,
+                has_ai_summary=cl_id in clusters_with_summary,
             )
         )
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -57,6 +57,9 @@ class Settings(BaseSettings):
     gdelt_fetch_interval_minutes: int = 15
     embedding_backfill_interval_minutes: int = 5
 
+    # GDELT query (parametrized for region/language; default India + English)
+    gdelt_query: str = "sourcecountry:IN"
+
     # Embedding config
     embedding_model: str = "text-embedding-3-small"
     embedding_dimensions: int = 1536

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -44,6 +44,11 @@ class Settings(BaseSettings):
     # OpenAI
     openai_api_key: str = ""
 
+    # LLM generation provider (embeddings stay on OpenAI — see embeddings.py)
+    generation_provider: str = "openai"  # "openai" | "gemini"
+    gemini_api_key: str = ""
+    gemini_model: str = "gemini-2.0-flash"
+
     # Encryption (for storing API keys in DB)
     encryption_key: str = ""
 

--- a/backend/app/data/sources.json
+++ b/backend/app/data/sources.json
@@ -1,0 +1,25 @@
+[
+  {"name": "The Guardian - World", "url": "https://www.theguardian.com", "rss_url": "https://www.theguardian.com/world/rss", "is_paywalled": false, "source_type": "newspaper", "region": "global", "category": "world"},
+  {"name": "BBC News", "url": "https://www.bbc.com/news", "rss_url": "http://feeds.bbci.co.uk/news/rss.xml", "is_paywalled": false, "source_type": "newspaper", "region": "global", "category": "world"},
+  {"name": "NPR News", "url": "https://www.npr.org", "rss_url": "https://feeds.npr.org/1001/rss.xml", "is_paywalled": false, "source_type": "channel", "region": "global", "category": "world"},
+  {"name": "Al Jazeera", "url": "https://www.aljazeera.com", "rss_url": "https://www.aljazeera.com/xml/rss/all.xml", "is_paywalled": false, "source_type": "channel", "region": "global", "category": "world"},
+  {"name": "Ars Technica", "url": "https://arstechnica.com", "rss_url": "https://feeds.arstechnica.com/arstechnica/index", "is_paywalled": false, "source_type": "blog", "region": "global", "category": "technology"},
+  {"name": "TechCrunch", "url": "https://techcrunch.com", "rss_url": "https://techcrunch.com/feed/", "is_paywalled": false, "source_type": "blog", "region": "global", "category": "technology"},
+  {"name": "The Verge", "url": "https://www.theverge.com", "rss_url": "https://www.theverge.com/rss/index.xml", "is_paywalled": false, "source_type": "blog", "region": "global", "category": "technology"},
+  {"name": "Hacker News", "url": "https://news.ycombinator.com", "rss_url": "https://hnrss.org/frontpage", "is_paywalled": false, "source_type": "other", "region": "global", "category": "technology"},
+  {"name": "Nature News", "url": "https://www.nature.com", "rss_url": "https://www.nature.com/nature.rss", "is_paywalled": true, "source_type": "newspaper", "region": "global", "category": "science"},
+  {"name": "Wall Street Journal", "url": "https://www.wsj.com", "rss_url": "https://feeds.a.dj.com/rss/RSSWorldNews.xml", "is_paywalled": true, "source_type": "newspaper", "region": "global", "category": "business"},
+
+  {"name": "The Hindu - National", "url": "https://www.thehindu.com", "rss_url": "https://www.thehindu.com/news/national/feeder/default.rss", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "national"},
+  {"name": "Times of India - Top", "url": "https://timesofindia.indiatimes.com", "rss_url": "https://timesofindia.indiatimes.com/rssfeedstopstories.cms", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "national"},
+  {"name": "The Indian Express", "url": "https://indianexpress.com", "rss_url": "https://indianexpress.com/feed/", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "national"},
+  {"name": "Hindustan Times - India", "url": "https://www.hindustantimes.com", "rss_url": "https://www.hindustantimes.com/feeds/rss/india-news/rssfeed.xml", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "national"},
+  {"name": "NDTV - India", "url": "https://www.ndtv.com", "rss_url": "https://feeds.feedburner.com/ndtvnews-india-news", "is_paywalled": false, "source_type": "channel", "region": "in", "category": "national"},
+  {"name": "The Print", "url": "https://theprint.in", "rss_url": "https://theprint.in/feed/", "is_paywalled": false, "source_type": "blog", "region": "in", "category": "national"},
+  {"name": "Scroll.in", "url": "https://scroll.in", "rss_url": "https://feeds.feedburner.com/ScrollinArticles.rss", "is_paywalled": false, "source_type": "blog", "region": "in", "category": "national"},
+  {"name": "LiveMint", "url": "https://www.livemint.com", "rss_url": "https://www.livemint.com/rss/news", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "business"},
+  {"name": "Moneycontrol", "url": "https://www.moneycontrol.com", "rss_url": "https://www.moneycontrol.com/rss/latestnews.xml", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "business"},
+  {"name": "Economic Times - Markets", "url": "https://economictimes.indiatimes.com", "rss_url": "https://economictimes.indiatimes.com/markets/rssfeeds/1977021501.cms", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "business"},
+  {"name": "Business Standard", "url": "https://www.business-standard.com", "rss_url": "https://www.business-standard.com/rss/latest.rss", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "business"},
+  {"name": "PIB India", "url": "https://pib.gov.in", "rss_url": "https://pib.gov.in/RssMain.aspx?ModId=6&Lang=1&Regid=3", "is_paywalled": false, "source_type": "wire", "region": "in", "category": "policy"}
+]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,6 +55,9 @@ async def init_db():
             # E2: source region + category
             "ALTER TABLE sources ADD COLUMN IF NOT EXISTS region VARCHAR(16) DEFAULT 'global'",
             "ALTER TABLE sources ADD COLUMN IF NOT EXISTS category VARCHAR(64)",
+            # E4: HNSW index for fast vector search (clustering + /search)
+            "CREATE INDEX IF NOT EXISTS ix_articles_embedding_hnsw "
+            "ON articles USING hnsw (embedding vector_cosine_ops)",
             # Add 'read' to feedback_type enum if not present
             "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'read' AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'feedbacktype')) THEN ALTER TYPE feedbacktype ADD VALUE 'read'; END IF; END $$",
         ]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,6 +39,22 @@ async def init_db():
         for stmt in [
             "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS coherence FLOAT",
             "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS summary_generated_at TIMESTAMPTZ",
+            # E5/E6/E7/E8: cached LLM lens outputs + source-set hash for invalidation
+            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS analysis_json JSONB",
+            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS impact_json JSONB",
+            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS strategic_json JSONB",
+            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS trivia_json JSONB",
+            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS source_hash VARCHAR(64)",
+            # E3: profession-agnostic personalization
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS profession VARCHAR(255)",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS locale VARCHAR(16) DEFAULT 'IN'",
+            # E1: per-user Gemini key
+            "ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS gemini_api_key_encrypted TEXT",
+            "ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS gemini_key_verified BOOLEAN DEFAULT FALSE",
+            "ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS gemini_key_verified_at TIMESTAMPTZ",
+            # E2: source region + category
+            "ALTER TABLE sources ADD COLUMN IF NOT EXISTS region VARCHAR(16) DEFAULT 'global'",
+            "ALTER TABLE sources ADD COLUMN IF NOT EXISTS category VARCHAR(64)",
             # Add 'read' to feedback_type enum if not present
             "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'read' AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'feedbacktype')) THEN ALTER TYPE feedbacktype ADD VALUE 'read'; END IF; END $$",
         ]:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.config import settings
@@ -46,6 +47,9 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    # E3: profession-agnostic personalization (free-text profession + locale)
+    profession: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    locale: Mapped[str] = mapped_column(String(16), default="IN")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -68,6 +72,9 @@ class Source(Base):
         Enum(SourceType), default=SourceType.other
     )
     is_paywalled: Mapped[bool] = mapped_column(Boolean, default=False)
+    # E2: region ("global" | "in") + free-form category for India/topic sourcing
+    region: Mapped[str | None] = mapped_column(String(16), default="global")
+    category: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -143,6 +150,14 @@ class StoryCluster(Base):
     summary_generated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # E5/E6/E7/E8: cached LLM lens outputs (keyed by profession-hash inside the JSON
+    # where personalized). source_hash invalidates caches when the cluster's article
+    # set changes.
+    analysis_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    impact_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    strategic_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    trivia_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    source_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -211,6 +226,12 @@ class UserSetting(Base):
     openai_api_key_encrypted: Mapped[str | None] = mapped_column(Text)
     openai_key_verified: Mapped[bool] = mapped_column(Boolean, default=False)
     openai_key_verified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True)
+    )
+    # E1: per-user Gemini key (mirrors the OpenAI trio)
+    gemini_api_key_encrypted: Mapped[str | None] = mapped_column(Text)
+    gemini_key_verified: Mapped[bool] = mapped_column(Boolean, default=False)
+    gemini_key_verified_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True)
     )
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -169,6 +169,24 @@ class KeyTestResult(BaseModel):
     models_available: int = 0
 
 
+# --- Profile (E3) ---
+class ProfileOut(BaseModel):
+    profession: str | None = None
+    locale: str = "IN"
+    interests: list[str] = []
+
+
+class ProfileUpdate(BaseModel):
+    profession: str | None = None
+    locale: str | None = None
+    interests: list[str] | None = None  # topic names; replaces the user's preferences
+
+
+# --- Gemini key (E1) ---
+class GeminiKeyUpdate(BaseModel):
+    gemini_api_key: str | None = None  # raw key to save, or None to remove
+
+
 # --- Saved ---
 class SavedArticleOut(BaseModel):
     article_id: int

--- a/backend/app/services/fetcher.py
+++ b/backend/app/services/fetcher.py
@@ -1,10 +1,13 @@
 """RSS feed fetcher service with retry and structured logging."""
 
+import json
 import structlog
 import feedparser
 import httpx
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from pathlib import Path
+from urllib.parse import quote_plus
 
 from sqlalchemy import select, text
 
@@ -119,40 +122,73 @@ async def backfill_topic_assignments():
     logger.info("topic_assignment_backfill_complete", processed=len(articles), success=success)
 
 
-# Starter RSS feeds
-STARTER_FEEDS = [
-    {"name": "Reuters - World", "url": "https://www.reuters.com", "rss_url": "https://www.rssboard.org/rss-specification", "is_paywalled": False, "source_type": "wire"},
-    {"name": "Ars Technica", "url": "https://arstechnica.com", "rss_url": "https://feeds.arstechnica.com/arstechnica/index", "is_paywalled": False, "source_type": "blog"},
-    {"name": "TechCrunch", "url": "https://techcrunch.com", "rss_url": "https://techcrunch.com/feed/", "is_paywalled": False, "source_type": "blog"},
-    {"name": "The Verge", "url": "https://www.theverge.com", "rss_url": "https://www.theverge.com/rss/index.xml", "is_paywalled": False, "source_type": "blog"},
-    {"name": "Hacker News", "url": "https://news.ycombinator.com", "rss_url": "https://hnrss.org/frontpage", "is_paywalled": False, "source_type": "other"},
-    {"name": "BBC News", "url": "https://www.bbc.com/news", "rss_url": "http://feeds.bbci.co.uk/news/rss.xml", "is_paywalled": False, "source_type": "newspaper"},
-    {"name": "NPR News", "url": "https://www.npr.org", "rss_url": "https://feeds.npr.org/1001/rss.xml", "is_paywalled": False, "source_type": "channel"},
-    {"name": "Al Jazeera", "url": "https://www.aljazeera.com", "rss_url": "https://www.aljazeera.com/xml/rss/all.xml", "is_paywalled": False, "source_type": "channel"},
-    {"name": "Nature News", "url": "https://www.nature.com", "rss_url": "https://www.nature.com/nature.rss", "is_paywalled": True, "source_type": "newspaper"},
-    {"name": "Wall Street Journal", "url": "https://www.wsj.com", "rss_url": "https://feeds.a.dj.com/rss/RSSWorldNews.xml", "is_paywalled": True, "source_type": "newspaper"},
-]
+_SOURCES_FILE = Path(__file__).resolve().parent.parent / "data" / "sources.json"
 
 
-async def ensure_sources():
-    """Seed starter sources if none exist."""
-    async with async_session() as session:
-        result = await session.execute(select(Source).limit(1))
-        if result.scalar_one_or_none() is not None:
-            return
+def load_feeds() -> list[dict]:
+    """Load the configured feed list (global + India) from app/data/sources.json."""
+    with open(_SOURCES_FILE, encoding="utf-8") as f:
+        return json.load(f)
 
-        for feed in STARTER_FEEDS:
-            source = Source(
-                name=feed["name"],
-                url=feed["url"],
-                rss_url=feed["rss_url"],
-                is_paywalled=feed["is_paywalled"],
-                source_type=feed["source_type"],
-            )
-            session.add(source)
 
+def google_news_rss_url(
+    query: str, *, hl: str = "en-IN", gl: str = "IN", ceid: str = "IN:en"
+) -> str:
+    """Build a Google News RSS search URL for per-topic ingestion (default: India/English)."""
+    return (
+        f"https://news.google.com/rss/search?q={quote_plus(query)}"
+        f"&hl={hl}&gl={gl}&ceid={ceid}"
+    )
+
+
+async def ensure_sources(session=None):
+    """Upsert configured sources: insert new feeds, backfill region/category on existing.
+
+    Keyed on rss_url (fallback url). Safe to run repeatedly — adds feeds to an existing DB
+    instead of only seeding when the table is empty. Accepts an optional session (tests).
+    """
+    if session is not None:
+        await _upsert_sources(session, load_feeds())
+        return
+    async with async_session() as s:
+        await _upsert_sources(s, load_feeds())
+
+
+async def _upsert_sources(session, feeds: list[dict]):
+    added = 0
+    if True:
+        for feed in feeds:
+            existing = (
+                await session.execute(
+                    select(Source).where(Source.rss_url == feed["rss_url"])
+                )
+            ).scalar_one_or_none()
+            if existing is None:
+                existing = (
+                    await session.execute(
+                        select(Source).where(Source.url == feed["url"])
+                    )
+                ).scalar_one_or_none()
+            if existing is not None:
+                existing.region = feed.get("region", existing.region)
+                existing.category = feed.get("category", existing.category)
+                if not existing.rss_url:
+                    existing.rss_url = feed["rss_url"]
+            else:
+                session.add(
+                    Source(
+                        name=feed["name"],
+                        url=feed["url"],
+                        rss_url=feed["rss_url"],
+                        is_paywalled=feed.get("is_paywalled", False),
+                        source_type=feed.get("source_type", "other"),
+                        region=feed.get("region", "global"),
+                        category=feed.get("category"),
+                    )
+                )
+                added += 1
         await session.commit()
-        logger.info("sources_seeded", count=len(STARTER_FEEDS))
+    logger.info("sources_ensured", total=len(feeds), added=added)
 
 
 def parse_pub_date(entry) -> datetime | None:

--- a/backend/app/services/gdelt.py
+++ b/backend/app/services/gdelt.py
@@ -35,7 +35,7 @@ async def fetch_gdelt():
             response = await client.get(
                 GDELT_DOC_API,
                 params={
-                    "query": "sourcecountry:US",
+                    "query": settings.gdelt_query,
                     "mode": "artlist",
                     "maxrecords": "50",
                     "format": "json",

--- a/backend/app/services/lenses.py
+++ b/backend/app/services/lenses.py
@@ -1,0 +1,199 @@
+"""LLM "lens" engine (E5 analysis · E6 WIIFM impact · E7 strategic/game-theory · E8 trivia).
+
+Each lens: build a prompt from a cluster's source articles -> llm.generate(schema=...) ->
+cache the parsed JSON on the cluster's JSONB column (sub-keyed by sub-lens / profession /
+difficulty), invalidated by a hash of the cluster's article set. Returns a typed dict;
+on no key returns ``{"unavailable": True}`` (never raises to the caller).
+"""
+import hashlib
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models import Article, ClusterArticle, StoryCluster, User
+from app.services import llm
+
+logger = structlog.get_logger()
+
+
+def profession_hash(profession: str | None) -> str:
+    """Stable, normalized cache key for a (free-text) profession. Empty -> 'default'."""
+    norm = (profession or "").strip().lower()
+    if not norm:
+        return "default"
+    return hashlib.sha1(norm.encode()).hexdigest()[:12]
+
+
+def _source_hash(articles: list[Article]) -> str:
+    ids = sorted(a.id for a in articles)
+    return hashlib.sha1(",".join(map(str, ids)).encode()).hexdigest()[:16]
+
+
+def _cluster_text(cluster: StoryCluster, articles: list[Article]) -> str:
+    lines = [f"STORY: {cluster.title}"]
+    for i, a in enumerate(articles, 1):
+        lines.append(f"\n{i}. {a.title}")
+        if a.snippet:
+            lines.append(f"   {a.snippet[:400]}")
+    return "\n".join(lines)
+
+
+# ── prompt builders (each returns (prompt, schema_flag)) ──
+def _prompt_key_facts(text):
+    return (
+        f"{text}\n\nExtract the 4-6 most important, concrete facts from the above coverage. "
+        'Respond ONLY as JSON: {"facts": ["fact 1", "fact 2", ...]}'
+    )
+
+
+def _prompt_5ws(text):
+    return (
+        f"{text}\n\nAnswer the five Ws for this story. "
+        'Respond ONLY as JSON: {"who": "...", "what": "...", "when": "...", '
+        '"where": "...", "why": "..."}'
+    )
+
+
+def _prompt_profession(text, profession):
+    who = profession or "a curious generalist reader"
+    return (
+        f"{text}\n\nExplain what this story means specifically for {who}. Be concrete and "
+        'practical. Respond ONLY as JSON: {"headline": "one-line takeaway for them", '
+        '"points": ["point 1", "point 2", "point 3"]}'
+    )
+
+
+def _prompt_impact(text, profession, locale):
+    who = profession or "a curious generalist reader"
+    return (
+        f"{text}\n\nReader profile: profession='{who}', locale='{locale}'. "
+        "Answer 'What's in it for me?' — how this news may affect this reader across "
+        "Finance/markets, their Profession, Policy & regulation, and Daily life. Lead with a "
+        "single sharp headline verdict (what it means + what, if anything, to consider). "
+        'Respond ONLY as JSON: {"headline": "...", "dimensions": ['
+        '{"key": "finance", "label": "Finance", "body": "..."}, '
+        '{"key": "profession", "label": "Your field", "body": "..."}, '
+        '{"key": "policy", "label": "Policy", "body": "..."}, '
+        '{"key": "daily", "label": "Daily life", "body": "..."}]}'
+    )
+
+
+def _prompt_strategic(text):
+    return (
+        f"{text}\n\nGive a game-theory / strategic read of this story. Identify the key actors "
+        "and each one's incentives and likely next move; name the type of 'game' being played "
+        "(e.g. zero-sum, coordination, chicken, prisoner's dilemma, signalling); list 2-3 "
+        "second-order effects; and end with one non-obvious take. "
+        'Respond ONLY as JSON: {"actors": [{"name": "...", "incentive": "...", '
+        '"likely_move": "..."}], "game_type": "...", "second_order": ["...", "..."], '
+        '"non_obvious_take": "..."}'
+    )
+
+
+def _prompt_trivia(text, difficulty):
+    return (
+        f"{text}\n\nWrite 3 {difficulty}-difficulty multiple-choice quiz questions testing "
+        "understanding of this story. Each has exactly 4 options, one correct. "
+        'Respond ONLY as JSON: {"questions": [{"question": "...", "options": ["a","b","c","d"], '
+        '"answer_index": 0, "explanation": "...", "difficulty": "' + difficulty + '"}]}'
+    )
+
+
+async def _load(db: AsyncSession, cluster_id: int):
+    cluster = (
+        await db.execute(select(StoryCluster).where(StoryCluster.id == cluster_id))
+    ).scalar_one_or_none()
+    if not cluster:
+        return None, []
+    articles = (
+        await db.execute(
+            select(Article)
+            .join(ClusterArticle, ClusterArticle.article_id == Article.id)
+            .where(ClusterArticle.cluster_id == cluster_id)
+        )
+    ).scalars().all()
+    return cluster, list(articles)
+
+
+async def get_lens(
+    db: AsyncSession,
+    cluster_id: int,
+    *,
+    column: str,
+    subkey: str,
+    prompt: str,
+    schema: dict,
+    force: bool = False,
+):
+    """Return cached lens JSON for (cluster, subkey) or generate + cache it."""
+    cluster, articles = await _load(db, cluster_id)
+    if cluster is None:
+        return {"error": "cluster_not_found"}
+    if not articles:
+        return {"unavailable": True, "reason": "no_sources"}
+
+    sh = _source_hash(articles)
+    cache = dict(getattr(cluster, column) or {})
+    entry = cache.get(subkey)
+    if entry and entry.get("source_hash") == sh and not force:
+        return {"cached": True, **entry["data"]}
+
+    try:
+        data = await llm.generate(prompt, schema=schema)
+    except llm.LLMUnavailable:
+        return {"unavailable": True, "reason": "no_llm_key"}
+    except Exception as e:  # noqa: BLE001 — never 500 on an LLM/API failure
+        logger.warning("lens_generate_failed", column=column, error=str(e))
+        return {"unavailable": True, "reason": "llm_error"}
+    if not isinstance(data, dict):
+        data = {"result": data}
+
+    cache[subkey] = {"source_hash": sh, "data": data}
+    setattr(cluster, column, cache)
+    await db.commit()
+    return {"cached": False, **data}
+
+
+# ── public API (used by routes) ──
+async def analysis(db, cluster_id, lens: str, profession: str | None = None):
+    cluster, articles = await _load(db, cluster_id)
+    if cluster is None:
+        return {"error": "cluster_not_found"}
+    text = _cluster_text(cluster, articles) if articles else ""
+    if lens == "key_facts":
+        return await get_lens(db, cluster_id, column="analysis_json", subkey="key_facts",
+                              prompt=_prompt_key_facts(text), schema={"facts": []})
+    if lens == "5ws":
+        return await get_lens(db, cluster_id, column="analysis_json", subkey="5ws",
+                              prompt=_prompt_5ws(text), schema={"who": ""})
+    if lens == "profession":
+        return await get_lens(db, cluster_id, column="analysis_json",
+                              subkey=f"prof:{profession_hash(profession)}",
+                              prompt=_prompt_profession(text, profession),
+                              schema={"headline": ""})
+    return {"error": "unknown_lens"}
+
+
+async def impact(db, cluster_id, profession: str | None, locale: str = "IN"):
+    cluster, articles = await _load(db, cluster_id)
+    text = _cluster_text(cluster, articles) if cluster and articles else ""
+    return await get_lens(db, cluster_id, column="impact_json",
+                          subkey=f"prof:{profession_hash(profession)}",
+                          prompt=_prompt_impact(text, profession, locale),
+                          schema={"headline": "", "dimensions": []})
+
+
+async def strategic(db, cluster_id):
+    cluster, articles = await _load(db, cluster_id)
+    text = _cluster_text(cluster, articles) if cluster and articles else ""
+    return await get_lens(db, cluster_id, column="strategic_json", subkey="default",
+                          prompt=_prompt_strategic(text), schema={"actors": []})
+
+
+async def trivia(db, cluster_id, difficulty: str = "medium"):
+    cluster, articles = await _load(db, cluster_id)
+    text = _cluster_text(cluster, articles) if cluster and articles else ""
+    return await get_lens(db, cluster_id, column="trivia_json", subkey=difficulty,
+                          prompt=_prompt_trivia(text, difficulty), schema={"questions": []})

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -68,7 +68,29 @@ async def _resolve_gemini_key() -> str | None:
     now = time.time()
     if _gem_key_cache is not None and (now - _gem_key_ts) < _GEM_TTL:
         return _gem_key_cache
-    key = settings.gemini_api_key or None
+    key = None
+    try:
+        from sqlalchemy import select
+        from app.database import async_session
+        from app.models import UserSetting
+        from app.services.encryption import decrypt_value
+
+        async with async_session() as s:
+            row = (
+                await s.execute(
+                    select(UserSetting).where(
+                        UserSetting.user_id == 1,
+                        UserSetting.gemini_api_key_encrypted.isnot(None),
+                        UserSetting.gemini_key_verified.is_(True),
+                    )
+                )
+            ).scalar_one_or_none()
+            if row and row.gemini_api_key_encrypted:
+                key = decrypt_value(row.gemini_api_key_encrypted)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("gemini_key_lookup_failed", error=str(e))
+    if not key:
+        key = settings.gemini_api_key or None
     _gem_key_cache, _gem_key_ts = key, now
     return key
 

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -1,0 +1,128 @@
+"""Unified LLM generation seam (E1 / E★).
+
+Generation provider is switchable via ``settings.generation_provider`` ("openai"|"gemini").
+Embeddings stay on OpenAI (see ``embeddings.py``) — do NOT route embeddings through here.
+All generative features (summary, analysis, impact, strategic, trivia) should call ``generate()``.
+"""
+import json
+import re
+import time
+
+import structlog
+
+from app.config import settings
+
+logger = structlog.get_logger()
+
+
+class LLMUnavailable(Exception):
+    """Raised when no usable LLM key/client is configured.
+
+    Callers should catch this and return a typed ``unavailable`` state, never a 500.
+    """
+
+
+# ── Pure helper: robust JSON extraction from model output ──
+def extract_json(text):
+    """Best-effort parse of JSON from an LLM response.
+
+    Handles already-parsed dict/list, ```json fenced blocks, and JSON embedded in prose.
+    Raises ``ValueError`` if nothing parseable is found.
+    """
+    if isinstance(text, (dict, list)):
+        return text
+    if not text or not str(text).strip():
+        raise ValueError("empty LLM output")
+    s = str(text).strip()
+
+    fence = re.search(r"```(?:json)?\s*(.*?)```", s, re.DOTALL)
+    if fence:
+        s = fence.group(1).strip()
+
+    try:
+        return json.loads(s)
+    except Exception:
+        pass
+
+    # Fall back to the widest {...} or [...] span in the string.
+    for open_ch, close_ch in (("{", "}"), ("[", "]")):
+        start, end = s.find(open_ch), s.rfind(close_ch)
+        if 0 <= start < end:
+            try:
+                return json.loads(s[start:end + 1])
+            except Exception:
+                continue
+    raise ValueError("could not parse JSON from model output")
+
+
+# ── Per-user Gemini key resolver (separate cache slot from the OpenAI one) ──
+# NOTE: per-user DB key (user_settings.gemini_api_key_encrypted) lands with the E1
+# migration; until then this resolves the env key. Kept as a seam so callers don't change.
+_gem_key_cache: str | None = None
+_gem_key_ts: float = 0.0
+_GEM_TTL = 300
+
+
+async def _resolve_gemini_key() -> str | None:
+    global _gem_key_cache, _gem_key_ts
+    now = time.time()
+    if _gem_key_cache is not None and (now - _gem_key_ts) < _GEM_TTL:
+        return _gem_key_cache
+    key = settings.gemini_api_key or None
+    _gem_key_cache, _gem_key_ts = key, now
+    return key
+
+
+async def _generate_openai(prompt: str, *, system: str | None = None,
+                           schema=None, model: str | None = None):
+    # Module ref (not a bound import) so tests can patch embeddings._get_client_async.
+    from app.services import embeddings
+    client = await embeddings._get_client_async()
+    if client is None:
+        raise LLMUnavailable("no OpenAI key configured")
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": prompt})
+    kwargs = {
+        "model": model or settings.summary_model,
+        "messages": messages,
+        "temperature": 0.3,
+        "max_tokens": 800,
+    }
+    if schema is not None:
+        kwargs["response_format"] = {"type": "json_object"}
+    resp = await client.chat.completions.create(**kwargs)
+    text = resp.choices[0].message.content
+    return extract_json(text) if schema is not None else text.strip()
+
+
+async def _generate_gemini(prompt: str, *, system: str | None = None,
+                           schema=None, model: str | None = None):
+    key = await _resolve_gemini_key()
+    if not key:
+        raise LLMUnavailable("no Gemini key configured")
+    import google.generativeai as genai  # lazy import — only needed on the gemini path
+    genai.configure(api_key=key)
+    gen_config = {"temperature": 0.3}
+    if schema is not None:
+        gen_config["response_mime_type"] = "application/json"
+    gmodel = genai.GenerativeModel(
+        model or settings.gemini_model,
+        system_instruction=system,
+        generation_config=gen_config,
+    )
+    resp = await gmodel.generate_content_async(prompt)
+    return extract_json(resp.text) if schema is not None else resp.text.strip()
+
+
+async def generate(prompt: str, *, system: str | None = None,
+                   schema=None, model: str | None = None):
+    """Generate text (or parsed JSON when ``schema`` is given) via the configured provider.
+
+    Raises ``LLMUnavailable`` when no key is configured.
+    """
+    provider = (settings.generation_provider or "openai").lower()
+    if provider == "gemini":
+        return await _generate_gemini(prompt, system=system, schema=schema, model=model)
+    return await _generate_openai(prompt, system=system, schema=schema, model=model)

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -5,7 +5,7 @@ Hybrid strategy: batch job pre-generates + on-demand fallback.
 """
 
 import structlog
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 from sqlalchemy import select, update
 
@@ -14,6 +14,15 @@ from app.database import async_session
 from app.models import ClusterArticle, StoryCluster, Article, EmbeddingStatus
 
 logger = structlog.get_logger()
+
+
+def _staleness_cutoff(now: datetime | None = None) -> datetime:
+    """Summaries older than this are stale and eligible for refresh.
+
+    Fixes the original ``datetime.now().replace(hour=hour-4)`` bug (ValueError before 4am).
+    """
+    now = now or datetime.now(timezone.utc)
+    return now - timedelta(hours=4)
 
 
 async def _get_client():
@@ -146,9 +155,7 @@ async def backfill_summaries():
         # Find clusters without summaries or with stale summaries (>4 hours)
         from sqlalchemy import or_
 
-        four_hours_ago = datetime.now(timezone.utc).replace(
-            hour=datetime.now(timezone.utc).hour - 4
-        )
+        cutoff = _staleness_cutoff()
 
         result = await session.execute(
             select(StoryCluster.id)
@@ -156,6 +163,7 @@ async def backfill_summaries():
                 or_(
                     StoryCluster.summary_generated_at.is_(None),
                     StoryCluster.summary.is_(None),
+                    StoryCluster.summary_generated_at < cutoff,
                 )
             )
             .order_by(StoryCluster.created_at.desc())

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,0 +1,89 @@
+"""Integration test harness (E★) — runs against a real Postgres + pgvector.
+
+MUST RUN IN DOCKER (greenlet's async DLL fails on native Windows-ARM):
+
+    docker compose run --rm \
+      -e DATABASE_URL=postgresql+asyncpg://newslens:newslens_dev@db:5432/newslens_test \
+      backend python -m pytest tests/integration -q
+
+Per-test isolation uses an outer transaction + ``join_transaction_mode="create_savepoint"``
+so endpoint ``commit()`` calls are contained and rolled back after each test.
+"""
+import os
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from app.database import Base, get_db
+from app.main import app
+
+TEST_DB_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    os.getenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://newslens:newslens_dev@db:5432/newslens_test",
+    ),
+)
+
+
+@pytest_asyncio.fixture
+async def engine():
+    eng = create_async_engine(TEST_DB_URL, future=True)
+    async with eng.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.run_sync(Base.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def db_session(engine) -> AsyncSession:
+    conn = await engine.connect()
+    trans = await conn.begin()
+    session = AsyncSession(
+        bind=conn, expire_on_commit=False, join_transaction_mode="create_savepoint"
+    )
+    try:
+        yield session
+    finally:
+        await session.close()
+        await trans.rollback()
+        await conn.close()
+
+
+@pytest_asyncio.fixture
+async def aclient(db_session):
+    async def _override():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def fake_llm(monkeypatch):
+    """Patch the generation + embedding seams to deterministic values (no network)."""
+    calls = {"generate": 0, "embed": 0}
+
+    async def _gen(prompt, *, system=None, schema=None, model=None):
+        calls["generate"] += 1
+        return {"stub": True} if schema is not None else "STUB SUMMARY"
+
+    async def _embed(_text):
+        calls["embed"] += 1
+        from app.config import settings as _s
+        v = [0.0] * _s.embedding_dimensions
+        v[0] = 1.0
+        return v
+
+    import app.services.embeddings as emb
+    import app.services.llm as llm
+    monkeypatch.setattr(llm, "generate", _gen)
+    monkeypatch.setattr(emb, "generate_embedding", _embed)
+    return calls

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -35,6 +35,12 @@ async def engine():
     async with eng.begin() as conn:
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
         await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_articles_embedding_hnsw "
+                "ON articles USING hnsw (embedding vector_cosine_ops)"
+            )
+        )
     yield eng
     await eng.dispose()
 

--- a/backend/tests/integration/test_feed.py
+++ b/backend/tests/integration/test_feed.py
@@ -1,0 +1,55 @@
+"""E0: /feed must report real source_count + cluster_id (multi-source visible)."""
+import pytest
+
+from app.models import (
+    Article,
+    ClusterArticle,
+    EmbeddingStatus,
+    Source,
+    SourceType,
+    StoryCluster,
+)
+
+
+async def _seed(db_session):
+    src = Source(name="Src", url="https://x.example/feed-src", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    arts = []
+    for i in range(3):
+        a = Article(
+            title=f"Clustered {i}", url=f"https://x.example/c{i}",
+            source_id=src.id, embedding_status=EmbeddingStatus.complete,
+        )
+        db_session.add(a)
+        arts.append(a)
+    standalone = Article(
+        title="Standalone", url="https://x.example/solo",
+        source_id=src.id, embedding_status=EmbeddingStatus.complete,
+    )
+    db_session.add(standalone)
+    cl = StoryCluster(title="Big story", summary="A real summary exists")
+    db_session.add(cl)
+    await db_session.flush()
+    for a in arts:
+        db_session.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db_session.flush()
+    return cl, arts, standalone
+
+
+@pytest.mark.asyncio
+async def test_feed_reports_real_source_count_and_cluster(aclient, db_session):
+    cl, _arts, _standalone = await _seed(db_session)
+    resp = await aclient.get("/feed?per_page=50")
+    assert resp.status_code == 200
+    items = {it["title"]: it for it in resp.json()["articles"]}
+
+    c0 = items["Clustered 0"]
+    assert c0["source_count"] == 3
+    assert c0["cluster_id"] == cl.id
+    assert c0["has_ai_summary"] is True
+
+    s = items["Standalone"]
+    assert s["source_count"] == 1
+    assert s["cluster_id"] is None
+    assert s["has_ai_summary"] is False

--- a/backend/tests/integration/test_foundation.py
+++ b/backend/tests/integration/test_foundation.py
@@ -1,0 +1,89 @@
+"""E★ foundation: prove the pgvector integration harness works end-to-end."""
+import pytest
+from sqlalchemy import func, select, text
+
+from app.config import settings
+from app.models import (
+    Article,
+    ClusterArticle,
+    EmbeddingStatus,
+    Source,
+    SourceType,
+    StoryCluster,
+)
+
+
+@pytest.mark.asyncio
+async def test_pgvector_extension_available(db_session):
+    v = (
+        await db_session.execute(
+            text("select extversion from pg_extension where extname='vector'")
+        )
+    ).scalar()
+    assert v is not None
+
+
+@pytest.mark.asyncio
+async def test_create_and_query_cluster(db_session):
+    src = Source(
+        name="Reuters", url="https://reuters.com/u1", rss_url="https://reuters.com/rss",
+        source_type=SourceType.wire, is_paywalled=False,
+    )
+    db_session.add(src)
+    await db_session.flush()
+    art = Article(
+        title="EU AI Act", snippet="x", url="https://reuters.com/a1",
+        source_id=src.id, embedding_status=EmbeddingStatus.pending,
+    )
+    db_session.add(art)
+    await db_session.flush()
+    cl = StoryCluster(title="Cluster", summary="s")
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db_session.flush()
+
+    got = (await db_session.execute(select(Article).where(Article.id == art.id))).scalar_one()
+    assert got.title == "EU AI Act"
+    n = (
+        await db_session.execute(
+            select(func.count()).select_from(ClusterArticle).where(
+                ClusterArticle.cluster_id == cl.id
+            )
+        )
+    ).scalar()
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_embedding_column_accepts_vector(db_session):
+    src = Source(name="S", url="https://s.example/u2", source_type=SourceType.other)
+    db_session.add(src)
+    await db_session.flush()
+    vec = [0.0] * settings.embedding_dimensions
+    vec[0] = 1.0
+    art = Article(
+        title="V", url="https://s.example/v", source_id=src.id,
+        embedding=vec, embedding_status=EmbeddingStatus.complete,
+    )
+    db_session.add(art)
+    await db_session.flush()
+    got = (await db_session.execute(select(Article).where(Article.id == art.id))).scalar_one()
+    assert got.embedding is not None
+
+
+@pytest.mark.asyncio
+async def test_isolation_rolls_back_between_tests(db_session):
+    # Each test's writes are rolled back; the table is empty at the start of every test.
+    n = (await db_session.execute(select(func.count()).select_from(Source))).scalar()
+    assert n == 0
+
+
+@pytest.mark.asyncio
+async def test_fake_llm_seam(fake_llm, db_session):
+    from app.services import embeddings, llm
+    out = await llm.generate("hi")
+    emb = await embeddings.generate_embedding("hi")
+    assert out == "STUB SUMMARY"
+    assert len(emb) == settings.embedding_dimensions
+    assert fake_llm["generate"] == 1 and fake_llm["embed"] == 1

--- a/backend/tests/integration/test_lenses.py
+++ b/backend/tests/integration/test_lenses.py
@@ -1,0 +1,76 @@
+"""E5/E6/E7/E8: cluster lens endpoints — generate + cache + graceful unavailable."""
+import pytest
+
+from app.models import (
+    Article,
+    ClusterArticle,
+    EmbeddingStatus,
+    Source,
+    SourceType,
+    StoryCluster,
+)
+
+
+async def _seed_cluster(db_session, n=2):
+    src = Source(name="S", url="https://l.example/src", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    arts = []
+    for i in range(n):
+        a = Article(
+            title=f"Story {i}", snippet="detail text", url=f"https://l.example/{i}",
+            source_id=src.id, embedding_status=EmbeddingStatus.complete,
+        )
+        db_session.add(a)
+        arts.append(a)
+    cl = StoryCluster(title="Cluster", summary="s")
+    db_session.add(cl)
+    await db_session.flush()
+    for a in arts:
+        db_session.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db_session.flush()
+    return cl
+
+
+@pytest.mark.asyncio
+async def test_impact_generates_then_serves_from_cache(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    r1 = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r1.status_code == 200
+    assert r1.json().get("cached") is False
+    assert fake_llm["generate"] == 1
+    r2 = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r2.json().get("cached") is True
+    assert fake_llm["generate"] == 1  # cache hit, no second LLM call
+
+
+@pytest.mark.asyncio
+async def test_analysis_keyfacts_and_5ws_generate(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    assert (await aclient.get(f"/clusters/{cl.id}/analysis?lens=key_facts")).status_code == 200
+    assert (await aclient.get(f"/clusters/{cl.id}/analysis?lens=5ws")).status_code == 200
+    assert fake_llm["generate"] == 2  # two distinct sub-lenses
+
+
+@pytest.mark.asyncio
+async def test_analysis_invalid_lens_400(aclient, db_session):
+    cl = await _seed_cluster(db_session)
+    assert (await aclient.get(f"/clusters/{cl.id}/analysis?lens=bogus")).status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_strategic_and_trivia(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    assert (await aclient.get(f"/clusters/{cl.id}/strategic")).status_code == 200
+    assert (await aclient.get(f"/clusters/{cl.id}/trivia?difficulty=hard")).status_code == 200
+    assert (await aclient.get(f"/clusters/{cl.id}/trivia?difficulty=bogus")).status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_impact_graceful_when_llm_fails(aclient, db_session):
+    # No fake_llm -> real seam. Whether the key is missing or the API errors
+    # (e.g. quota), the lens must return a typed unavailable, never a 500.
+    cl = await _seed_cluster(db_session)
+    r = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r.status_code == 200
+    assert r.json().get("unavailable") is True

--- a/backend/tests/integration/test_profile.py
+++ b/backend/tests/integration/test_profile.py
@@ -1,0 +1,36 @@
+"""E3 (profile) + E1 (gemini key) endpoint integration tests."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_put_and_get_profile_with_interests(aclient, db_session):
+    r = await aclient.put(
+        "/profile",
+        json={"profession": "cardiologist", "locale": "IN", "interests": ["Health", "Science"]},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["profession"] == "cardiologist"
+    assert body["locale"] == "IN"
+    assert set(body["interests"]) == {"Health", "Science"}
+
+    g = await aclient.get("/profile")
+    assert g.json()["profession"] == "cardiologist"
+    assert set(g.json()["interests"]) == {"Health", "Science"}
+
+
+@pytest.mark.asyncio
+async def test_profile_accepts_arbitrary_freetext_profession(aclient, db_session):
+    r = await aclient.put("/profile", json={"profession": "marine biologist"})
+    assert r.status_code == 200
+    assert r.json()["profession"] == "marine biologist"
+
+
+@pytest.mark.asyncio
+async def test_set_and_clear_gemini_key(aclient, db_session):
+    r = await aclient.put("/settings/gemini-key", json={"gemini_api_key": "test-key-123"})
+    assert r.status_code == 200
+    assert r.json()["has_gemini_key"] is True
+    r2 = await aclient.put("/settings/gemini-key", json={"gemini_api_key": None})
+    assert r2.status_code == 200
+    assert r2.json()["has_gemini_key"] is False

--- a/backend/tests/integration/test_search.py
+++ b/backend/tests/integration/test_search.py
@@ -1,0 +1,41 @@
+"""E4 integration: hybrid search (keyword ranks above semantic-only)."""
+import pytest
+
+from app.config import settings
+from app.models import Article, EmbeddingStatus, Source, SourceType
+
+
+async def _article(db_session, src, title, url, embedding):
+    a = Article(
+        title=title, url=url, source_id=src.id, embedding=embedding,
+        embedding_status=EmbeddingStatus.complete,
+    )
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_keyword_ranks_above_semantic_only(aclient, db_session, fake_llm):
+    src = Source(name="S", url="https://s.example/se", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    dim = settings.embedding_dimensions
+    near = [0.0] * dim
+    near[0] = 1.0  # matches fake query embedding [1,0,...]
+    far = [0.0] * dim
+    far[1] = 1.0
+    await _article(db_session, src, "Reliance earnings beat estimates", "https://s.example/kw", far)
+    await _article(db_session, src, "Tata quarterly report", "https://s.example/sem", near)
+
+    r = await aclient.get("/search?q=Reliance")
+    assert r.status_code == 200
+    titles = [x["title"] for x in r.json()["results"]]
+    assert "Reliance earnings beat estimates" in titles
+    assert titles.index("Reliance earnings beat estimates") < titles.index("Tata quarterly report")
+
+
+@pytest.mark.asyncio
+async def test_search_empty_query_rejected(aclient, db_session):
+    r = await aclient.get("/search?q=")
+    assert r.status_code in (400, 422)

--- a/backend/tests/integration/test_sources.py
+++ b/backend/tests/integration/test_sources.py
@@ -1,0 +1,45 @@
+"""E2 integration: source upsert + admin endpoints."""
+import pytest
+from sqlalchemy import func, select
+
+from app.models import Source
+from app.services import fetcher
+
+
+@pytest.mark.asyncio
+async def test_ensure_sources_upsert_idempotent_and_backfills_region(db_session):
+    feeds = fetcher.load_feeds()
+    f0 = feeds[0]
+    # pre-existing row matching a feed by url, but missing region
+    db_session.add(Source(name=f0["name"], url=f0["url"], rss_url=f0["rss_url"], region=None))
+    await db_session.flush()
+
+    await fetcher.ensure_sources(db_session)
+    total = (await db_session.execute(select(func.count()).select_from(Source))).scalar()
+    assert total == len(feeds)  # upserted, not duplicated
+
+    s0 = (
+        await db_session.execute(select(Source).where(Source.url == f0["url"]))
+    ).scalar_one()
+    assert s0.region == f0["region"]  # backfilled
+
+    # idempotent
+    await fetcher.ensure_sources(db_session)
+    total2 = (await db_session.execute(select(func.count()).select_from(Source))).scalar()
+    assert total2 == len(feeds)
+
+
+@pytest.mark.asyncio
+async def test_admin_create_source(aclient, db_session):
+    r = await aclient.post(
+        "/admin/sources",
+        json={"name": "My Feed", "url": "https://my.example",
+              "rss_url": "https://my.example/rss", "region": "in", "category": "tech"},
+    )
+    assert r.status_code == 200
+    r_dup = await aclient.post("/admin/sources", json={"name": "Dup", "url": "https://my.example"})
+    assert r_dup.status_code == 409
+    r_bad = await aclient.post("/admin/sources", json={"name": "x"})
+    assert r_bad.status_code == 400
+    g = await aclient.get("/admin/sources")
+    assert any(s["url"] == "https://my.example" for s in g.json())

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -34,7 +34,11 @@ class TestHealth:
 
     async def test_health_degraded_when_db_unreachable(self, client: AsyncClient):
         """Health returns degraded when database is down."""
-        with patch("app.api.routes.async_session") as mock_session_maker:
+        # Patch BOTH the session and the raw asyncpg fallback so the result is
+        # deterministic even when a real DB is reachable (e.g. CI/Docker).
+        with patch("app.api.routes.async_session") as mock_session_maker, patch(
+            "asyncpg.connect", side_effect=Exception("Connection refused")
+        ):
             mock_session_maker.return_value.__aenter__ = AsyncMock(
                 side_effect=Exception("Connection refused")
             )
@@ -67,6 +71,10 @@ class TestFeed:
         assert data["per_page"] == 20
         assert "explore_ratio" in data
 
+    @pytest.mark.skip(
+        reason="Superseded by tests/integration/test_feed.py — the /feed cluster "
+        "aggregate uses real SQL the MockSession can't simulate (per eng review)."
+    )
     async def test_feed_returns_articles(self, client: AsyncClient, mock_session: MockSession):
         """Feed includes articles with source information."""
         source = make_source(id=1, name="Reuters", is_paywalled=False)

--- a/backend/tests/unit/test_llm.py
+++ b/backend/tests/unit/test_llm.py
@@ -1,0 +1,74 @@
+"""Unit tests for the LLM generation seam (E1/E★). Pure/native — no DB, no network."""
+import pytest
+
+from app.services import llm
+
+
+class TestExtractJson:
+    def test_plain_json(self):
+        assert llm.extract_json('{"a": 1}') == {"a": 1}
+
+    def test_fenced_json_block(self):
+        assert llm.extract_json('```json\n{"a": 1, "b": [2, 3]}\n```') == {"a": 1, "b": [2, 3]}
+
+    def test_prose_wrapped_json(self):
+        assert llm.extract_json('Sure! {"a": 1} — hope that helps.') == {"a": 1}
+
+    def test_array_root(self):
+        assert llm.extract_json("[1, 2, 3]") == [1, 2, 3]
+
+    def test_passthrough_when_already_parsed(self):
+        assert llm.extract_json({"a": 1}) == {"a": 1}
+
+    def test_unparseable_raises(self):
+        with pytest.raises(ValueError):
+            llm.extract_json("there is no json here at all")
+
+
+@pytest.mark.asyncio
+class TestGenerateRouting:
+    async def test_routes_to_gemini(self, monkeypatch):
+        from app.config import settings
+        monkeypatch.setattr(settings, "generation_provider", "gemini")
+        called = {}
+
+        async def fake_gemini(prompt, **kw):
+            called["gemini"] = True
+            return "G"
+
+        async def fake_openai(prompt, **kw):
+            called["openai"] = True
+            return "O"
+
+        monkeypatch.setattr(llm, "_generate_gemini", fake_gemini)
+        monkeypatch.setattr(llm, "_generate_openai", fake_openai)
+        out = await llm.generate("hi")
+        assert out == "G"
+        assert called == {"gemini": True}
+
+    async def test_routes_to_openai_by_default(self, monkeypatch):
+        from app.config import settings
+        monkeypatch.setattr(settings, "generation_provider", "openai")
+
+        async def fake_gemini(prompt, **kw):
+            return "G"
+
+        async def fake_openai(prompt, **kw):
+            return "O"
+
+        monkeypatch.setattr(llm, "_generate_gemini", fake_gemini)
+        monkeypatch.setattr(llm, "_generate_openai", fake_openai)
+        assert await llm.generate("hi") == "O"
+
+    async def test_unavailable_when_no_openai_key(self, monkeypatch):
+        from app.config import settings
+        monkeypatch.setattr(settings, "generation_provider", "openai")
+        monkeypatch.setattr(settings, "openai_api_key", "")
+        import app.services.embeddings as emb
+
+        async def none_client():
+            return None
+
+        monkeypatch.setattr(emb, "_get_client_async", none_client)
+        with pytest.raises(llm.LLMUnavailable):
+            await llm.generate("hi")

--- a/backend/tests/unit/test_sources.py
+++ b/backend/tests/unit/test_sources.py
@@ -1,0 +1,26 @@
+"""E2 unit tests (pure, native): feed config + Google News builder + GDELT query."""
+from app.config import settings
+from app.services import fetcher
+
+
+def test_google_news_rss_url_builder():
+    url = fetcher.google_news_rss_url("RBI rate cut")
+    assert url.startswith("https://news.google.com/rss/search?q=")
+    assert "RBI" in url and "rate" in url
+    assert "hl=en-IN" in url and "gl=IN" in url and "ceid=IN:en" in url
+
+
+def test_load_feeds_has_india_and_global_and_no_bogus_reuters():
+    feeds = fetcher.load_feeds()
+    regions = {f.get("region") for f in feeds}
+    assert "in" in regions and "global" in regions
+    # the old bogus Reuters spec-page URL must be gone
+    assert all("rss-specification" not in f["rss_url"] for f in feeds)
+    assert all(f["rss_url"].startswith("http") for f in feeds)
+    # India business desk present (the relevance payoff)
+    names = {f["name"] for f in feeds}
+    assert "Moneycontrol" in names and "The Hindu - National" in names
+
+
+def test_gdelt_query_includes_country():
+    assert "sourcecountry" in settings.gdelt_query

--- a/backend/tests/unit/test_summarizer_window.py
+++ b/backend/tests/unit/test_summarizer_window.py
@@ -1,0 +1,17 @@
+"""Unit test for the summary staleness window (E0 fix: no crash before 4am)."""
+from datetime import datetime, timezone, timedelta
+
+from app.services import summarizer
+
+
+def test_staleness_cutoff_pre_4am_does_not_raise():
+    # The original bug: datetime.now().replace(hour=hour-4) -> ValueError when hour < 4.
+    now = datetime(2026, 6, 23, 2, 0, tzinfo=timezone.utc)
+    cutoff = summarizer._staleness_cutoff(now)
+    assert cutoff == now - timedelta(hours=4)
+
+
+def test_staleness_cutoff_defaults_to_now():
+    cutoff = summarizer._staleness_cutoff()
+    assert isinstance(cutoff, datetime)
+    assert cutoff < datetime.now(timezone.utc)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   db:
     image: pgvector/pgvector:pg16
@@ -26,6 +24,9 @@ services:
     restart: unless-stopped
     ports:
       - "${BACKEND_PORT:-8000}:8000"
+    volumes:
+      # Live source for local dev + in-container test runs (deps live in site-packages, unaffected)
+      - ./backend:/app
     environment:
       DATABASE_URL: postgresql+asyncpg://newslens:${POSTGRES_PASSWORD:-newslens_dev}@db:5432/newslens
       DATABASE_URL_SYNC: postgresql://newslens:${POSTGRES_PASSWORD:-newslens_dev}@db:5432/newslens

--- a/docs/content/COPY-GUIDELINES.md
+++ b/docs/content/COPY-GUIDELINES.md
@@ -1,0 +1,130 @@
+# NewsLens — Copy Guidelines & Review Process
+
+The single standard for every word a user can read in NewsLens: screen copy, button labels,
+empty states, errors, notifications, store listings, onboarding.
+
+**Why this exists:** internal jargon leaked into the UI (`src:7 · coh:0.88`, "OpenAI API key for
+embeddings…"). Readers don't know what coherence or an embedding is. This guide + the automated
+guard (`npm run lint:copy`) + the review checklist make sure it never ships again.
+
+Machine-readable companion: [`terminology.json`](./terminology.json) — the guard reads `banned`,
+this guide explains the `glossary`.
+
+---
+
+## 1. Brand voice
+
+NewsLens is **calm, credible, and editorial** — a smart desk editor, not a hype machine and not a
+lab notebook. It serves any profession (doctor, PM, trader, geopolitics geek), so copy is
+**plain and universal**, never insider.
+
+| We are | We are not |
+|---|---|
+| Clear, plain, confident | Jargon-y, clever-for-its-own-sake |
+| Calm and editorial | Clickbait, breathless, ALL-CAPS hype |
+| Trust-forward (sources, agreement) | Vague ("trust us") |
+| Concise | Padded, hedge-heavy |
+| Neutral on the news itself | Editorialising the story's politics |
+
+**Voice test:** would this read naturally in a quality newspaper's product, to a smart reader who
+is *not* an engineer? If not, rewrite.
+
+## 2. Plain language — the core rule
+
+> Never expose how the sausage is made. Show the value, hide the pipeline.
+
+Every internal term has a user-facing translation. The full map is in
+[`terminology.json`](./terminology.json) → `glossary`. The essentials:
+
+| Internal (code/DB/ML) | Show the user |
+|---|---|
+| `src:N` / source_count | **N sources** |
+| `coh:0.88` / coherence | **88% agreement** (tiered colour, see §4) |
+| "High confidence" (legacy) | **agreement** — standardise the word |
+| cluster / story_cluster | **story** |
+| embedding / pgvector | *(hidden)* — say the benefit: "find related stories" |
+| explore/exploit mix | **Your topics** / **Discover new** |
+| GDELT, RSS, trafilatura, asyncpg, Fernet, dedup, backfill | *(never surface)* |
+| embedding_status = pending | *(hidden)* — show the snippet instead |
+
+## 3. Numbers
+
+- **Percentages, not decimals.** `0.88` → **88%**. Round to whole numbers in UI.
+- **Spell the unit in words** where space allows: `88% agreement`, `7 sources`, `3 min read`.
+- Counts get a real noun and pluralise: `1 source` / `7 sources`.
+- No false precision — `~100k`, not `103,412`, unless the exact figure is the point.
+
+## 4. The trust signal (sources + agreement)
+
+The most jargon-prone surface. Standard treatment:
+
+- **Sources** — neutral pill: `7 sources`.
+- **Agreement** — colour-coded by tier (this is the *only* place colour encodes a value):
+  - **≥ 80%** → green · "high agreement"
+  - **60–79%** → amber · "moderate"
+  - **< 60%** → grey · "mixed / developing"
+- **Wording honesty:** coherence is a similarity score, so "agreement" / "consensus" is a fair
+  plain-English translation — never imply a literal vote ("88% of sources voted").
+
+## 5. Theme & discipline
+
+- **Sentence case** for sentences and buttons ("Read full article"). `UPPERCASE` mono is reserved
+  for the established label style (section kickers like `TOP STORIES`, data tags) — that's a
+  *design* convention, not prose; don't uppercase sentences.
+- **Consistent terms:** one concept = one word, everywhere. A "story" is always a story (never
+  also "cluster" or "article group"). Add new terms to the glossary before using them.
+- **Verbs for actions** ("Save", "Read full article"), **nouns for things** ("Briefing", "Sources").
+- **Errors** are calm and actionable, never raw: not "500: cluster not found" → "We couldn't load
+  this story. Pull to refresh."
+- **No leaking secrets/IDs** in copy — never show internal IDs, keys (mask them), or stack traces.
+
+## 6. Do / Don't
+
+| Don't | Do |
+|---|---|
+| `src:7 · coh:0.88` | `7 sources` · `88% agreement` |
+| "OpenAI API key for embeddings and summaries" | "Powers AI summaries and related-story matching" |
+| "High confidence ●●●○" | "88% agreement" (green) |
+| "No clusters found" | "No stories yet — check back soon" |
+| "Embedding pending" | *(show the article snippet)* |
+| "Explore ratio: 0.3" | *(hidden — it just tunes the mix)* |
+
+---
+
+## 7. Review process
+
+Copy is reviewed **every time it changes**, at three gates:
+
+1. **Author self-check** — writer runs the checklist (§8) before opening a PR.
+2. **Automated guard (blocking)** — `npm run lint:copy` runs locally and in CI. `error`-level
+   jargon fails the build. Run it as part of standard validation (see root `CLAUDE.md`).
+3. **Human copy review** — the reviewer confirms the checklist on the PR. Anything user-visible
+   (screens, emails, push, store text) needs a copy ✓ in review, same as a code ✓.
+
+New user-facing term? → add it to [`terminology.json`](./terminology.json) (glossary, and `banned`
+if its internal form must never ship) **in the same PR**.
+
+## 8. Copy review checklist
+
+Paste into the PR description for any change touching user-visible text:
+
+```
+Copy review
+- [ ] No internal jargon (ran `npm run lint:copy`, 0 errors)
+- [ ] Numbers are %/rounded; units spelled out where space allows
+- [ ] One concept = one word; matches terminology.json glossary
+- [ ] Sentence case for prose/buttons; UPPERCASE only for label style
+- [ ] Errors are calm + actionable; no raw codes/IDs/keys
+- [ ] Reads naturally to a non-engineer (voice test)
+- [ ] New terms added to terminology.json
+```
+
+## 9. The guard
+
+`frontend/scripts/check-copy.mjs` scans `frontend/src/**/*.{ts,tsx}` for `banned` entries:
+
+- `pattern` (e.g. `src:`, `coh:`) → flagged anywhere.
+- `word` with `scope: "string"` → flagged inside quoted strings / JSX text (skips imports & types).
+- `word` with `scope: "jsx-text"` → flagged only in visible JSX text (lower-confidence, `warn`).
+
+`error` severity exits non-zero (fails CI); `warn` prints advisories. Run: `npm run lint:copy`.

--- a/docs/content/terminology.json
+++ b/docs/content/terminology.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Source of truth for NewsLens user-facing copy. The check-copy guard reads `banned`. Humans read `glossary`. Update both together. See COPY-GUIDELINES.md.",
+  "version": 1,
+  "banned": [
+    { "term": "src:", "kind": "pattern", "severity": "error", "scope": "any", "why": "Internal abbreviation for source count.", "useInstead": "\"N sources\"" },
+    { "term": "coh:", "kind": "pattern", "severity": "error", "scope": "any", "why": "Internal abbreviation for the coherence score.", "useInstead": "\"NN% agreement\"" },
+    { "term": "embeddings", "kind": "word", "severity": "error", "scope": "string", "why": "ML implementation detail. Users don't know or care what an embedding is.", "useInstead": "Describe the benefit, e.g. \"to find related stories\"." },
+    { "term": "pgvector", "kind": "word", "severity": "error", "scope": "string", "why": "Database extension name. Pure plumbing.", "useInstead": "(never surface)" },
+    { "term": "GDELT", "kind": "word", "severity": "error", "scope": "string", "why": "Internal data-pipeline source name.", "useInstead": "(never surface)" },
+    { "term": "trafilatura", "kind": "word", "severity": "error", "scope": "string", "why": "Internal extraction library.", "useInstead": "(never surface)" },
+    { "term": "rapidfuzz", "kind": "word", "severity": "error", "scope": "string", "why": "Internal dedup library.", "useInstead": "(never surface)" },
+    { "term": "asyncpg", "kind": "word", "severity": "error", "scope": "string", "why": "Internal DB driver.", "useInstead": "(never surface)" },
+    { "term": "Fernet", "kind": "word", "severity": "error", "scope": "string", "why": "Internal encryption scheme.", "useInstead": "\"encrypted\" / \"stored securely\"" },
+    { "term": "dedup", "kind": "word", "severity": "error", "scope": "string", "why": "Engineering shorthand for deduplication.", "useInstead": "(hidden) / \"removed duplicates\"" },
+    { "term": "backfill", "kind": "word", "severity": "error", "scope": "string", "why": "Pipeline-job jargon.", "useInstead": "(hidden)" },
+    { "term": "coherence", "kind": "word", "severity": "warn", "scope": "jsx-text", "why": "ML clustering term; meaningless to readers.", "useInstead": "\"agreement\" / \"consensus\"" },
+    { "term": "cluster", "kind": "word", "severity": "warn", "scope": "jsx-text", "why": "Internal term for a grouped story.", "useInstead": "\"story\"" },
+    { "term": "exploit", "kind": "word", "severity": "warn", "scope": "jsx-text", "why": "Half of \"explore/exploit\" recommender jargon.", "useInstead": "\"Your topics\"" }
+  ],
+  "glossary": [
+    { "internal": "story_cluster / cluster", "user": "story", "note": "A story groups multiple source articles covering the same event." },
+    { "internal": "source_count / src", "user": "N sources", "note": "How many outlets reported it. Breadth of corroboration." },
+    { "internal": "coherence / coh (0–1)", "user": "NN% agreement", "note": "How aligned the sources are. Tiers: ≥80% high (green), 60–79% moderate (amber), <60% mixed (grey). Say \"agreement\"/\"consensus\", never \"coherence\"." },
+    { "internal": "confidence label", "user": "agreement", "note": "Legacy label said \"High confidence\". Standardise on \"agreement\" to match the meter + pills." },
+    { "internal": "embedding / pgvector NN", "user": "(don't expose)", "note": "Describe the outcome instead: \"find related stories\", \"AI summaries\"." },
+    { "internal": "explore / exploit mix", "user": "Your topics / Discover new", "note": "Never show the ratio or the word \"exploit\"." },
+    { "internal": "is_paywalled", "user": "Paywall / Free", "note": "Always pair: lead with \"Free\" sources, tag the rest \"Paywall\"." },
+    { "internal": "GDELT / RSS / fetcher / trafilatura", "user": "(hidden)", "note": "Never name the ingestion pipeline in the UI." },
+    { "internal": "embedding_status (pending/complete/failed)", "user": "(hidden)", "note": "If a summary isn't ready, show the snippet — don't expose the status enum." }
+  ]
+}

--- a/docs/enhancement/00-PLAN.md
+++ b/docs/enhancement/00-PLAN.md
@@ -1,0 +1,148 @@
+# NewsLens — Enhancement Plan (v1)
+
+> Status: REVIEWED. **Authoritative final scope, phasing & decisions live in [01-REVIEWS.md](01-REVIEWS.md)** (post CEO/Eng/Design review + owner reconciliation). This file is the original draft; where it conflicts with 01-REVIEWS.md, the latter wins. The build spec is [02-PRD.md](02-PRD.md).
+> Date: 2026-06-23. Owner: Rohit (personal project).
+>
+> **Key post-review changes:** added **P-1 Foundation** (Alembic baseline + pgvector integration-test DB + LLM mock seam) as the first hard-blocker phase; **WIIFM impact (E6) promoted to the P1 front door**; strategic lens (E7) = "house voice" in P2; **all-professions kept** via a profession-agnostic engine (free-text profession, no heavy taxonomy); **trivia (E8) + search (E4) kept** but moved to P3; SSL `CERT_NONE` fix + design-system.md reconcile added to P0.
+
+## 0. Positioning (corrected)
+
+NewsLens is a **personal, profession-agnostic news-intelligence app**. It is **not** an InvestorAi product and must not be coupled to it. The thesis: *"Breadth, not bubbles"* — multi-source clustering + AI analysis that adapts to **whoever you are**.
+
+Every persona is first-class:
+
+| Persona | Core job | Signature value |
+|---|---|---|
+| Doctor / clinician | Track developments in their field | "What changed in cardiology this week + why it matters to practice" |
+| Product manager | Track product/tech/market moves | "What this launch means for product strategy" |
+| AI enthusiast | Track AI research & industry | "What's new, who shipped, what's hype" |
+| Geopolitics geek | Track world events | **Game-theory strategic lens** (see §5.7) — each party's incentives, the "game" being played, non-obvious takes |
+| Investor / market trader | Track market-moving news | "How this may impact markets / sectors" |
+| Generalist | Stay informed, fast | Personalized briefing + "why this matters to me" |
+
+The unifying engine: a **"What's in it for me" (WIIFM) layer** keyed on each user's **profession + interests + locale**, applied to every story.
+
+## 1. Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Database / infra | **Stay on Neon + Render** for the build; "evaluate Supabase" parked | Auth is Firebase (not Supabase Auth), so Supabase's main draw is moot; don't migrate infra + add features simultaneously. Supabase MCP is connected → easy future move if Neon SSL/cold-starts persist. |
+| Auth & Sign-in | **Firebase Auth (incl. Google sign-in)** — **SCOPED & PARKED** (see [FIREBASE-DEFERRED.md](FIREBASE-DEFERRED.md)) | Multi-user is a large lift; do features first. App stays single-user (`user_id=1`) until then. |
+| Push notifications | **Firebase Cloud Messaging** — **PARKED** with auth | Ties to the existing notification-engine thinking; needs auth first. |
+| LLM — generation | **Gemini** (`gemini-2.0-flash` / `1.5-flash`) via a provider abstraction | Cheap, strong for summaries/analysis/trivia; user has keys. |
+| LLM — embeddings | **Keep OpenAI `text-embedding-3-small` (1536-dim)** for now | Switching to Gemini (768-dim) forces a pgvector column change + full re-embed; decouple that migration from feature work. |
+| Google item #1 (Gemini) | Build now | — |
+| Google item #2 (Sign-in) | = Firebase Auth → parked | — |
+| Google item #3 (Google News) | Build now as a source | Cheap breadth + recency. |
+
+## 2. Build-now scope (epics)
+
+- **E0 — P0 fixes** (make the existing brain visible & safe)
+- **E1 — LLM provider abstraction + Gemini** (generation)
+- **E2 — Sources: India + global + Google News + admin/upsert + GDELT country**
+- **E3 — Onboarding: interests + profession + locale; persist; personalize feed**
+- **E4 — Semantic search** (by keyword / interest / profession)
+- **E5 — In-depth analysis** (Key Facts, 5Ws, "Explain for a {profession}")
+- **E6 — WIIFM impact lens** (multi-dimension, profession-aware)
+- **E7 — Strategic / game-theory lens** (geopolitics)
+- **E8 — Trivia** (easy / medium / hard) + daily quiz loop
+
+## 3. Parked (scoped, not built now)
+
+- **Firebase Auth** (Google sign-in, multi-user) — [FIREBASE-DEFERRED.md](FIREBASE-DEFERRED.md)
+- **Firebase Cloud Messaging** (push) — depends on auth
+- **Gemini embeddings migration** (768-dim re-embed) — optional later
+- **Supabase migration** — optional later
+- SSE live updates, vernacular/multi-language, admin breadth dashboard
+
+## 4. Non-goals (this phase)
+
+- No paid/multi-tenant accounts beyond the single-user model.
+- No real-money or InvestorAi integration.
+- No mobile-native rewrite (Capacitor wrapper stays).
+
+## 5. Detailed scoping (per epic)
+
+### E0 — P0 fixes
+- **/feed cluster bug**: the cluster-count query is built but never executed; `source_count` hardcoded to 1, `cluster_id` always None (`routes.py:110-131`). Fix so feed items carry real `source_count` + `cluster_id` (multi-source visible).
+- **Summary crash**: `backfill_summaries` does `hour-4` → ValueError before 4am (`summarizer.py:149`). Use a safe windowed query.
+- **Reuters feed**: replace the bogus URL (points at RSS spec page, `fetcher.py:124`) with a working feed; remove if none.
+- **Encryption safety**: empty `ENCRYPTION_KEY` silently stores plaintext (`encryption.py:22`). Fail-fast or generate+persist a key; never store plaintext.
+- **Wire topic chips**: Settings topic toggles are localStorage-only & inert (`settings/page.tsx:108`). Persist to backend `user_preferences` and make them affect the feed.
+- (Frontend trust) remove hardcoded coherence `0.85` & source-name-as-category in `DeepDiveView.tsx`; surface real cluster coherence + topic.
+
+### E1 — LLM provider abstraction + Gemini
+- New `backend/app/services/llm.py`: `async generate(prompt, *, json=False, model=None)` and `async embed(text)`; provider switch via `settings.llm_provider` (`openai` | `gemini`).
+- `config.py`: add `LLM_PROVIDER`, `GEMINI_API_KEY`; `requirements.txt`: add `google-generativeai`.
+- Per-user Gemini key: add `gemini_api_key_encrypted` to `user_settings` (mirror OpenAI), reuse Fernet (`encryption.py`).
+- Refactor `summarizer.generate_cluster_summary` and the new analysis features to call `llm.generate`. Embeddings stay on OpenAI (`embeddings.py`) for now.
+- Graceful degradation preserved: no key → snippet fallback.
+
+### E2 — Sources
+- Move `STARTER_FEEDS` to `backend/app/data/sources.json` (or config); `ensure_sources` becomes an **upsert** (adds new feeds to existing DBs), not "only when empty" (`fetcher.py:140`).
+- Add global feeds (fix Reuters; add AP, Guardian, CNBC, Politico, Axios) + **India** feeds (The Hindu, TOI, Indian Express, HT, NDTV, The Print, Scroll, LiveMint, Moneycontrol, ET Markets, Business Standard, PIB, RBI, SEBI). Tag each with `region` (`global`/`in`) and optional `category`.
+- **Google News RSS** as a source type: `https://news.google.com/rss/search?q={query}&hl=en-IN&gl=IN&ceid=IN:en` — enables per-topic ingestion.
+- **GDELT**: parametrize `sourcecountry`/`sourcelang` (`gdelt.py:38`) → add an `IN` query alongside `US`.
+- Build the unused **`POST /admin/sources`** + `GET /admin/sources` endpoints (schemas already exist).
+
+### E3 — Onboarding + personalization
+- First-run flow (frontend): pick **interests** (topics), **profession/role** (from a curated list + free text), **locale** (default India). Skippable.
+- Data model: add `profession` (string) + `locale` (string) to `users` (or a `user_profile` table); persist selected interests as `user_preferences` rows (real topic weights), not localStorage.
+- New endpoints: `GET/PUT /profile` (profession, locale, interests). Wire Settings "Your Topics" to it.
+- Personalize: `/briefing` + `/feed` weight by stored preferences (the explore/exploit logic already exists server-side; feed it real weights).
+
+### E4 — Semantic search
+- `GET /search?q=...` → embed query (OpenAI) → pgvector nearest-neighbor over `articles.embedding` + keyword `ILIKE` fallback; group by cluster; rank.
+- Frontend: activate the dead navbar search icon → search screen with results list (reuse StoryCard). Recent/suggested searches by interest.
+
+### E5 — In-depth analysis (Gemini)
+- Replace the "Coming soon" tabs (`AISummaryBox.tsx:90,126`): **Key Facts** (bulleted extraction), **5Ws** (who/what/when/where/why), and new **"For a {profession}"** lens.
+- Backend: `GET /clusters/{id}/analysis?lens={key_facts|5ws|profession}` → Gemini over the cluster's source texts; cache on `story_clusters` (new JSON columns) to avoid recompute.
+
+### E6 — WIIFM impact lens (Gemini)
+- Per cluster, generate **"How this affects you"** across dimensions the user cares about: **Finance / markets, Profession, Policy & regulation, Daily life** — conditioned on `profession` + `locale`.
+- Backend: `GET /clusters/{id}/impact` (uses profile); cache per (cluster, profession) hash. Frontend: an "Impact" card on Deep Dive.
+- Profession-agnostic: doctor → clinical-practice impact; trader → market impact; PM → product/strategy impact, etc.
+
+### E7 — Strategic / game-theory lens (Gemini)
+- For **geopolitics / multi-actor** stories: a **"Strategic Lens"** that, inspired by **Prof. Jiang Xueqin's game-theory commentary**, analyzes: (a) the actors/parties, (b) each party's incentives & likely payoffs, (c) the type of "game" (zero-sum, coordination, chicken, prisoner's dilemma, signalling), (d) second-order effects & a **non-obvious take**.
+- Backend: `GET /clusters/{id}/strategic`; Gemini with a structured prompt + schema. Auto-offered when topic ∈ geopolitics/world.
+- ⚠️ **Source-fidelity note:** the specific "Jiang Xueqin principles" must be sourced/validated (link real essays) before claiming attribution; until then frame as "game-theory strategic analysis." (Confidence: needs validation.)
+
+### E8 — Trivia (easy/medium/hard)
+- Gemini generates quiz questions from a story or a topic, three difficulty tiers, each with the correct answer + a one-line explanation.
+- `GET /clusters/{id}/trivia?difficulty=` and `GET /trivia/daily?topic=` (by interest). Frontend: "Test your knowledge" on a story + a **daily quiz** with streaks (engagement loop; future FCM hook).
+
+## 6. Data-model deltas (summary)
+
+- `users`: + `profession`, `locale` (or new `user_profile`).
+- `user_settings`: + `gemini_api_key_encrypted`, `gemini_key_verified`.
+- `sources`: + `region`, `category` (+ JSON seed file).
+- `story_clusters`: + `analysis_json`, `impact_json`, `strategic_json`, `trivia_json` (caches).
+- All via Alembic migrations.
+
+## 7. Phasing
+
+| Phase | Epics | Goal |
+|---|---|---|
+| P0 | E0 | Existing brain visible + safe |
+| P1 | E2, E3, E4 | Relevance: India sources, personalization, search → "this is mine" |
+| P2 | E1, E5, E6 | Gemini value: deep analysis + WIIFM impact |
+| P3 | E7, E8 | Differentiators: strategic lens + trivia/engagement loop |
+
+(E1 is foundational and may land at the start of P2 or earlier since E5–E8 depend on it.)
+
+## 8. Risks
+
+- **Gemini cost/latency** on per-cluster analysis → cache aggressively (§6 JSON columns), generate lazily on view.
+- **Embedding-dim trap** if Gemini embeddings are adopted later (768 vs 1536) → separate migration.
+- **Profession taxonomy** sprawl → curated list + free-text fallback; map free text → nearest curated for prompting.
+- **Game-theory attribution** (Jiang Xueqin) → validate sources before attributing.
+- **Single-user model** limits real personalization testing until Firebase auth lands.
+
+## 9. Open questions (for reviews)
+
+1. Profession taxonomy: curated list size? (10 broad vs 50 granular)
+2. Analysis caching: per-cluster (shared) vs per-(cluster,profession) (personalized) — cost vs relevance.
+3. Trivia: per-story vs daily-by-topic as the primary loop?
+4. Search: semantic-only vs hybrid (keyword+semantic) for v1?

--- a/docs/enhancement/01-REVIEWS.md
+++ b/docs/enhancement/01-REVIEWS.md
@@ -1,0 +1,48 @@
+# NewsLens Plan — CEO / Eng / Design Reviews + Decisions
+
+> Three independent reviews of [00-PLAN.md](00-PLAN.md), then synthesis, then owner reconciliation.
+> Date: 2026-06-23. Method: parallel critic agents (workflow `wf_4012c66b-811`).
+
+## Review highlights
+
+**CEO / founder** — *Right direction, wrong center of gravity.* WIIFM impact + the game-theory/second-order lens is the only non-commodity idea and it's buried in P2/P3. Reframe from "news reader that explains" → **"a daily strategic-intelligence briefing sourced from news"** where every story carries a **decision/impact verdict, not a summary**. Make the strategic lens the **house voice**. (Also urged: collapse personas, defer search, cut trivia — see Reconciliation below.)
+
+**Eng / architecture** — Technically sound, but **two hard blockers**: (1) `migrations/versions/` is **empty** — schema is `create_all` + ad-hoc `ALTER`; no Alembic baseline → no new SQL is migratable. (2) Tests are **100% mocked** (`MockSession` sniffs SQL strings) → pgvector/JSONB/aggregate features are untestable. Must add a **migration baseline + pgvector integration-test DB + LLM mock seam FIRST**. Plus: split `generation_provider` from embeddings (keep embed on OpenAI), `generate(prompt, *, schema=None)` with JSON-repair, **HNSW index** before search, `/feed` as one aggregate (the current query is malformed + N+1), **SSL `CERT_NONE` is a real MITM hole** (missed by plan), JSONB caches keyed by profession-hash, integration tests run in **Docker/Linux only** (greenlet/Win-ARM).
+
+**Design** — Features are strong but the plan adds **7+ blocks to DeepDive with no IA** → AI scroll-wall that buries the source-first/confidence-first soul. Lock the DeepDive IA: **one AI hub** (tabs in the existing AISummaryBox) + **Impact as the hero card** + **Strategic/Trivia collapsed disclosures**. Onboarding **interests-first** (profession/locale deferred to a Today banner that arrives *with* the payoff). Every generated surface needs the **AI disclaimer**; keep **monochromatic-until-interaction** (AI = violet/drill token). Reconcile the **stale design-system.md** (says top-nav + Instrument Serif; app ships BottomTabBar + Fraunces).
+
+## Decision log (condensed from synthesis)
+
+**Adopted in full:** Foundation phase first (Alembic baseline + pgvector test DB + LLM seam); E1 LLM abstraction locked to front of P1; **WIIFM impact promoted to P1 hero / front door**; strategic lens = house voice (P2), generalize the "what's really going on" beat to all stories; DeepDive IA (one AI hub + Impact hero + collapsed Strategic/Trivia); onboarding interests-first + profession-unset graceful CTAs; reframe positioning to "decision/impact verdict not summary."
+
+**Eng specifics adopted:** `profession`/`locale` → **`users` columns**; Gemini key mirrors full OpenAI trio (`gemini_api_key_encrypted`, `gemini_key_verified`, `gemini_key_verified_at`); `sources.region` **enum** (`global`/`in`) nullable+default, upsert on `rss_url`/`url` with UPDATE path; cluster caches **JSONB** keyed by profession-hash + **cache-version/source-hash** for invalidation; `generation_provider` separate, `embed()` stays OpenAI, second key-cache slot for Gemini; `generate(prompt, *, schema=None)` + JSON-repair; **HNSW index** prerequisite of search; **hybrid search**; `/feed` single aggregate; summary fix `now - timedelta(hours=4)` + apply window; encryption fail-fast + tighten `decrypt_value`; **SSL verify-ca/full**; backfill GDELT source region; lazy one-lens-per-endpoint; integration tests in Docker.
+
+**Design specifics adopted:** AISummaryBox capped at 4 scrollable tabs; Impact = headline + expandable dimension chips, distinct accent; Strategic collapsed w/ teaser + game-type mono Badge; search empty-state (interest-seeded + recent) + "matched on" tag; disclaimer on all generated surfaces; reconcile design-system.md (P0 doc task).
+
+## Reconciliation with owner's explicit requirements (overrides)
+
+The CEO review is advisory; the owner gave explicit product requirements that take precedence. Three deliberate divergences from the synthesis:
+
+| Synthesis said | Owner requirement | Final decision |
+|---|---|---|
+| Collapse to 1 persona; defer taxonomy | "NewsLens for **all professions**, not just mine" (doctor, PM, AI enthusiast, geopolitics geek, trader…) | **Keep multi-profession** — but implement as a **profession-agnostic engine**: free-text `profession` + curated suggestion chips (NOT a 50-item ontology). The lenses take the profession string and adapt via the LLM, so it serves *any* profession with zero taxonomy. Satisfies both "all professions" and "ship the lens not the ontology." |
+| Cut trivia until auth | Owner explicitly wants **trivia easy/medium/hard** | **Keep trivia** — sequence at **P3** (after the wedge), restrained tone (mono streak, no confetti), daily quiz as a Today card not a tab. |
+| Defer search | Owner wants **search by interest/profession** | **Keep search** at **P3**, hybrid + HNSW (synthesis already kept it thin — aligned). |
+
+## Finalized phasing (reconciled)
+
+| Phase | Epics | Goal |
+|---|---|---|
+| **P-1 Foundation** | **E★** Alembic baseline · pgvector integration-test DB · LLM/embeddings mock seam | Make the codebase TDD-able (hard blocker) |
+| **P0 Fix & safe** | **E0** + SSL `CERT_NONE` fix + design-system.md reconcile | Existing brain visible, safe, trustworthy |
+| **P1 Wedge** | **E1** LLM abstraction → **E6** WIIFM impact (hero/front door) → **E3** onboarding (interests-first + free-text profession, all professions) → **E2** sources (India + Google News + trimmed global) | Lead with "what this means for me" |
+| **P2 Depth** | **E5** analysis tabs → **E7** strategic/game-theory lens (house voice) | Differentiated point-of-view |
+| **P3 Utility & engagement** | **E4** hybrid search (+HNSW) → **E8** trivia (easy/med/hard) + daily quiz | Owner-requested; after the wedge |
+| **Parked** | Firebase Auth, FCM, Gemini-embeddings migration, Supabase | Post-auth / future |
+
+## Resolved open questions
+
+1. **Profession taxonomy:** free-text + curated suggestion chips on `users` (no heavy ontology) — serves all professions.
+2. **Analysis caching:** per-(cluster, profession-hash), stored `{profession:{...}}` in JSONB; cache-version/source-hash invalidation.
+3. **Trivia loop:** kept (owner) — daily-by-topic as primary, Today card; per-story as collapsed disclosure.
+4. **Search:** hybrid (semantic-primary + keyword union, dedup by article, group by cluster) + HNSW index.

--- a/docs/enhancement/02-PRD.md
+++ b/docs/enhancement/02-PRD.md
@@ -1,0 +1,228 @@
+# NewsLens — PRD (build spec, TDD targets)
+
+> Source of truth for the build. Derived from [00-PLAN.md](00-PLAN.md) + [01-REVIEWS.md](01-REVIEWS.md).
+> Test legend: **(U)** pure unit, native-OK · **(I)** integration, needs pgvector DB (Docker/Linux) · **(L)** LLM seam mocked.
+
+## Vision & positioning
+A **personal daily strategic-intelligence briefing sourced from news.** Every story leads with a **decision/impact verdict** — *what it means for you and what (if anything) to do* — not a summary. Works for **any profession** (doctor, PM, AI enthusiast, geopolitics geek, trader, generalist) via a **profession-agnostic engine** (free-text profession + the LLM adapts). Single-user for now (`user_id=1`); auth parked (Firebase).
+
+## Cross-cutting requirements
+- **Graceful degradation:** any LLM feature with no key returns a typed `unavailable` state, never a 500.
+- **AI honesty:** every generated surface carries the "AI-generated · may contain errors" disclaimer; never show AI confidence numbers that aren't real.
+- **Caching:** LLM lens outputs persist to JSONB on `story_clusters`, keyed by profession-hash, with a `source_hash`/`cache_version` so re-clustering invalidates.
+- **Color budget:** monochromatic-until-interaction; AI surfaces use the violet/`drill` token; reuse existing semantic tokens (no new palette).
+
+## Test strategy
+- **Unit (U):** pure logic — explore/exploit math, free-first sort, dedup ratios, prompt builders, source upsert diff, profession-hash, JSON-repair. Run native (`pytest tests/unit`).
+- **Integration (I):** anything touching SQL/pgvector/JSONB/aggregates — run against a real Postgres+pgvector via `docker-compose`; session-scoped DB + per-test transaction rollback. `pytest tests/integration` (Docker/Linux only; greenlet fails on native Win-ARM).
+- **LLM seam (L):** patch `app.services.llm.generate` and `app.services.embeddings.generate_embedding`; inject deterministic strings / orthogonal unit vectors. No real API calls in tests.
+- New fixtures: `db_session` (real, rollback), `seed_cluster`, `seed_articles_with_embeddings`, `fake_llm`.
+
+---
+
+## P-1 — E★ Foundation (hard blocker, do first)
+
+**Story:** As a developer, I need a migratable schema and a DB-backed test harness so every later feature is TDD-able.
+
+**Acceptance:**
+- Alembic baseline migration stamps the **current** schema (9 tables) so `alembic upgrade head` on a fresh DB reproduces today's prod schema; the ad-hoc `ALTER` block in `main.py` is removed once baselined (Alembic authoritative for Neon/Render; `create_all` kept for local/test only).
+- `docker-compose` test profile brings up Postgres+pgvector; `tests/integration` connects and rolls back per test.
+- `app/services/llm.py` exists as the single generation seam; `tests/conftest.py` gains `fake_llm` + `db_session` fixtures.
+
+**Test cases:**
+- (I) `test_alembic_upgrade_from_empty_creates_all_tables` — upgrade head on empty DB → all 9 tables + pgvector extension present.
+- (I) `test_alembic_baseline_matches_models` — `alembic revision --autogenerate` after baseline yields no diffs.
+- (I) `test_integration_db_fixture_rolls_back` — row added in one test absent in the next.
+- (U) `test_fake_llm_seam_returns_injected` — patched `llm.generate` returns the injected value.
+
+---
+
+## P0 — E0 Fixes & safety
+
+**Story:** As a user, the multi-source intelligence I was promised is visible and the app is safe.
+
+**Acceptance & test cases:**
+1. **/feed real cluster data** — feed items carry true `source_count` + `cluster_id` from **one grouped aggregate** (count + min(cluster_id) grouped by article_id); the malformed/never-run query is replaced; no per-article N+1.
+   - (I) `test_feed_item_has_real_source_count` — seed a 3-source cluster → feed item shows `source_count=3`, `cluster_id` set.
+   - (I) `test_feed_no_n_plus_one` — assert query count is O(1) for an N-item page.
+2. **Summary scheduler no crash** — `backfill_summaries` uses `now - timedelta(hours=4)` and applies the staleness window.
+   - (U) `test_backfill_window_pre_4am_no_valueerror` — freeze time 02:00 → builds window, no error.
+   - (I) `test_backfill_selects_stale_and_missing` — picks summaries that are null OR older than 4h.
+3. **Reuters feed fixed** — bogus spec-page URL replaced with a working feed (or removed).
+   - (U) `test_starter_feeds_urls_are_valid_feed_urls` — no URL points at `rss-specifications`/spec pages; all look like feeds.
+4. **Encryption safety** — empty `ENCRYPTION_KEY` → fail-fast (no plaintext); `decrypt_value` raises on real failure instead of returning ciphertext.
+   - (U) `test_encrypt_requires_key` — no key → raises, never returns plaintext.
+   - (U) `test_encrypt_decrypt_roundtrip` — with key, round-trips.
+   - (U) `test_decrypt_failure_does_not_leak_ciphertext`.
+5. **SSL fix** — DB connect uses `verify-ca`/`verify-full` (not `CERT_NONE`).
+   - (U) `test_ssl_context_not_cert_none` — built context has `verify_mode != CERT_NONE` when a CA is configured.
+6. **Topic prefs persist** — Settings topic toggles write to backend `user_preferences` and affect `/briefing` & `/feed`.
+   - (I) `test_put_profile_interests_persists` — PUT interests → rows in `user_preferences`.
+   - (I) `test_briefing_weights_by_preferences` — preferred topic ranks higher in briefing.
+7. **Frontend trust** — remove hardcoded `coh:0.85` + source-name-as-category in `DeepDiveView.tsx`; surface real cluster coherence + topic (backend returns them).
+   - (I) `test_cluster_response_includes_coherence_and_topic`.
+8. **Docs** — reconcile `design-system.md` (BottomTabBar, Fraunces) — doc task, no test.
+
+---
+
+## P1 — E1 LLM provider abstraction + Gemini
+
+**Story:** As the owner, I wire my Gemini key so generation runs on Gemini while embeddings stay on OpenAI.
+
+**Acceptance:**
+- `services/llm.py`: `async generate(prompt, *, schema=None, model=None) -> str|dict`; provider via `settings.generation_provider` (`openai`|`gemini`); `embed()` stays bound to OpenAI in `embeddings.py`.
+- Per-user Gemini key (Fernet, separate cache slot) → env `GEMINI_API_KEY` fallback.
+- `schema` path uses Gemini structured output; JSON-repair (`try/except json.loads` + brace-extraction) fallback.
+- `requirements.txt` += `google-generativeai`; `config.py` += `generation_provider`, `gemini_api_key`.
+- `/settings` + `/settings/test-key` support Gemini key (mirrors OpenAI trio).
+
+**Test cases:**
+- (U,L) `test_generate_routes_to_provider` — provider=gemini → gemini path called; =openai → openai path.
+- (U) `test_json_repair_recovers_wrapped_json` — model returns text+```json fenced``` → parsed dict.
+- (U) `test_generate_no_key_returns_unavailable` — no key → typed unavailable, no exception.
+- (U) `test_gemini_key_cache_slot_separate_from_openai`.
+- (I) `test_put_settings_stores_gemini_key_encrypted` — key stored encrypted, never plaintext, masked last4 on GET.
+
+---
+
+## P1 — E6 WIIFM impact lens (the front door / hero)
+
+**Story:** As a {profession} in {locale}, every story tells me **why it matters to me** and what to do, across Finance / Profession / Policy / Daily-life.
+
+**Acceptance:**
+- `GET /clusters/{id}/impact` → `{ headline, dimensions: [{key, label, body}], unavailable? }`, conditioned on the user's `profession`+`locale`; cached in `story_clusters.impact_json[profession_hash]` with `source_hash`.
+- Feed/briefing items can carry a one-line **impact headline** (the "verdict not summary" inversion) when cheap/cached.
+- Profession unset → typed "personalize" state (UI shows "Set your profession →" CTA), not generic filler.
+- Disclaimer present; lazy-generated on first view, served from cache after.
+
+**Test cases:**
+- (L,I) `test_impact_generates_and_caches` — first call hits `llm.generate`; second call same (cluster,profession) does NOT (served from JSONB).
+- (L,I) `test_impact_reuses_cache_per_profession_hash` — different profession → separate cache entry.
+- (I) `test_impact_invalidates_on_source_hash_change` — adding an article to the cluster changes `source_hash` → regenerates.
+- (U) `test_impact_unavailable_when_profession_unset`.
+- (U) `test_profession_hash_stable_and_normalized` — "Doctor" / "doctor " → same hash.
+
+---
+
+## P1 — E3 Onboarding & personalization (all professions)
+
+**Story:** As a new user of any profession, I pick interests fast, optionally set my profession/locale, and the feed becomes mine.
+
+**Acceptance:**
+- Data: `users.profession` (free text), `users.locale` (default `IN`); interests persisted as `user_preferences` weights (not localStorage).
+- `GET/PUT /profile` (profession, locale, interests[]). Settings "Your Topics" wired to it.
+- **Onboarding UX:** interests-first single screen (grid) → feed seeded immediately; **profession/locale deferred** to a dismissible Today banner ("Personalize your impact lens") that appears once impact cards exist; skippable at every step; editable in Profile; "X of 3 set up" nudge.
+- Profession input = curated suggestion **chips + free-text** (serves all professions; no rigid taxonomy).
+
+**Test cases:**
+- (I) `test_put_profile_sets_profession_locale`.
+- (I) `test_interests_persist_as_preferences_not_localstorage`.
+- (I) `test_feed_personalizes_after_interests_set`.
+- (U) `test_profession_freetext_accepted` — arbitrary string (e.g., "marine biologist") accepted.
+- (frontend) `test_onboarding_skippable_each_step`; `test_profession_banner_appears_after_first_impact`.
+
+---
+
+## P1 — E2 Sources (India + Google News + trimmed global)
+
+**Story:** As an India-based reader, my feed includes credible Indian + global sources.
+
+**Acceptance:**
+- Sources move to `app/data/sources.json` with `{name,url,rss_url,type,region,category,is_paywalled}`; `ensure_sources` is an **upsert** keyed on `rss_url`/`url` with an UPDATE path (backfills `region`/`category` on existing rows).
+- `sources.region` = enum (`global`|`in`), nullable+default; `category` nullable.
+- Feeds: fix Reuters; add AP, Guardian (global, trimmed); **India:** The Hindu, TOI, Indian Express, HT, NDTV, The Print, Scroll, LiveMint, Moneycontrol, ET Markets, Business Standard, PIB, RBI, SEBI.
+- **Google News RSS** source type (per-topic query URL, `hl=en-IN&gl=IN`).
+- GDELT `sourcecountry`/`sourcelang` parametrized; add `IN` query; backfill GDELT-created sources' `region`.
+- Build `GET/POST /admin/sources`.
+
+**Test cases:**
+- (U) `test_sources_seed_parses_json`.
+- (I) `test_ensure_sources_upsert_adds_new_without_dupes`.
+- (I) `test_ensure_sources_backfills_region_on_existing`.
+- (U) `test_gdelt_query_includes_country_param`.
+- (U) `test_google_news_rss_url_builder` — builds correct `news.google.com/rss/search` URL.
+- (I) `test_admin_post_source_creates_row`.
+
+---
+
+## P2 — E5 In-depth analysis tabs
+
+**Story:** As a reader, I can go beyond the summary: Key Facts, 5Ws, and "For a {profession}".
+
+**Acceptance:**
+- `GET /clusters/{id}/analysis?lens={key_facts|5ws|profession}` → typed JSON; cached in `analysis_json[lens(/profession)]`.
+- Fills the existing AISummaryBox "Coming soon" tabs + adds a 4th "For a {profession}" tab (capped at 4, scrollable <320px; unset profession → CTA).
+- Lazy per-tab; disclaimer on each.
+
+**Test cases:**
+- (L,I) `test_analysis_keyfacts_returns_bullets_and_caches`.
+- (L,I) `test_analysis_5ws_returns_five_keys` — who/what/when/where/why present.
+- (L,I) `test_analysis_profession_lens_uses_profile`.
+- (U) `test_analysis_unknown_lens_400`.
+
+---
+
+## P2 — E7 Strategic / game-theory lens (house voice)
+
+**Story:** As a geopolitics geek, multi-actor stories get a strategic read — actors, incentives, the "game," and a non-obvious take; every story gets a lightweight "what's really going on" beat.
+
+**Acceptance:**
+- `GET /clusters/{id}/strategic` → `{ actors:[{name,incentive,likely_move}], game_type, second_order:[...], non_obvious_take }` via schema'd Gemini; cached.
+- Auto-offered when topic ∈ world/geopolitics; collapsed-by-default disclosure UI + game-type mono Badge.
+- Lightweight "what's really going on" one-liner available for any story.
+- **No attribution** to specific named principles until sources validated (ship as "game-theory analysis").
+
+**Test cases:**
+- (L,I) `test_strategic_returns_structured_actors_and_game_type`.
+- (L,I) `test_strategic_caches`.
+- (U) `test_strategic_schema_validates_required_fields`.
+- (U) `test_strategic_offered_only_for_geopolitics_topics`.
+
+---
+
+## P3 — E4 Hybrid search
+
+**Story:** As any professional, I search news by keyword / interest / profession area.
+
+**Acceptance:**
+- `GET /search?q=` → **hybrid**: embed query (OpenAI, cache recent) → pgvector `<=>` NN **+** keyword `ILIKE` union → dedup by article → group by cluster → ranked.
+- **HNSW index** on `articles.embedding` (migration; prerequisite).
+- Frontend: activate the inert NavBar search icon → search screen; empty state with interest-seeded + recent searches; per-result "matched on: topic/meaning" mono tag.
+
+**Test cases:**
+- (I) `test_hnsw_index_exists_after_migration`.
+- (L,I) `test_search_exact_keyword_ranks_above_semantic_only` — exact entity match beats paraphrase.
+- (L,I) `test_search_groups_by_cluster_dedup_articles`.
+- (U) `test_query_embedding_cached`.
+- (I) `test_search_empty_query_400`.
+
+---
+
+## P3 — E8 Trivia (easy/medium/hard) + daily quiz
+
+**Story:** As a curious reader, I test my knowledge on a story or my interest area at easy/medium/hard.
+
+**Acceptance:**
+- `GET /clusters/{id}/trivia?difficulty={easy|medium|hard}` and `GET /trivia/daily?topic=` → `[{question, options[], answer_index, explanation, difficulty}]` (schema'd Gemini); cached.
+- UI: per-story collapsed disclosure (bottom of DeepDive); daily quiz as a dismissible **Today card** (not a tab); restrained mono streak counter (no confetti).
+
+**Test cases:**
+- (L,I) `test_trivia_returns_questions_for_each_difficulty`.
+- (U) `test_trivia_each_question_has_answer_and_explanation`.
+- (U) `test_trivia_invalid_difficulty_400`.
+- (L,I) `test_trivia_caches_per_difficulty`.
+
+---
+
+## Data-model deltas (Alembic migrations)
+- `users`: + `profession` (str, null), `locale` (str, default `'IN'`).
+- `user_settings`: + `gemini_api_key_encrypted`, `gemini_key_verified` (bool), `gemini_key_verified_at`.
+- `sources`: + `region` (enum global|in, null+default), `category` (str, null).
+- `story_clusters`: + `analysis_json`, `impact_json`, `strategic_json`, `trivia_json` (JSONB, null) + `source_hash` (str) / `cache_version` (int).
+- Index: HNSW on `articles.embedding` (E4).
+
+## New/changed API surface
+`GET/PUT /profile` · `GET /clusters/{id}/impact` · `GET /clusters/{id}/analysis` · `GET /clusters/{id}/strategic` · `GET /clusters/{id}/trivia` · `GET /trivia/daily` · `GET /search` · `GET/POST /admin/sources` · `PUT /settings` (+gemini) · `POST /settings/test-key` (+gemini).
+
+## DeepDive IA (design-locked)
+Hero (title · real coh:0.XX · src:N) → **AISummaryBox** (Summary / Key Facts / 5Ws / For a {profession}) → **Impact hero card** (headline + expandable dimension chips) → **Strategic Lens** (collapsed) → Source Spectrum → Sources (free-first) → **Trivia** (collapsed, bottom). Lazy-generate on reveal; disclaimer on all AI surfaces.

--- a/docs/enhancement/03-ISSUES.md
+++ b/docs/enhancement/03-ISSUES.md
@@ -1,0 +1,18 @@
+# NewsLens enhancement — issue index
+
+GitHub: [Mr-Genesis/newslens](https://github.com/Mr-Genesis/newslens/issues) · Master: [#43](https://github.com/Mr-Genesis/newslens/issues/43)
+
+| # | Epic | Phase | Depends |
+|---|------|-------|---------|
+| [#33](https://github.com/Mr-Genesis/newslens/issues/33) | E★ Foundation (Alembic baseline + pgvector test DB + LLM seam) | P-1 | — |
+| [#34](https://github.com/Mr-Genesis/newslens/issues/34) | E0 Fixes & safety (/feed, summary, Reuters, encryption, SSL, prefs) | P0 | #33 |
+| [#35](https://github.com/Mr-Genesis/newslens/issues/35) | E1 LLM abstraction + Gemini | P1 | #33 |
+| [#36](https://github.com/Mr-Genesis/newslens/issues/36) | E6 WIIFM impact lens (hero) | P1 | #35,#33 |
+| [#37](https://github.com/Mr-Genesis/newslens/issues/37) | E3 Onboarding + personalization (all professions) | P1 | #33 |
+| [#38](https://github.com/Mr-Genesis/newslens/issues/38) | E2 Sources (India + Google News + upsert/admin) | P1 | #33 |
+| [#39](https://github.com/Mr-Genesis/newslens/issues/39) | E5 Analysis tabs | P2 | #35,#33 |
+| [#40](https://github.com/Mr-Genesis/newslens/issues/40) | E7 Strategic / game-theory lens | P2 | #35,#33 |
+| [#41](https://github.com/Mr-Genesis/newslens/issues/41) | E4 Hybrid search (+HNSW) | P3 | #35,#33 |
+| [#42](https://github.com/Mr-Genesis/newslens/issues/42) | E8 Trivia + daily quiz | P3 | #35,#33 |
+
+Build order: #33 → #34 → #35 → #36 → #37 → #38 → #39 → #40 → #41 → #42.

--- a/docs/enhancement/FIREBASE-DEFERRED.md
+++ b/docs/enhancement/FIREBASE-DEFERRED.md
@@ -1,0 +1,65 @@
+# Firebase — Auth + Notifications (SCOPED & PARKED)
+
+> Decision (2026-06-23): Scope now, **build later**. NewsLens stays **single-user** (`user_id=1`)
+> until this lands. Parked because multi-user auth is a large, cross-cutting lift and the
+> enhancement roadmap (E0–E8) delivers more user value first. This doc is the spec to pick up later.
+
+## Why Firebase (vs alternatives)
+
+- **One SDK for both needs we have**: Firebase **Auth** (Google sign-in out of the box) + **Cloud Messaging (FCM)** for push — including the future notification-engine ideas (daily briefing, "breaking in your topics", trivia streaks).
+- Folds in **"Google Sign-in"** (one of the three Google asks) natively — no separate Google Cloud OAuth client wiring.
+- Free tier is ample for a personal app.
+
+## A. Authentication (Firebase Auth)
+
+### What it unlocks
+- Real multi-user: each user gets their own interests, profession, saved items, API keys, history.
+- Makes personalization (E3) and per-(user) impact (E6) genuinely testable.
+
+### Backend changes
+- Add `firebase-admin` to `requirements.txt`; init with a service-account credential (env: `FIREBASE_CREDENTIALS_JSON` or path).
+- `users` table: add `firebase_uid` (unique), `email`, `display_name`, `photo_url`, `created_at` (exists).
+- New dependency `get_current_user()` (FastAPI `Depends`): read `Authorization: Bearer <ID token>` → `firebase_admin.auth.verify_id_token` → resolve/create local `users` row by `firebase_uid`.
+- **Replace the ~15 hardcoded `user_id=1` call sites** (`routes.py` etc.) and the pipeline default (`embeddings.py:41`) with the resolved user. Pipeline jobs (ingest/cluster) stay system-level; only user-scoped reads/writes change.
+- Migration: backfill the existing single user; gate new endpoints behind auth.
+
+### Frontend changes
+- Add Firebase JS SDK + a **Login screen** (Google sign-in button; email-link optional).
+- Store the ID token; attach `Authorization: Bearer` in `fetchJSON` (`lib/api.ts:8`).
+- Auth guard / redirect; "signed in as" in Settings/Profile (replaces the cosmetic greeting).
+- Capacitor: use the Firebase Auth web flow inside the WebView (or `@capacitor-firebase/authentication` plugin for native Google sign-in).
+
+### Effort (rough): backend ~M, frontend ~M, migration ~S. Net ~1–2 focused builds.
+
+## B. Push notifications (Firebase Cloud Messaging)
+
+> Depends on Auth (need a user → device-token mapping).
+
+### Backend
+- `device_tokens` table: `user_id`, `token`, `platform`, `created_at`, `last_seen`.
+- Endpoints: `POST /devices` (register token), `DELETE /devices/{token}`.
+- Send service via `firebase-admin` messaging; triggers (APScheduler jobs):
+  - **Daily briefing ready** (morning, per locale).
+  - **Breaking in your topics** (new high-coherence cluster matching user preferences).
+  - **Trivia streak / daily quiz** nudge (engagement loop — ties to E8).
+- Respect quiet hours + per-type opt-in (a `notification_prefs` JSON on the user).
+
+### Frontend / Capacitor
+- Web: FCM JS SDK + service worker (`firebase-messaging-sw.js`) for web push.
+- Android (Capacitor): `@capacitor/push-notifications` + FCM; register token on login; handle foreground/background.
+- Settings UI: notification toggles per type + quiet hours.
+
+### Effort (rough): backend ~M, Android wiring ~M (physical device needed — emulator unsupported on Win-ARM).
+
+## Prerequisites (when we start)
+1. Create a **Firebase project**; add a **Web app** (config) and **Android app** (`google-services.json`, package `com.newslens.app`).
+2. Generate a **service-account key** for `firebase-admin` (backend).
+3. Enable **Google** provider in Firebase Auth; add authorized domains (Render URL, localhost).
+4. Enable **Cloud Messaging**.
+
+## Sequencing
+Build **after E0–E8** (or at least after E3 personalization), so auth lands on top of real per-user value. Auth is a prerequisite for FCM. The Gemini/feature work does **not** depend on auth (stays single-user-friendly).
+
+## Open questions
+- Email-link / anonymous sign-in in addition to Google?
+- Do we gate the whole app behind login, or allow anonymous browse + sign-in to personalize? (Recommend the latter — lower acquisition friction.)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
+    "lint:copy": "node scripts/check-copy.mjs",
     "build:android": "mv src/app/story/[clusterId] src/app/story/_clusterId_bak && BUILD_TARGET=capacitor NEXT_PUBLIC_API_BASE_URL=http://10.0.2.2:8000 next build --webpack; mv src/app/story/_clusterId_bak src/app/story/[clusterId] && npx cap sync android",
     "build:android:prod": "mv src/app/story/[clusterId] src/app/story/_clusterId_bak && BUILD_TARGET=capacitor NEXT_PUBLIC_API_BASE_URL=https://newslens-3gpu.onrender.com next build --webpack; mv src/app/story/_clusterId_bak src/app/story/[clusterId] && npx cap sync android",
     "apk:debug": "cd android && ./gradlew assembleDebug"

--- a/frontend/scripts/check-copy.mjs
+++ b/frontend/scripts/check-copy.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Copy guard — fails the build if internal jargon reaches user-facing strings.
+ * Reads the banned list from docs/content/terminology.json and scans
+ * frontend/src for offending text. See docs/content/COPY-GUIDELINES.md.
+ *
+ * Only inspects user-facing text: quoted string literals + JSX text nodes.
+ * Code identifiers, imports, and type declarations are ignored, so a prop
+ * named `coherence` or a field `embedding_status` won't trip it.
+ *
+ * Suppress a single line with a trailing  // copy-lint-ignore
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const srcDir = join(here, "..", "src");
+const terms = JSON.parse(
+  readFileSync(join(repoRoot, "docs", "content", "terminology.json"), "utf8")
+).banned;
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) out.push(...walk(p));
+    else if (/\.(ts|tsx)$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+/** Pull the user-facing slices out of one line: quoted strings + JSX text. */
+function userFacing(line) {
+  const strings = [...line.matchAll(/(['"`])((?:\\.|(?!\1).)*)\1/g)].map((m) => m[2]);
+  const jsxText = [...line.matchAll(/>([^<>{}]*[A-Za-z][^<>{}]*)</g)].map((m) => m[1]);
+  // Bare prose line = multi-line JSX text (e.g. text sitting alone between <p> … </p>).
+  // It has letters but none of the structural code characters.
+  const trimmed = line.trim();
+  // Require a space → real prose, not a lone identifier like `coherence,`.
+  if (trimmed && /\s/.test(trimmed) && /[A-Za-z]/.test(trimmed) && !/[<>{}=;()"'`]/.test(trimmed)) {
+    jsxText.push(trimmed);
+  }
+  return { strings, jsxText, all: [...strings, ...jsxText] };
+}
+
+const isCodeLine = (l) =>
+  /^\s*(import |export (type|interface|default type)|\/\/|\*|\/\*)/.test(l) ||
+  /^\s*(type|interface)\s+\w/.test(l);
+
+const findings = [];
+for (const file of walk(srcDir)) {
+  const rel = relative(repoRoot, file).replace(/\\/g, "/");
+  const lines = readFileSync(file, "utf8").split(/\r?\n/);
+  lines.forEach((line, i) => {
+    if (isCodeLine(line) || /\/\/\s*copy-lint-ignore/.test(line)) return;
+    const seg = userFacing(line);
+    for (const b of terms) {
+      const haystacks =
+        b.scope === "jsx-text" ? seg.jsxText : seg.all;
+      let hit = false;
+      if (b.kind === "pattern") {
+        hit = haystacks.some((s) => s.includes(b.term));
+      } else {
+        const re = new RegExp(`\\b${b.term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i");
+        hit = haystacks.some((s) => re.test(s));
+      }
+      if (hit) {
+        findings.push({
+          severity: b.severity, file: rel, line: i + 1,
+          term: b.term, text: line.trim().slice(0, 100), use: b.useInstead,
+        });
+      }
+    }
+  });
+}
+
+const errors = findings.filter((f) => f.severity === "error");
+const warns = findings.filter((f) => f.severity === "warn");
+
+for (const f of [...errors, ...warns]) {
+  const tag = f.severity === "error" ? "ERROR" : "warn ";
+  console.log(`${tag}  ${f.file}:${f.line}  "${f.term}" → ${f.use}`);
+  console.log(`        ${f.text}`);
+}
+
+console.log(
+  `\ncopy-lint: ${errors.length} error(s), ${warns.length} warning(s) across user-facing strings.`
+);
+if (errors.length) {
+  console.log("Fix the ERROR lines (see docs/content/COPY-GUIDELINES.md) or run with care.");
+  process.exit(1);
+}

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -20,6 +20,7 @@ export default function DiscoverPage() {
   const [state, setState] = useState<PageState>("loading");
   const [deck, setDeck] = useState<DiscoverCardType[]>([]);
   const [totalSwiped, setTotalSwiped] = useState(0);
+  const [history, setHistory] = useState<DiscoverCardType[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isFetching, setIsFetching] = useState(false);
 
@@ -72,6 +73,7 @@ export default function DiscoverPage() {
       const card = deck[0];
       if (!card) return;
 
+      setHistory((prev) => [...prev, card]);
       setDeck((prev) => prev.slice(1));
       setTotalSwiped((prev) => prev + 1);
 
@@ -106,6 +108,17 @@ export default function DiscoverPage() {
     [deck]
   );
 
+  const handleUndo = useCallback(() => {
+    setHistory((h) => {
+      if (h.length === 0) return h;
+      const last = h[h.length - 1];
+      setDeck((d) => [last, ...d]);
+      setTotalSwiped((n) => Math.max(0, n - 1));
+      setState("swiping");
+      return h.slice(0, -1);
+    });
+  }, []);
+
   // Keyboard support
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -127,7 +140,6 @@ export default function DiscoverPage() {
   }, [state, deck.length, handleSwipe]);
 
   const visibleCards = deck.slice(0, 3);
-  const showAffordance = totalSwiped < 3;
 
   return (
     <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)]">
@@ -184,6 +196,14 @@ export default function DiscoverPage() {
       {/* Swiping: card stack */}
       {state === "swiping" && (
         <div className="flex flex-col items-center pt-2">
+          {/* Header */}
+          <div className="w-full mb-3">
+            <h1 className="text-hero text-[var(--text-primary)]">Discover</h1>
+            <p className="text-mono text-[var(--text-muted)] mt-1">
+              SWIPE TO TRIAGE &middot; {totalSwiped + 1} OF {deck.length + totalSwiped}
+            </p>
+          </div>
+
           {/* Card stack */}
           <div
             className="relative w-full"
@@ -204,59 +224,43 @@ export default function DiscoverPage() {
             </AnimatePresence>
           </div>
 
-          {/* Progress bar */}
-          <div className="w-full max-w-[180px] mt-3">
-            <div className="h-[2px] bg-[var(--surface-raised)] rounded-full overflow-hidden">
-              <motion.div
-                className="h-full bg-[var(--accent)] rounded-full"
-                initial={{ width: "100%" }}
-                animate={{
-                  width: `${Math.max(5, (deck.length / (deck.length + totalSwiped)) * 100)}%`,
-                }}
-                transition={{ duration: 0.3 }}
-              />
-            </div>
-            <p className="text-mono text-[var(--text-ghost)] text-center mt-2">
-              {deck.length} stories left
-            </p>
-          </div>
-
-          {/* Swipe affordance hints — fade after 3 swipes */}
-          <AnimatePresence>
-            {showAffordance && (
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -10 }}
-                className="flex items-center justify-center gap-5 mt-2"
+          {/* Action buttons — Skip / Undo / Save */}
+          <div className="flex items-center justify-center gap-6 mt-6">
+            <div className="flex flex-col items-center gap-1.5">
+              <motion.button
+                whileTap={{ scale: 0.92 }}
+                onClick={() => handleSwipe("left")}
+                aria-label="Skip"
+                className="w-12 h-12 rounded-full bg-[var(--surface-raised)] border border-[var(--border)] flex items-center justify-center text-[var(--text-secondary)]"
               >
-                <div className="flex flex-col items-center gap-1">
-                  <div className="w-8 h-8 rounded-full bg-[var(--dismiss-muted)] flex items-center justify-center">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--dismiss)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                      <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-                    </svg>
-                  </div>
-                  <span className="text-[10px] text-[var(--text-ghost)]">Not interested</span>
-                </div>
-                <div className="flex flex-col items-center gap-1">
-                  <div className="w-8 h-8 rounded-full bg-[var(--drill-muted)] flex items-center justify-center">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--drill)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                      <line x1="12" y1="19" x2="12" y2="5" /><polyline points="5 12 12 5 19 12" />
-                    </svg>
-                  </div>
-                  <span className="text-[10px] text-[var(--text-ghost)]">Deep dive</span>
-                </div>
-                <div className="flex flex-col items-center gap-1">
-                  <div className="w-8 h-8 rounded-full bg-[var(--agree-muted)] flex items-center justify-center">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--agree)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                      <polyline points="20 6 9 17 4 12" />
-                    </svg>
-                  </div>
-                  <span className="text-[10px] text-[var(--text-ghost)]">More like this</span>
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+              </motion.button>
+              <span className="text-mono text-[10px] text-[var(--text-ghost)]">SKIP</span>
+            </div>
+            <div className="flex flex-col items-center gap-1.5">
+              <motion.button
+                whileTap={{ scale: 0.92 }}
+                onClick={handleUndo}
+                disabled={history.length === 0}
+                aria-label="Undo last"
+                className="w-11 h-11 rounded-full bg-[var(--surface-raised)] border border-[var(--border)] flex items-center justify-center text-[var(--text-muted)] disabled:opacity-40"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" /></svg>
+              </motion.button>
+              <span className="text-mono text-[10px] text-[var(--text-ghost)]">UNDO</span>
+            </div>
+            <div className="flex flex-col items-center gap-1.5">
+              <motion.button
+                whileTap={{ scale: 0.92 }}
+                onClick={() => handleSwipe("right")}
+                aria-label="Save"
+                className="w-16 h-16 rounded-full bg-[var(--accent)] text-[var(--bg)] flex items-center justify-center shadow-[var(--shadow-md)]"
+              >
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" /></svg>
+              </motion.button>
+              <span className="text-mono text-[10px] text-[var(--accent)]">SAVE</span>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -99,6 +99,7 @@ export default function BriefingPage() {
   );
 
   return (
+    <PullToRefresh onRefresh={() => fetchBriefing(true)}>
     <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)]">
       {/* Greeting + Date */}
       {(state === "success" || state === "refreshing") && (
@@ -107,19 +108,16 @@ export default function BriefingPage() {
           animate={{ opacity: 1 }}
           className="pt-4 pb-2"
         >
-          <div className="flex items-baseline justify-between">
-            <h1 className="text-title text-[var(--text-primary)]">
-              {getGreeting()}
-            </h1>
+          <div className="flex items-baseline justify-between gap-2">
+            <p className="text-mono text-[var(--accent)] uppercase">
+              {getGreeting()} &middot; {formatDate()}
+            </p>
             {briefing && isStale(briefing.generated_at) && (
               <Badge variant="accent" size="md">
                 Stale
               </Badge>
             )}
           </div>
-          <p className="text-small text-[var(--text-muted)] mt-0.5">
-            {formatDate()}
-          </p>
         </motion.div>
       )}
 
@@ -231,6 +229,9 @@ export default function BriefingPage() {
           {/* Hero story */}
           {heroStory && (
             <div className="mb-4">
+              <h2 className="text-category text-[var(--text-muted)] mb-2">
+                TOP STORY
+              </h2>
               <HeroStoryCard story={heroStory} />
             </div>
           )}
@@ -265,8 +266,10 @@ export default function BriefingPage() {
         </motion.div>
       )}
     </div>
+    </PullToRefresh>
   );
 }
 
 // Need Badge import for stale indicator
 import { Badge } from "@/components/ui/Badge";
+import { PullToRefresh } from "@/components/PullToRefresh";

--- a/frontend/src/app/saved/page.tsx
+++ b/frontend/src/app/saved/page.tsx
@@ -110,12 +110,10 @@ export default function SavedPage() {
       {/* Saved articles list */}
       {state === "success" && (
         <div className="pt-3">
-          <div className="flex items-center justify-between mb-3">
-            <h1 className="text-heading text-[var(--text-primary)]">
-              Saved Stories
-            </h1>
+          <div className="flex items-baseline justify-between mb-3">
+            <h1 className="text-hero text-[var(--text-primary)]">Saved</h1>
             <span className="text-mono text-[var(--text-ghost)]">
-              {articles.length} saved
+              {articles.length} {articles.length === 1 ? "story" : "stories"}
             </span>
           </div>
 
@@ -135,7 +133,7 @@ export default function SavedPage() {
                       {article.cluster_id ? (
                         <Link
                           href={storyHref(article.cluster_id)}
-                          className="text-heading text-[var(--text-primary)] line-clamp-2 hover:text-[var(--accent)] transition-colors"
+                          className="text-title text-[var(--text-primary)] line-clamp-2 hover:text-[var(--accent)] transition-colors"
                         >
                           {article.title}
                         </Link>
@@ -144,7 +142,7 @@ export default function SavedPage() {
                           href={article.url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="text-heading text-[var(--text-primary)] line-clamp-2 hover:text-[var(--accent)] transition-colors"
+                          className="text-title text-[var(--text-primary)] line-clamp-2 hover:text-[var(--accent)] transition-colors"
                         >
                           {article.title}
                         </a>

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import { Input } from "@/components/ui/Input";
+import { Chip } from "@/components/ui/Chip";
+import { search, type SearchResultItem } from "@/lib/api";
+import { storyHref } from "@/lib/utils";
+
+type FilterKey = "all" | "semantic" | "topic" | "recent";
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "semantic", label: "Semantic" },
+  { key: "topic", label: "Topic" },
+  { key: "recent", label: "Recent" },
+];
+
+const SearchIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="11" cy="11" r="8" />
+    <path d="M21 21l-4.35-4.35" />
+  </svg>
+);
+
+function matchedLabel(matchedOn: string): string {
+  if (matchedOn.includes("topic") && matchedOn.includes("meaning")) return "matched: both";
+  if (matchedOn.includes("topic")) return "matched: topic";
+  return "matched: meaning";
+}
+
+export default function SearchPage() {
+  const [query, setQuery] = useState("");
+  const [submitted, setSubmitted] = useState("");
+  const [filter, setFilter] = useState<FilterKey>("all");
+  const [results, setResults] = useState<SearchResultItem[]>([]);
+  const [state, setState] = useState<"idle" | "loading" | "done" | "error">("idle");
+
+  async function runSearch(q: string) {
+    const trimmed = q.trim();
+    if (!trimmed) return;
+    setState("loading");
+    setSubmitted(trimmed);
+    try {
+      const res = await search(trimmed);
+      setResults(res.results);
+      setState("done");
+    } catch {
+      setResults([]);
+      setState("error");
+    }
+  }
+
+  const filtered = results.filter((r) => {
+    if (filter === "semantic") return r.matched_on.includes("meaning");
+    if (filter === "topic") return r.matched_on.includes("topic");
+    return true;
+  });
+
+  return (
+    <div className="mx-auto max-w-[640px] w-full px-[var(--space-lg)] py-[var(--space-lg)]">
+      <h1 className="text-hero text-[var(--text-primary)] mb-[var(--space-md)]">Search</h1>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          runSearch(query);
+        }}
+      >
+        <Input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search the news"
+          leftIcon={<SearchIcon />}
+          aria-label="Search the news"
+          autoFocus
+        />
+      </form>
+
+      <div className="flex gap-2 mt-[var(--space-md)] overflow-x-auto no-scrollbar">
+        {FILTERS.map((f) => (
+          <Chip key={f.key} selected={filter === f.key} onClick={() => setFilter(f.key)}>
+            {f.label}
+          </Chip>
+        ))}
+      </div>
+
+      <div className="mt-[var(--space-lg)]">
+        {state === "loading" && (
+          <p className="text-mono text-[var(--text-muted)]">Searching…</p>
+        )}
+        {state === "error" && (
+          <p className="text-small text-[var(--text-muted)]">
+            Couldn&apos;t run that search. Try again.
+          </p>
+        )}
+        {state === "idle" && (
+          <p className="text-small text-[var(--text-muted)]">
+            Search across every source — by topic or by meaning.
+          </p>
+        )}
+        {state === "done" && (
+          <>
+            <p className="text-mono text-[var(--text-muted)] mb-[var(--space-md)]">
+              &ldquo;{submitted}&rdquo; &middot; {filtered.length}{" "}
+              {filtered.length === 1 ? "result" : "results"}
+            </p>
+            {filtered.length === 0 ? (
+              <p className="text-small text-[var(--text-muted)]">
+                No stories match &mdash; try a broader query.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-[var(--space-md)]">
+                <AnimatePresence initial={false}>
+                  {filtered.map((r, i) => (
+                    <motion.div
+                      key={r.id}
+                      initial={{ opacity: 0, y: 8 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.2, delay: i * 0.03 }}
+                    >
+                      <Link
+                        href={r.cluster_id ? storyHref(r.cluster_id) : r.url}
+                        className="block rounded-[var(--radius-lg)] bg-[var(--surface)] border border-[var(--border-subtle)] p-[var(--space-md)] transition-colors hover:bg-[var(--surface-hover)]"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <h2 className="text-heading text-[var(--text-primary)]">
+                            {r.title}
+                          </h2>
+                          <span className="shrink-0 text-mono text-[10px] px-2 py-0.5 rounded-full bg-[var(--accent-subtle)] text-[var(--accent)]">
+                            {matchedLabel(r.matched_on)}
+                          </span>
+                        </div>
+                        {r.snippet && (
+                          <p className="text-small text-[var(--text-secondary)] line-clamp-2 mt-1.5">
+                            {r.snippet}
+                          </p>
+                        )}
+                        <p className="text-mono text-[var(--text-muted)] mt-2">
+                          {r.source?.name}
+                        </p>
+                      </Link>
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -321,7 +321,7 @@ export default function ProfilePage() {
                   )}
                 </div>
                 <p className="text-mono text-[var(--text-ghost)] mb-4">
-                  OpenAI API key for embeddings and summaries
+                  Powers AI summaries and related-story matching
                 </p>
 
                 {/* Current key display */}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -8,6 +8,7 @@ import { Card } from "@/components/ui/Card";
 import { Chip } from "@/components/ui/Chip";
 import { Badge } from "@/components/ui/Badge";
 import { useTheme } from "@/components/ThemeProvider";
+import { ProfileFields } from "@/components/ProfileFields";
 import {
   getSettings,
   getStats,
@@ -248,6 +249,11 @@ export default function ProfilePage() {
               </Card>
             </motion.div>
           )}
+
+          {/* Profile + Gemini key (v2) */}
+          <motion.div variants={fadeUp} className="flex flex-col gap-4 mb-4">
+            <ProfileFields />
+          </motion.div>
 
           {/* Your Topics */}
           <motion.div variants={fadeUp} className="mb-4">

--- a/frontend/src/app/template.tsx
+++ b/frontend/src/app/template.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+/** Per-route enter transition — a subtle fade + slide on every navigation.
+ *  (App Router remounts templates on navigation, giving each screen an entrance.) */
+export default function Template({ children }: { children: React.ReactNode }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/frontend/src/components/DeepDiveView.tsx
+++ b/frontend/src/components/DeepDiveView.tsx
@@ -1,47 +1,45 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { AISummaryBox } from "@/components/ui/AISummaryBox";
+import { ImpactCard } from "@/components/ui/ImpactCard";
 import { SourceCard } from "@/components/SourceCard";
 import { SourceSpectrum } from "@/components/SourceSpectrum";
-import { StoryActionBar } from "@/components/StoryActionBar";
-import { Badge } from "@/components/ui/Badge";
+import { IconButton } from "@/components/ui/IconButton";
 import { ConfidenceScore } from "@/components/ui/ConfidenceScore";
 import { Button } from "@/components/ui/Button";
 import { DeepDiveSkeleton } from "@/components/ui/Skeleton";
 import { relativeTime } from "@/lib/utils";
-import { getCluster, type ClusterDetail } from "@/lib/api";
+import { getCluster, postFeedback, type ClusterDetail } from "@/lib/api";
 
 type PageState = "loading" | "success" | "error";
 
-const topicColorMap: Record<string, string> = {
-  technology: "var(--topic-tech)",
-  tech: "var(--topic-tech)",
-  politics: "var(--topic-politics)",
-  business: "var(--topic-business)",
-  science: "var(--topic-science)",
-  sports: "var(--topic-sports)",
-  health: "var(--topic-health)",
-  world: "var(--topic-world)",
-};
+const ShareIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+    <polyline points="16 6 12 2 8 6" />
+    <line x1="12" y1="2" x2="12" y2="15" />
+  </svg>
+);
 
-function getTopicColor(category: string): string {
-  const lower = category.toLowerCase();
-  return topicColorMap[lower] || "var(--topic-default)";
-}
+const BookmarkIcon = ({ filled }: { filled: boolean }) => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+  </svg>
+);
 
 export default function DeepDiveView({
   clusterIdOverride,
 }: { clusterIdOverride?: number } = {}) {
   const params = useParams();
-  const router = useRouter();
   const clusterId = clusterIdOverride ?? Number(params.clusterId);
 
   const [state, setState] = useState<PageState>("loading");
   const [cluster, setCluster] = useState<ClusterDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
 
   const fetchCluster = useCallback(async () => {
     if (!clusterId || isNaN(clusterId)) {
@@ -49,7 +47,6 @@ export default function DeepDiveView({
       setState("error");
       return;
     }
-
     try {
       setState("loading");
       setError(null);
@@ -57,9 +54,7 @@ export default function DeepDiveView({
       setCluster(data);
       setState("success");
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load story details"
-      );
+      setError(err instanceof Error ? err.message : "Failed to load story details");
       setState("error");
     }
   }, [clusterId]);
@@ -68,170 +63,125 @@ export default function DeepDiveView({
     fetchCluster();
   }, [fetchCluster]);
 
-  // Sort sources: free first, then paywalled, alphabetical within each group
   const sortedSources = cluster?.sources
     ? [...cluster.sources].sort((a, b) => {
-        if (a.is_free !== b.is_free) {
-          return a.is_free ? -1 : 1;
-        }
+        if (a.is_free !== b.is_free) return a.is_free ? -1 : 1;
         return a.article.source.name.localeCompare(b.article.source.name);
       })
     : [];
-
   const freeCount = sortedSources.filter((s) => s.is_free).length;
   const paywallCount = sortedSources.filter((s) => !s.is_free).length;
-
-  // Get first article ID for action bar feedback
   const firstArticleId = cluster?.sources?.[0]?.article?.id;
 
-  // Infer category from first source's topics or fallback
-  const category =
-    cluster?.sources?.[0]?.article?.source?.name || "News";
+  async function handleSave() {
+    if (!firstArticleId) return;
+    setSaved((s) => !s);
+    try {
+      await postFeedback(firstArticleId, "save");
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function handleShare() {
+    const url = typeof window !== "undefined" ? window.location.href : "";
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: cluster?.title ?? "NewsLens", url });
+      } else {
+        await navigator.clipboard.writeText(url);
+      }
+      if (firstArticleId) await postFeedback(firstArticleId, "share");
+    } catch {
+      /* user cancelled */
+    }
+  }
 
   return (
-    <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)] pb-[80px]">
-      {/* Loading */}
+    <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)] pb-[var(--space-2xl)]">
       {state === "loading" && (
         <div className="pt-[var(--space-md)]">
           <DeepDiveSkeleton />
         </div>
       )}
 
-      {/* Error */}
       {state === "error" && (
         <div className="flex flex-col items-center justify-center pt-[var(--space-3xl)] text-center">
-          <div className="w-12 h-12 rounded-full bg-[var(--dismiss-muted)] flex items-center justify-center mb-4">
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="var(--dismiss)"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <circle cx="12" cy="12" r="10" />
-              <line x1="15" y1="9" x2="9" y2="15" />
-              <line x1="9" y1="9" x2="15" y2="15" />
-            </svg>
-          </div>
           <p className="text-heading text-[var(--text-primary)]">
-            Couldn&apos;t load story details
+            Couldn&apos;t load this story
           </p>
-          {error && (
-            <p className="text-mono text-[var(--dismiss)] mt-2">{error}</p>
-          )}
+          {error && <p className="text-mono text-[var(--text-muted)] mt-2">{error}</p>}
           <Button variant="secondary" onClick={fetchCluster} className="mt-4">
             Try again
           </Button>
         </div>
       )}
 
-      {/* Success */}
       {state === "success" && cluster && (
-        <>
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.3 }}
-            className="pt-[var(--space-md)]"
-          >
-            {/* Hero section */}
-            <div className="mb-4">
-              {/* Category + timestamp + confidence */}
-              <div className="flex items-center gap-2 mb-2">
-                <Badge
-                  variant="topic"
-                  size="md"
-                  color={getTopicColor(category)}
-                >
-                  {category}
-                </Badge>
-                <span className="text-mono text-[var(--text-ghost)]">
-                  {relativeTime(cluster.created_at)}
-                </span>
-              </div>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+          className="pt-[var(--space-md)] flex flex-col gap-4"
+        >
+          {/* Top actions */}
+          <div className="flex justify-end gap-1">
+            <IconButton label="Share" onClick={handleShare}>
+              <ShareIcon />
+            </IconButton>
+            <IconButton
+              label={saved ? "Saved" : "Save"}
+              variant={saved ? "accent" : "default"}
+              onClick={handleSave}
+            >
+              <BookmarkIcon filled={saved} />
+            </IconButton>
+          </div>
 
-              {/* Title */}
-              <motion.h1
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.3, delay: 0.1 }}
-                className="text-hero text-[var(--text-primary)]"
-              >
-                {cluster.title}
-              </motion.h1>
-
-              {/* Confidence */}
-              <div className="mt-3">
-                <ConfidenceScore
-                  sourceCount={cluster.sources.length}
-                  coherence={0.85}
-                />
-              </div>
-            </div>
-
-            {/* AI Summary — tabbed */}
-            <motion.div
+          {/* Hero */}
+          <div>
+            <p className="text-mono text-[var(--accent)] mb-2">AI &middot; DEEP DIVE</p>
+            <motion.h1
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.3, delay: 0.15 }}
-              className="mb-4"
+              transition={{ duration: 0.3, delay: 0.1 }}
+              className="text-hero text-[var(--text-primary)]"
             >
-              <AISummaryBox
-                summary={cluster.summary}
-                coherence={0.85}
-                clusterId={clusterId}
-              />
-            </motion.div>
-
-            {/* Source Spectrum */}
-            <motion.div
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.3, delay: 0.2 }}
-              className="mb-4"
-            >
-              <SourceSpectrum
-                freeCount={freeCount}
-                paywallCount={paywallCount}
-              />
-            </motion.div>
-
-            {/* Sources header */}
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ delay: 0.25 }}
-              className="mb-3"
-            >
-              <h2 className="text-category text-[var(--text-muted)]">
-                Sources
-              </h2>
-            </motion.div>
-
-            {/* Source cards */}
-            <div>
-              {sortedSources.map((sourceCard, index) => (
-                <SourceCard
-                  key={sourceCard.article.id}
-                  sourceName={sourceCard.article.source.name}
-                  url={sourceCard.article.url}
-                  snippet={sourceCard.article.snippet}
-                  isFree={sourceCard.is_free}
-                  publishedAt={sourceCard.article.published_at}
-                  index={index}
-                />
-              ))}
+              {cluster.title}
+            </motion.h1>
+            <div className="mt-3 flex items-center gap-1.5 flex-wrap">
+              <ConfidenceScore sourceCount={cluster.sources.length} coherence={0.85} />
+              <span className="text-mono text-[var(--text-ghost)]">&middot;</span>
+              <span className="text-mono text-[var(--text-muted)]">
+                {relativeTime(cluster.created_at)}
+              </span>
             </div>
-          </motion.div>
+          </div>
 
-          {/* Floating action bar */}
-          {firstArticleId && (
-            <StoryActionBar articleId={firstArticleId} />
-          )}
-        </>
+          {/* AI Summary */}
+          <AISummaryBox summary={cluster.summary} coherence={0.85} clusterId={clusterId} />
+
+          {/* What's in it for me */}
+          <ImpactCard clusterId={clusterId} />
+
+          {/* Source access */}
+          <SourceSpectrum freeCount={freeCount} paywallCount={paywallCount} />
+
+          {/* Source cards */}
+          <div className="flex flex-col">
+            {sortedSources.map((sourceCard, index) => (
+              <SourceCard
+                key={sourceCard.article.id}
+                sourceName={sourceCard.article.source.name}
+                url={sourceCard.article.url}
+                snippet={sourceCard.article.snippet}
+                isFree={sourceCard.is_free}
+                publishedAt={sourceCard.article.published_at}
+                index={index}
+              />
+            ))}
+          </div>
+        </motion.div>
       )}
     </div>
   );

--- a/frontend/src/components/DeepDiveView.tsx
+++ b/frontend/src/components/DeepDiveView.tsx
@@ -8,10 +8,9 @@ import { ImpactCard } from "@/components/ui/ImpactCard";
 import { SourceCard } from "@/components/SourceCard";
 import { SourceSpectrum } from "@/components/SourceSpectrum";
 import { IconButton } from "@/components/ui/IconButton";
-import { ConfidenceScore } from "@/components/ui/ConfidenceScore";
+import { AgreementMeter } from "@/components/ui/AgreementMeter";
 import { Button } from "@/components/ui/Button";
 import { DeepDiveSkeleton } from "@/components/ui/Skeleton";
-import { relativeTime } from "@/lib/utils";
 import { getCluster, postFeedback, type ClusterDetail } from "@/lib/api";
 
 type PageState = "loading" | "success" | "error";
@@ -149,12 +148,12 @@ export default function DeepDiveView({
             >
               {cluster.title}
             </motion.h1>
-            <div className="mt-3 flex items-center gap-1.5 flex-wrap">
-              <ConfidenceScore sourceCount={cluster.sources.length} coherence={0.85} />
-              <span className="text-mono text-[var(--text-ghost)]">&middot;</span>
-              <span className="text-mono text-[var(--text-muted)]">
-                {relativeTime(cluster.created_at)}
-              </span>
+            <div className="mt-4">
+              <AgreementMeter
+                coherence={0.85}
+                sourceCount={cluster.sources.length}
+                createdAt={cluster.created_at}
+              />
             </div>
           </div>
 

--- a/frontend/src/components/DeepDiveView.tsx
+++ b/frontend/src/components/DeepDiveView.tsx
@@ -179,7 +179,11 @@ export default function DeepDiveView({
               transition={{ duration: 0.3, delay: 0.15 }}
               className="mb-4"
             >
-              <AISummaryBox summary={cluster.summary} coherence={0.85} />
+              <AISummaryBox
+                summary={cluster.summary}
+                coherence={0.85}
+                clusterId={clusterId}
+              />
             </motion.div>
 
             {/* Source Spectrum */}

--- a/frontend/src/components/DiscoverCard.tsx
+++ b/frontend/src/components/DiscoverCard.tsx
@@ -8,7 +8,6 @@ import {
 } from "framer-motion";
 import { useCallback } from "react";
 import { Badge } from "@/components/ui/Badge";
-import { ConfidenceScore } from "@/components/ui/ConfidenceScore";
 import { cn } from "@/lib/utils";
 import type { DiscoverCard as DiscoverCardType } from "@/lib/api";
 
@@ -35,8 +34,13 @@ const topicColorMap: Record<string, string> = {
 };
 
 function getTopicColor(topicName: string): string {
-  const lower = topicName.toLowerCase();
-  return topicColorMap[lower] || "var(--topic-default)";
+  return topicColorMap[topicName.toLowerCase()] || "var(--topic-default)";
+}
+
+function agreementColor(coherence: number): string {
+  if (coherence >= 0.8) return "var(--agree)";
+  if (coherence >= 0.6) return "var(--warning)";
+  return "var(--text-muted)";
 }
 
 export function DiscoverCard({
@@ -48,45 +52,25 @@ export function DiscoverCard({
   const x = useMotionValue(0);
   const y = useMotionValue(0);
 
-  const rotate = useTransform(
-    x,
-    [-300, 0, 300],
-    [-MAX_ROTATION, 0, MAX_ROTATION]
-  );
-
-  const glowRightOpacity = useTransform(
-    x,
-    [0, COMMIT_THRESHOLD_X],
-    [0, 0.8]
-  );
-  const glowLeftOpacity = useTransform(
-    x,
-    [-COMMIT_THRESHOLD_X, 0],
-    [0.8, 0]
-  );
+  const rotate = useTransform(x, [-300, 0, 300], [-MAX_ROTATION, 0, MAX_ROTATION]);
+  const glowRightOpacity = useTransform(x, [0, COMMIT_THRESHOLD_X], [0, 0.9]);
+  const glowLeftOpacity = useTransform(x, [-COMMIT_THRESHOLD_X, 0], [0.9, 0]);
   const glowUpOpacity = useTransform(y, [COMMIT_THRESHOLD_Y, 0], [0.8, 0]);
 
   const scale = 1 - stackIndex * 0.03;
   const translateY = stackIndex * 8;
   const opacity = 1 - stackIndex * 0.35;
   const topicColor = getTopicColor(card.topic_name);
+  const pct = Math.round(card.coherence * 100);
+  const aColor = agreementColor(card.coherence);
+  const filled = Math.max(1, Math.min(4, Math.round(card.coherence * 4)));
 
   const handleDragEnd = useCallback(
     (_: unknown, info: PanInfo) => {
       const { offset, velocity } = info;
-
-      if (offset.y < COMMIT_THRESHOLD_Y || velocity.y < -500) {
-        onSwipe("up");
-        return;
-      }
-      if (offset.x > COMMIT_THRESHOLD_X || velocity.x > 500) {
-        onSwipe("right");
-        return;
-      }
-      if (offset.x < -COMMIT_THRESHOLD_X || velocity.x < -500) {
-        onSwipe("left");
-        return;
-      }
+      if (offset.y < COMMIT_THRESHOLD_Y || velocity.y < -500) return onSwipe("up");
+      if (offset.x > COMMIT_THRESHOLD_X || velocity.x > 500) return onSwipe("right");
+      if (offset.x < -COMMIT_THRESHOLD_X || velocity.x < -500) return onSwipe("left");
     },
     [onSwipe]
   );
@@ -113,86 +97,84 @@ export function DiscoverCard({
       dragElastic={0.7}
       onDragEnd={isTop ? handleDragEnd : undefined}
       whileDrag={{ boxShadow: "var(--shadow-lg)" }}
-      exit={{
-        opacity: 0,
-        scale: 0.9,
-        transition: { duration: 0.2 },
-      }}
-      transition={{
-        type: "spring",
-        stiffness: 300,
-        damping: 25,
-      }}
+      exit={{ opacity: 0, scale: 0.9, transition: { duration: 0.2 } }}
+      transition={{ type: "spring", stiffness: 300, damping: 25 }}
     >
       {/* Edge glow overlays */}
       {isTop && (
         <>
-          <motion.div
-            className="absolute inset-0 pointer-events-none rounded-[var(--radius-lg)]"
-            style={{
-              opacity: glowRightOpacity,
-              boxShadow: "inset -4px 0 20px var(--swipe-glow-right)",
-            }}
-          />
-          <motion.div
-            className="absolute inset-0 pointer-events-none rounded-[var(--radius-lg)]"
-            style={{
-              opacity: glowLeftOpacity,
-              boxShadow: "inset 4px 0 20px var(--swipe-glow-left)",
-            }}
-          />
-          <motion.div
-            className="absolute inset-0 pointer-events-none rounded-[var(--radius-lg)]"
-            style={{
-              opacity: glowUpOpacity,
-              boxShadow: "inset 0 4px 20px var(--swipe-glow-up)",
-            }}
-          />
+          <motion.div className="absolute inset-0 pointer-events-none rounded-[var(--radius-lg)]" style={{ opacity: glowRightOpacity, boxShadow: "inset -4px 0 20px var(--swipe-glow-right)" }} />
+          <motion.div className="absolute inset-0 pointer-events-none rounded-[var(--radius-lg)]" style={{ opacity: glowLeftOpacity, boxShadow: "inset 4px 0 20px var(--swipe-glow-left)" }} />
+          <motion.div className="absolute inset-0 pointer-events-none rounded-[var(--radius-lg)]" style={{ opacity: glowUpOpacity, boxShadow: "inset 0 4px 20px var(--swipe-glow-up)" }} />
+          {/* Swipe stamps */}
+          <motion.div style={{ opacity: glowRightOpacity }} className="absolute top-5 right-5 z-10 rotate-12 pointer-events-none text-mono font-bold border-2 rounded-[var(--radius-md)] px-2.5 py-1 border-[var(--agree)] text-[var(--agree)]">
+            SAVE
+          </motion.div>
+          <motion.div style={{ opacity: glowLeftOpacity }} className="absolute top-5 left-5 z-10 -rotate-12 pointer-events-none text-mono font-bold border-2 rounded-[var(--radius-md)] px-2.5 py-1 border-[var(--dismiss)] text-[var(--dismiss)]">
+            SKIP
+          </motion.div>
         </>
       )}
 
       {/* Card content */}
       <div
         className={cn("p-4 flex flex-col", !isTop && "invisible")}
-        style={{ height: "min(340px, calc(100dvh - 260px))" }}
+        style={{ height: "min(420px, calc(100dvh - 240px))" }}
       >
-        {/* Topic badge — top left */}
-        <div className="flex items-center gap-2">
+        {/* Header: topic badge + agreement */}
+        <div className="flex items-center justify-between gap-2">
           <Badge variant="topic" size="md" color={topicColor}>
             {card.topic_name}
           </Badge>
+          <span className="text-mono inline-flex items-center gap-1.5" style={{ color: aColor }}>
+            {pct}%
+            <span className="inline-flex items-center gap-[2px]" aria-hidden="true">
+              {Array.from({ length: 4 }, (_, i) => (
+                <span
+                  key={i}
+                  className="inline-block w-1 h-1 rounded-full"
+                  style={{ backgroundColor: i < filled ? aColor : "var(--text-ghost)", opacity: i < filled ? 1 : 0.4 }}
+                />
+              ))}
+            </span>
+          </span>
         </div>
 
-        {/* Tension line — italic emphasis (the ONE place italic lives) */}
-        <h2 className="text-title text-emphasis text-[var(--text-primary)] mt-4 flex-shrink-0">
-          {card.tension_line || card.title}
+        {/* Headline */}
+        <h2 className="text-title text-[var(--text-primary)] mt-3 flex-shrink-0">
+          {card.title}
         </h2>
+
+        {/* Tension box — amber */}
+        {card.tension_line && card.tension_line !== card.title && (
+          <div className="mt-3 rounded-[var(--radius-md)] border border-[var(--accent-muted)] bg-[var(--accent-subtle)] px-3 py-2.5 flex items-start gap-2">
+            <span className="text-[var(--accent)] shrink-0 mt-[2px]" aria-hidden="true">&#9888;</span>
+            <p className="text-small text-emphasis text-[var(--accent)]">{card.tension_line}</p>
+          </div>
+        )}
 
         {/* Facts */}
         <ul className="mt-4 space-y-2.5 flex-1 overflow-hidden">
           {card.facts.map((fact, i) => (
-            <li
-              key={i}
-              className="text-small text-[var(--text-secondary)] flex items-start gap-2.5"
-            >
-              <span
-                className="w-1.5 h-1.5 rounded-full shrink-0 mt-[7px]"
-                style={{ backgroundColor: topicColor }}
-              />
+            <li key={i} className="text-small text-[var(--text-secondary)] flex items-start gap-2.5">
+              <span className="w-1.5 h-1.5 rounded-full shrink-0 mt-[7px]" style={{ backgroundColor: topicColor }} />
               <span className="line-clamp-2">{fact}</span>
             </li>
           ))}
         </ul>
 
-        {/* Footer */}
-        <div className="flex items-center justify-between mt-4 pt-3 border-t border-[var(--glass-border)]">
-          <span className="text-mono text-[var(--text-ghost)] truncate max-w-[60%]">
-            {card.sources.join(" · ")}
-          </span>
-          <ConfidenceScore
-            sourceCount={card.sources.length}
-            coherence={card.coherence}
-          />
+        {/* Source chips */}
+        <div className="flex items-center gap-1.5 flex-wrap mt-4 pt-3 border-t border-[var(--glass-border)]">
+          {card.sources.slice(0, 3).map((s) => (
+            <span key={s} className="text-mono text-[10px] px-2 py-0.5 rounded-full bg-[var(--surface-raised)] text-[var(--text-secondary)]">
+              {s}
+            </span>
+          ))}
+          {card.sources.length > 3 && (
+            <span className="text-mono text-[10px] px-2 py-0.5 rounded-full bg-[var(--surface-raised)] text-[var(--text-muted)]">
+              +{card.sources.length - 3}
+            </span>
+          )}
         </div>
       </div>
     </motion.div>

--- a/frontend/src/components/HeroStoryCard.tsx
+++ b/frontend/src/components/HeroStoryCard.tsx
@@ -16,6 +16,7 @@ export function HeroStoryCard({ story }: HeroStoryCardProps) {
     <motion.div
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
+      whileHover={{ y: -3 }}
       transition={{ duration: 0.4, ease: "easeOut" }}
     >
       <Link

--- a/frontend/src/components/ProfileFields.tsx
+++ b/frontend/src/components/ProfileFields.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+import {
+  getProfile,
+  updateProfile,
+  setGeminiKey,
+  testGeminiKey,
+} from "@/lib/api";
+
+const LOCALES = ["IN", "US", "GB", "global"];
+
+/** v2 Profile additions: Profession + Locale (drives the impact lens) and the
+ *  Gemini API key. Self-contained — manages its own fetch/save. */
+export function ProfileFields() {
+  const [profession, setProfession] = useState("");
+  const [locale, setLocale] = useState("IN");
+  const [loaded, setLoaded] = useState(false);
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [profileSaved, setProfileSaved] = useState(false);
+
+  const [geminiKey, setGeminiKeyInput] = useState("");
+  const [savingKey, setSavingKey] = useState(false);
+  const [keyMsg, setKeyMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    getProfile()
+      .then((p) => {
+        setProfession(p.profession ?? "");
+        setLocale(p.locale ?? "IN");
+      })
+      .catch(() => {})
+      .finally(() => setLoaded(true));
+  }, []);
+
+  async function saveProfile() {
+    setSavingProfile(true);
+    setProfileSaved(false);
+    try {
+      await updateProfile({ profession: profession.trim() || null, locale });
+      setProfileSaved(true);
+      setTimeout(() => setProfileSaved(false), 2000);
+    } catch {
+      /* ignore */
+    } finally {
+      setSavingProfile(false);
+    }
+  }
+
+  async function saveGemini() {
+    if (!geminiKey.trim()) return;
+    setSavingKey(true);
+    setKeyMsg(null);
+    try {
+      await setGeminiKey(geminiKey.trim());
+      const res = await testGeminiKey();
+      setKeyMsg(res.success ? "Gemini key verified" : res.error || "Couldn't verify key");
+      if (res.success) setGeminiKeyInput("");
+    } catch {
+      setKeyMsg("Couldn't save the key");
+    } finally {
+      setSavingKey(false);
+    }
+  }
+
+  return (
+    <>
+      {/* PROFILE */}
+      <Card variant="raised">
+        <div className="p-3.5">
+          <h2 className="text-category text-[var(--text-muted)] mb-3">PROFILE</h2>
+
+          <label className="text-small text-[var(--text-secondary)] block mb-1">
+            Profession
+          </label>
+          <Input
+            value={profession}
+            onChange={(e) => setProfession(e.target.value)}
+            placeholder="e.g. Product Engineer, Doctor, Trader"
+            disabled={!loaded}
+          />
+          <p className="text-mono text-[var(--text-ghost)] mt-2">
+            Tailors the &ldquo;What&apos;s in it for me&rdquo; impact lens to you.
+          </p>
+
+          <label className="text-small text-[var(--text-secondary)] block mt-4 mb-1">
+            Locale
+          </label>
+          <div className="flex gap-2">
+            {LOCALES.map((l) => (
+              <button
+                key={l}
+                onClick={() => setLocale(l)}
+                className={cn(
+                  "px-3 py-1.5 rounded-[var(--radius-md)] text-mono transition-colors",
+                  locale === l
+                    ? "bg-[var(--accent)] text-[var(--bg)]"
+                    : "bg-[var(--surface-raised)] text-[var(--text-muted)]"
+                )}
+              >
+                {l}
+              </button>
+            ))}
+          </div>
+
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={saveProfile}
+            loading={savingProfile}
+            className="mt-4"
+          >
+            {profileSaved ? "Saved" : "Save profile"}
+          </Button>
+        </div>
+      </Card>
+
+      {/* GEMINI KEY */}
+      <Card variant="raised">
+        <div className="p-3.5">
+          <h2 className="text-category text-[var(--text-muted)] mb-1">
+            Gemini API key
+          </h2>
+          <p className="text-mono text-[var(--text-ghost)] mb-3">
+            Optional second AI provider for summaries and analysis.
+          </p>
+          <Input
+            type="password"
+            value={geminiKey}
+            onChange={(e) => setGeminiKeyInput(e.target.value)}
+            placeholder="AIza…"
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={saveGemini}
+            loading={savingKey}
+            disabled={!geminiKey.trim()}
+            className="mt-3"
+          >
+            Save &amp; verify
+          </Button>
+          {keyMsg && (
+            <p className="text-mono text-[var(--text-muted)] mt-2">{keyMsg}</p>
+          )}
+        </div>
+      </Card>
+    </>
+  );
+}

--- a/frontend/src/components/PullToRefresh.tsx
+++ b/frontend/src/components/PullToRefresh.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+const THRESHOLD = 70;
+
+/** Touch pull-to-refresh. Activates only at scroll-top on touch devices;
+ *  desktop keeps the in-page refresh button. */
+export function PullToRefresh({
+  onRefresh,
+  children,
+}: {
+  onRefresh: () => Promise<void> | void;
+  children: React.ReactNode;
+}) {
+  const [pull, setPull] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  const startY = useRef<number | null>(null);
+
+  function onTouchStart(e: React.TouchEvent) {
+    startY.current =
+      window.scrollY <= 0 && !refreshing ? e.touches[0].clientY : null;
+  }
+  function onTouchMove(e: React.TouchEvent) {
+    if (startY.current === null) return;
+    const dy = e.touches[0].clientY - startY.current;
+    if (dy > 0) setPull(Math.min(dy * 0.5, 90));
+  }
+  async function onTouchEnd() {
+    if (startY.current === null) return;
+    if (pull >= THRESHOLD) {
+      setRefreshing(true);
+      try {
+        await onRefresh();
+      } finally {
+        setRefreshing(false);
+      }
+    }
+    setPull(0);
+    startY.current = null;
+  }
+
+  return (
+    <div onTouchStart={onTouchStart} onTouchMove={onTouchMove} onTouchEnd={onTouchEnd}>
+      <motion.div
+        animate={{ height: refreshing ? 40 : pull }}
+        transition={{ duration: refreshing ? 0.2 : 0 }}
+        className="flex items-end justify-center overflow-hidden"
+        aria-hidden="true"
+      >
+        <div
+          className={cn(
+            "mb-2 w-5 h-5 rounded-full border-2 border-[var(--accent)] border-t-transparent",
+            refreshing && "animate-spin"
+          )}
+          style={{ opacity: pull > 10 || refreshing ? 1 : 0 }}
+        />
+      </motion.div>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/SourceCard.tsx
+++ b/frontend/src/components/SourceCard.tsx
@@ -48,6 +48,7 @@ export function SourceCard({
     <motion.div
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
+      whileHover={{ y: -2 }}
       transition={{ duration: 0.25, delay: index * 0.04 }}
     >
       <div
@@ -71,7 +72,7 @@ export function SourceCard({
                 {sourceName}
               </span>
               <Badge variant={isFree ? "free" : "paywall"} size="sm">
-                {isFree ? "Free" : "Paywall"}
+                {isFree ? "FREE" : "PAYWALL"}
               </Badge>
             </div>
             {publishedAt && (

--- a/frontend/src/components/StoryCard.tsx
+++ b/frontend/src/components/StoryCard.tsx
@@ -34,6 +34,7 @@ export function StoryCard({ story }: StoryCardProps) {
     <motion.div
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
+      whileHover={{ y: -2 }}
       transition={{ duration: 0.3, ease: "easeOut" }}
     >
       <Link
@@ -65,14 +66,16 @@ export function StoryCard({ story }: StoryCardProps) {
           </p>
 
           {/* Meta row */}
-          <div className="flex items-center gap-3 mt-2">
+          <div className="flex items-center justify-between gap-3 mt-2">
             <ConfidenceScore
               sourceCount={story.source_count}
               coherence={story.coherence}
             />
-            <span className="text-mono text-[var(--text-ghost)]">
-              {story.category}
-            </span>
+            {story.category && (
+              <Badge variant="topic" size="sm" color={topicColor}>
+                {story.category.toUpperCase()}
+              </Badge>
+            )}
           </div>
         </div>
       </Link>

--- a/frontend/src/components/layout/BottomTabBar.tsx
+++ b/frontend/src/components/layout/BottomTabBar.tsx
@@ -67,6 +67,25 @@ const tabs = [
     ),
   },
   {
+    label: "Search",
+    href: "/search",
+    icon: (active: boolean) => (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={active ? "2.25" : "1.75"}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="M21 21l-4.35-4.35" />
+      </svg>
+    ),
+  },
+  {
     label: "Profile",
     href: "/settings",
     icon: (active: boolean) => (

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -56,8 +56,9 @@ export function NavBar() {
           {/* Right action — contextual */}
           {!isDeepDive && (
             <div className="flex items-center gap-1">
-              {/* Search icon placeholder */}
-              <button
+              {/* Search → /search */}
+              <Link
+                href="/search"
                 className="flex items-center justify-center w-10 h-10 rounded-full text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-raised)] transition-colors"
                 aria-label="Search"
               >
@@ -74,7 +75,7 @@ export function NavBar() {
                   <circle cx="11" cy="11" r="8" />
                   <path d="M21 21l-4.35-4.35" />
                 </svg>
-              </button>
+              </Link>
             </div>
           )}
         </div>

--- a/frontend/src/components/ui/AISummaryBox.tsx
+++ b/frontend/src/components/ui/AISummaryBox.tsx
@@ -1,39 +1,61 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { getClusterAnalysis, type AnalysisLens, type LensResult } from "@/lib/api";
 
 type Tab = "summary" | "key-facts" | "5ws";
 
 interface AISummaryBoxProps {
   summary: string | null;
   coherence?: number;
+  clusterId?: number;
   className?: string;
 }
 
-const tabs: { id: Tab; label: string }[] = [
+const tabs: { id: Tab; label: string; lens?: AnalysisLens }[] = [
   { id: "summary", label: "Summary" },
-  { id: "key-facts", label: "Key Facts" },
-  { id: "5ws", label: "5Ws" },
+  { id: "key-facts", label: "Key Facts", lens: "key_facts" },
+  { id: "5ws", label: "5Ws", lens: "5ws" },
 ];
 
-export function AISummaryBox({
-  summary,
-  coherence,
-  className,
-}: AISummaryBoxProps) {
+const Disclaimer = () => (
+  <p className="text-mono text-[var(--text-ghost)] mt-3 text-[10px]">
+    AI-generated &middot; may contain errors &middot; verify with sources below
+  </p>
+);
+
+export function AISummaryBox({ summary, coherence, clusterId, className }: AISummaryBoxProps) {
   const [activeTab, setActiveTab] = useState<Tab>("summary");
+  const [cache, setCache] = useState<Record<string, LensResult | "loading">>({});
   const isLow = coherence !== undefined && coherence < 0.6;
 
+  useEffect(() => {
+    const lens = tabs.find((t) => t.id === activeTab)?.lens;
+    if (!lens || !clusterId || cache[lens]) return;
+    setCache((p) => ({ ...p, [lens]: "loading" }));
+    getClusterAnalysis(clusterId, lens)
+      .then((r) => setCache((p) => ({ ...p, [lens]: r })))
+      .catch(() => setCache((p) => ({ ...p, [lens]: { unavailable: true } })));
+  }, [activeTab, clusterId, cache]);
+
+  const renderLens = (lens: AnalysisLens, body: (r: LensResult) => React.ReactNode) => {
+    const state = cache[lens];
+    if (!clusterId) return <Unavailable msg="Open a story to see analysis." />;
+    if (state === "loading" || state === undefined)
+      return <div className="skeleton h-16 w-full" />;
+    if (state.unavailable) return <Unavailable />;
+    return (
+      <>
+        {body(state)}
+        <Disclaimer />
+      </>
+    );
+  };
+
   return (
-    <div
-      className={cn(
-        "rounded-[var(--radius-lg)] glass-light overflow-hidden",
-        className
-      )}
-    >
-      {/* Tab bar */}
+    <div className={cn("rounded-[var(--radius-lg)] glass-light overflow-hidden", className)}>
       <div className="flex border-b border-[var(--glass-border)]">
         {tabs.map((tab) => (
           <button
@@ -59,113 +81,84 @@ export function AISummaryBox({
         ))}
       </div>
 
-      {/* Tab content */}
       <div className="p-4 min-h-[120px]">
         <AnimatePresence mode="wait">
-          {activeTab === "summary" && (
-            <motion.div
-              key="summary"
-              initial={{ opacity: 0, y: 4 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.15 }}
-            >
-              {summary ? (
-                <p
-                  className={cn(
-                    "text-small text-[var(--text-secondary)] leading-relaxed",
-                    isLow && "tracking-[0.5px]"
-                  )}
-                >
-                  {summary}
-                </p>
+          <motion.div
+            key={activeTab}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.15 }}
+          >
+            {activeTab === "summary" &&
+              (summary ? (
+                <>
+                  <p
+                    className={cn(
+                      "text-small text-[var(--text-secondary)] leading-relaxed",
+                      isLow && "tracking-[0.5px]"
+                    )}
+                  >
+                    {summary}
+                  </p>
+                  <Disclaimer />
+                </>
               ) : (
                 <p className="text-small text-[var(--text-muted)] italic">
                   AI analysis unavailable
                 </p>
-              )}
-            </motion.div>
-          )}
+              ))}
 
-          {activeTab === "key-facts" && (
-            <motion.div
-              key="key-facts"
-              initial={{ opacity: 0, y: 4 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.15 }}
-              className="flex flex-col items-center justify-center py-4"
-            >
-              <div className="w-10 h-10 rounded-full bg-[var(--accent-subtle)] flex items-center justify-center mb-3">
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="var(--accent)"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-                  <polyline points="14 2 14 8 20 8" />
-                  <line x1="16" y1="13" x2="8" y2="13" />
-                  <line x1="16" y1="17" x2="8" y2="17" />
-                  <line x1="10" y1="9" x2="8" y2="9" />
-                </svg>
-              </div>
-              <p className="text-small text-[var(--text-muted)]">
-                Coming soon
-              </p>
-              <p className="text-mono text-[var(--text-ghost)] mt-1">
-                Extracted key facts from all sources
-              </p>
-            </motion.div>
-          )}
+            {activeTab === "key-facts" &&
+              renderLens("key_facts", (r) => {
+                const facts = (r.facts as string[] | undefined) ?? [];
+                return facts.length ? (
+                  <ul className="space-y-2">
+                    {facts.map((f, i) => (
+                      <li key={i} className="flex gap-2 text-small text-[var(--text-secondary)]">
+                        <span className="text-[var(--accent)] shrink-0">&bull;</span>
+                        <span>{f}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <Unavailable />
+                );
+              })}
 
-          {activeTab === "5ws" && (
-            <motion.div
-              key="5ws"
-              initial={{ opacity: 0, y: 4 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.15 }}
-              className="flex flex-col items-center justify-center py-4"
-            >
-              <div className="w-10 h-10 rounded-full bg-[var(--accent-subtle)] flex items-center justify-center mb-3">
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="var(--accent)"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <circle cx="12" cy="12" r="10" />
-                  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-                  <line x1="12" y1="17" x2="12.01" y2="17" />
-                </svg>
-              </div>
-              <p className="text-small text-[var(--text-muted)]">
-                Coming soon
-              </p>
-              <p className="text-mono text-[var(--text-ghost)] mt-1">
-                Who, What, When, Where, Why
-              </p>
-            </motion.div>
-          )}
+            {activeTab === "5ws" &&
+              renderLens("5ws", (r) => {
+                const ws: [string, string][] = [
+                  ["Who", r.who as string],
+                  ["What", r.what as string],
+                  ["When", r.when as string],
+                  ["Where", r.where as string],
+                  ["Why", r.why as string],
+                ];
+                return (
+                  <dl className="space-y-2">
+                    {ws.map(([k, v]) =>
+                      v ? (
+                        <div key={k} className="text-small">
+                          <dt className="text-mono text-[var(--accent)] uppercase">{k}</dt>
+                          <dd className="text-[var(--text-secondary)]">{v}</dd>
+                        </div>
+                      ) : null
+                    )}
+                  </dl>
+                );
+              })}
+          </motion.div>
         </AnimatePresence>
-
-        {/* Disclaimer */}
-        {activeTab === "summary" && summary && (
-          <p className="text-mono text-[var(--text-ghost)] mt-3 text-[10px]">
-            AI-generated &middot; may contain errors &middot; verify with
-            sources below
-          </p>
-        )}
       </div>
     </div>
+  );
+}
+
+function Unavailable({ msg }: { msg?: string }) {
+  return (
+    <p className="text-small text-[var(--text-muted)] italic">
+      {msg ?? "AI analysis unavailable — add an API key in Settings."}
+    </p>
   );
 }

--- a/frontend/src/components/ui/AgreementMeter.tsx
+++ b/frontend/src/components/ui/AgreementMeter.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { relativeTime } from "@/lib/utils";
+
+interface AgreementMeterProps {
+  coherence: number;
+  sourceCount: number;
+  createdAt: string;
+}
+
+/** Deep Dive trust meter — "Sources agree" + % + bar, tier-coloured.
+ *  Plain-language ("agreement", never "coherence"); see COPY-GUIDELINES §4. */
+function tier(coherence: number): { pct: number; color: string } {
+  const pct = Math.round(coherence * 100);
+  if (coherence >= 0.8) return { pct, color: "var(--agree)" };
+  if (coherence >= 0.6) return { pct, color: "var(--warning)" };
+  return { pct, color: "var(--text-muted)" };
+}
+
+export function AgreementMeter({
+  coherence,
+  sourceCount,
+  createdAt,
+}: AgreementMeterProps) {
+  const { pct, color } = tier(coherence);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <span className="text-small text-[var(--text-secondary)]">
+          Sources agree
+        </span>
+        <span className="text-mono" style={{ color }}>
+          {pct}%
+        </span>
+      </div>
+      <div className="h-1.5 w-full rounded-full bg-[var(--surface-raised)] overflow-hidden">
+        <motion.div
+          initial={{ width: 0 }}
+          animate={{ width: `${pct}%` }}
+          transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+          className="h-full rounded-full"
+          style={{ backgroundColor: color }}
+        />
+      </div>
+      <span className="text-mono text-[var(--text-ghost)]">
+        {sourceCount} {sourceCount === 1 ? "outlet" : "outlets"} &middot;{" "}
+        {relativeTime(createdAt)}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/ConfidenceScore.tsx
+++ b/frontend/src/components/ui/ConfidenceScore.tsx
@@ -6,42 +6,13 @@ interface ConfidenceScoreProps {
   className?: string;
 }
 
-function getConfidenceLabel(coherence: number): {
-  label: string;
-  filled: number;
-} {
-  if (coherence >= 0.8) return { label: "High confidence", filled: 3 };
-  if (coherence >= 0.6) return { label: "Moderate", filled: 2 };
-  return { label: "Low confidence", filled: 1 };
-}
-
-function ConfidenceDots({ filled }: { filled: number }) {
-  const total = 4;
-  return (
-    <span className="inline-flex items-center gap-[2px]">
-      {Array.from({ length: total }, (_, i) => (
-        <svg
-          key={i}
-          width="6"
-          height="6"
-          viewBox="0 0 6 6"
-          className="inline-block"
-        >
-          <circle
-            cx="3"
-            cy="3"
-            r="2.5"
-            fill={
-              i < filled
-                ? "currentColor"
-                : "var(--text-ghost)"
-            }
-            opacity={i < filled ? 1 : 0.3}
-          />
-        </svg>
-      ))}
-    </span>
-  );
+/** Plain-language trust signal: sources + colour-coded agreement %.
+ *  See docs/content/COPY-GUIDELINES.md §4. "coherence" is never shown to users. */
+function agreement(coherence: number): { pct: number; color: string } {
+  const pct = Math.round(coherence * 100);
+  if (coherence >= 0.8) return { pct, color: "var(--agree)" };
+  if (coherence >= 0.6) return { pct, color: "var(--warning)" };
+  return { pct, color: "var(--text-muted)" };
 }
 
 export function ConfidenceScore({
@@ -49,25 +20,22 @@ export function ConfidenceScore({
   coherence,
   className,
 }: ConfidenceScoreProps) {
-  const isLow = coherence < 0.6;
-  const { label, filled } = getConfidenceLabel(coherence);
+  const { pct, color } = agreement(coherence);
 
   return (
     <span
       className={cn("text-mono inline-flex items-center gap-1.5", className)}
     >
-      <span className="text-[var(--accent)]">
+      <span className="text-[var(--text-secondary)]">
         {sourceCount} {sourceCount === 1 ? "source" : "sources"}
       </span>
       <span className="text-[var(--text-ghost)]">&middot;</span>
-      <span
-        className={cn(
-          "inline-flex items-center gap-1",
-          isLow ? "text-[var(--warning)]" : "text-[var(--text-muted)]"
-        )}
-      >
-        {label}
-        <ConfidenceDots filled={filled} />
+      <span className="inline-flex items-center gap-1" style={{ color }}>
+        <span
+          className="inline-block w-1.5 h-1.5 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+        {pct}% agreement
       </span>
     </span>
   );

--- a/frontend/src/components/ui/ConfidenceScore.tsx
+++ b/frontend/src/components/ui/ConfidenceScore.tsx
@@ -6,13 +6,32 @@ interface ConfidenceScoreProps {
   className?: string;
 }
 
-/** Plain-language trust signal: sources + colour-coded agreement %.
- *  See docs/content/COPY-GUIDELINES.md §4. "coherence" is never shown to users. */
-function agreement(coherence: number): { pct: number; color: string } {
+/** Plain-language trust signal (v2): "N sources · NN% agreement ●●●●".
+ *  Colour-coded by tier; "coherence" is never shown to users.
+ *  See docs/content/COPY-GUIDELINES.md §4. */
+function tier(coherence: number): { pct: number; color: string; filled: number } {
   const pct = Math.round(coherence * 100);
-  if (coherence >= 0.8) return { pct, color: "var(--agree)" };
-  if (coherence >= 0.6) return { pct, color: "var(--warning)" };
-  return { pct, color: "var(--text-muted)" };
+  const filled = Math.max(1, Math.min(4, Math.round(coherence * 4)));
+  if (coherence >= 0.8) return { pct, color: "var(--agree)", filled };
+  if (coherence >= 0.6) return { pct, color: "var(--warning)", filled };
+  return { pct, color: "var(--text-muted)", filled };
+}
+
+function Dots({ filled, color }: { filled: number; color: string }) {
+  return (
+    <span className="inline-flex items-center gap-[2px]" aria-hidden="true">
+      {Array.from({ length: 4 }, (_, i) => (
+        <span
+          key={i}
+          className="inline-block w-1 h-1 rounded-full"
+          style={{
+            backgroundColor: i < filled ? color : "var(--text-ghost)",
+            opacity: i < filled ? 1 : 0.4,
+          }}
+        />
+      ))}
+    </span>
+  );
 }
 
 export function ConfidenceScore({
@@ -20,22 +39,17 @@ export function ConfidenceScore({
   coherence,
   className,
 }: ConfidenceScoreProps) {
-  const { pct, color } = agreement(coherence);
+  const { pct, color, filled } = tier(coherence);
 
   return (
-    <span
-      className={cn("text-mono inline-flex items-center gap-1.5", className)}
-    >
+    <span className={cn("text-mono inline-flex items-center gap-1.5", className)}>
       <span className="text-[var(--text-secondary)]">
         {sourceCount} {sourceCount === 1 ? "source" : "sources"}
       </span>
       <span className="text-[var(--text-ghost)]">&middot;</span>
-      <span className="inline-flex items-center gap-1" style={{ color }}>
-        <span
-          className="inline-block w-1.5 h-1.5 rounded-full"
-          style={{ backgroundColor: color }}
-        />
-        {pct}% agreement
+      <span className="inline-flex items-center gap-1.5" style={{ color }}>
+        <span>{pct}% agreement</span>
+        <Dots filled={filled} color={color} />
       </span>
     </span>
   );

--- a/frontend/src/components/ui/ImpactCard.tsx
+++ b/frontend/src/components/ui/ImpactCard.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { getClusterImpact, type LensResult } from "@/lib/api";
+
+interface Dimension {
+  key: string;
+  label: string;
+  body: string;
+}
+
+const ClockIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10" />
+    <polyline points="12 6 12 12 16 14" />
+  </svg>
+);
+
+/** "What's in it for me" — personalised impact, amber. Data: GET /clusters/{id}/impact.
+ *  Hides itself when the lens is unavailable (graceful degradation). */
+export function ImpactCard({ clusterId }: { clusterId: number }) {
+  const [data, setData] = useState<LensResult | "loading">("loading");
+
+  useEffect(() => {
+    let alive = true;
+    getClusterImpact(clusterId)
+      .then((r) => alive && setData(r))
+      .catch(() => alive && setData({ unavailable: true }));
+    return () => {
+      alive = false;
+    };
+  }, [clusterId]);
+
+  if (data === "loading") {
+    return <div className="skeleton h-24 rounded-[var(--radius-lg)]" />;
+  }
+  if (data.unavailable) return null;
+
+  const headline = typeof data.headline === "string" ? data.headline : null;
+  const dims = Array.isArray(data.dimensions) ? (data.dimensions as Dimension[]) : [];
+  if (!headline && dims.length === 0) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="rounded-[var(--radius-lg)] border border-[var(--accent-muted)] bg-[var(--accent-subtle)] p-[var(--space-md)]"
+    >
+      <div className="flex items-center gap-1.5 text-mono text-[var(--accent)] mb-2">
+        <ClockIcon />
+        WHAT&apos;S IN IT FOR ME
+      </div>
+      {headline && (
+        <p className="text-small text-[var(--text-primary)] leading-relaxed">{headline}</p>
+      )}
+      {dims.length > 0 && (
+        <dl className="mt-3 flex flex-col gap-2">
+          {dims.map((d) => (
+            <div key={d.key}>
+              <dt className="text-mono text-[10px] uppercase text-[var(--accent)]">{d.label}</dt>
+              <dd className="text-small text-[var(--text-secondary)]">{d.body}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      <p className="text-mono text-[10px] text-[var(--text-ghost)] mt-3">
+        AI-generated &middot; personalised to your profile
+      </p>
+    </motion.div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -255,3 +255,118 @@ export interface StatsResponse {
 export async function getStats(): Promise<StatsResponse> {
   return fetchJSON("/stats");
 }
+
+/* ── Profile (E3) ── */
+
+export interface Profile {
+  profession: string | null;
+  locale: string;
+  interests: string[];
+}
+
+export async function getProfile(): Promise<Profile> {
+  return fetchJSON("/profile");
+}
+
+export async function updateProfile(
+  data: Partial<{ profession: string | null; locale: string; interests: string[] }>
+): Promise<Profile> {
+  return fetchJSON("/profile", { method: "PUT", body: JSON.stringify(data) });
+}
+
+/* ── Gemini key (E1) ── */
+
+export async function setGeminiKey(
+  gemini_api_key: string | null
+): Promise<{ has_gemini_key: boolean }> {
+  return fetchJSON("/settings/gemini-key", {
+    method: "PUT",
+    body: JSON.stringify({ gemini_api_key }),
+  });
+}
+
+export async function testGeminiKey(): Promise<KeyTestResult> {
+  return fetchJSON("/settings/test-gemini-key", { method: "POST" });
+}
+
+/* ── Cluster lenses (E5/E6/E7/E8) ── */
+
+export interface LensResult {
+  cached?: boolean;
+  unavailable?: boolean;
+  reason?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export type AnalysisLens = "key_facts" | "5ws" | "profession";
+export type Difficulty = "easy" | "medium" | "hard";
+
+export async function getClusterAnalysis(
+  clusterId: number,
+  lens: AnalysisLens
+): Promise<LensResult> {
+  return fetchJSON(`/clusters/${clusterId}/analysis?lens=${lens}`);
+}
+
+export async function getClusterImpact(clusterId: number): Promise<LensResult> {
+  return fetchJSON(`/clusters/${clusterId}/impact`);
+}
+
+export async function getClusterStrategic(clusterId: number): Promise<LensResult> {
+  return fetchJSON(`/clusters/${clusterId}/strategic`);
+}
+
+export async function getClusterTrivia(
+  clusterId: number,
+  difficulty: Difficulty = "medium"
+): Promise<LensResult> {
+  return fetchJSON(`/clusters/${clusterId}/trivia?difficulty=${difficulty}`);
+}
+
+export async function getDailyTrivia(
+  topic = "world news",
+  difficulty: Difficulty = "medium"
+): Promise<LensResult> {
+  return fetchJSON(
+    `/trivia/daily?topic=${encodeURIComponent(topic)}&difficulty=${difficulty}`
+  );
+}
+
+/* ── Search (E4) ── */
+
+export interface SearchResultItem {
+  id: number;
+  title: string;
+  snippet: string | null;
+  url: string;
+  source: Source;
+  cluster_id: number | null;
+  matched_on: string;
+}
+
+export interface SearchResponse {
+  query: string;
+  results: SearchResultItem[];
+}
+
+export async function search(q: string): Promise<SearchResponse> {
+  return fetchJSON(`/search?q=${encodeURIComponent(q)}`);
+}
+
+/* ── Admin sources (E2) ── */
+
+export interface AdminSource {
+  id: number;
+  name: string;
+  url: string;
+  rss_url: string | null;
+  region: string | null;
+  category: string | null;
+  is_paywalled: boolean;
+  source_type: string | null;
+}
+
+export async function getAdminSources(): Promise<AdminSource[]> {
+  return fetchJSON("/admin/sources");
+}


### PR DESCRIPTION
## Summary
Ships the NewsLens enhancement program and the v2 design alignment across backend, frontend, copy governance, and Figma.

### Backend (tested — 59 passed / 1 skipped; unit native + integration in Docker/pgvector)
- LLM provider abstraction + **Gemini** (per-user key, Fernet-encrypted) alongside OpenAI.
- **Sources**: config-driven India + global feeds, Google-News URL builder, GDELT region param, upsert + `/admin/sources`.
- **Hybrid search** (`/search`) — pgvector NN + keyword, HNSW index.
- **Profile** (profession/locale/interests) + **lenses**: analysis (key facts / 5Ws), impact ("what's in it for me"), strategic, trivia. Graceful "unavailable" on any LLM failure.
- `/feed` real source_count + cluster_id; summary staleness-window crash fix.

### Copy governance
- `docs/content/COPY-GUIDELINES.md` + `terminology.json` (internal→user glossary + banned list).
- Automated guard `npm run lint:copy` (blocks internal jargon in UI) wired into validation.
- Passover fixes: dropped "embeddings" from settings; standardized the trust signal on **"NN% agreement"** (tiered) over "coherence".

### Frontend — aligned to the v2 merged flow (build + lint:copy green, preview-verified)
- Bottom **5-tab nav** (Today/Discover/Saved/**Search**/Profile).
- New **Search** screen; **Deep Dive** agreement meter + impact card + source-access bar; **Discover** tension box + Skip/Undo/Save; Today kicker + topic badges; Profile (Profession/Locale/Gemini).
- Motion: card hover lift, page transitions, pull-to-refresh.

### Figma
- Canonical v2 "Screens" + component library (Story/Saved Card, Badge, Meta Pills, Source Card, Tab Bar variant set); bottom-nav componentized; stale v1 archive cleared.

### Parked (documented)
Firebase Auth + FCM, Supabase, Gemini embeddings — see `docs/enhancement/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)