### PR TITLE
Epic completeness: fix real gaps + add named acceptance tests (all 10 epics)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -235,7 +235,7 @@ async def get_cluster(cluster_id: int, db: AsyncSession = Depends(get_db)):
             title=article.title,
             summary=article.snippet,
             created_at=article.published_at or article.fetched_at or datetime.now(timezone.utc),
-            coherence=0.70,
+            coherence=None,  # single-article synthetic cluster has no real coherence
             sources=[
                 ClusterSourceCard(
                     article=ArticleOut(
@@ -306,7 +306,7 @@ async def get_cluster(cluster_id: int, db: AsyncSession = Depends(get_db)):
         title=cluster.title,
         summary=cluster.summary,
         created_at=cluster.created_at,
-        coherence=cluster.coherence if cluster.coherence is not None else 0.85,
+        coherence=getattr(cluster, "coherence", None),  # real coherence; None when not yet computed
         sources=source_cards,
     )
 
@@ -359,6 +359,26 @@ async def create_feedback(
 
 
 # ── Briefing ──────────────────────────────────────────────
+
+
+def _extract_impact_headline(impact_json: dict | None) -> str | None:
+    """Best-effort headline from a cluster's cached impact_json (E6).
+
+    impact_json is keyed by sub-lens (e.g. ``prof:<hash>``) -> {"source_hash", "data"}
+    where ``data`` holds {"headline": ..., "dimensions": [...]}. Returns the first
+    non-empty cached headline found, or None. Makes NO LLM calls.
+    """
+    if not isinstance(impact_json, dict):
+        return None
+    for entry in impact_json.values():
+        if not isinstance(entry, dict):
+            continue
+        data = entry.get("data")
+        if isinstance(data, dict):
+            headline = data.get("headline")
+            if isinstance(headline, str) and headline.strip():
+                return headline.strip()
+    return None
 
 
 @router.get("/briefing", response_model=BriefingResponse)
@@ -462,6 +482,9 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
         pref_weight = prefs.get(topic_id, 0.0) if topic_id else 0.0
         story_weights[cluster.id] = pref_weight
 
+        # E6: best-effort WIIFM headline from ALREADY-cached impact_json (no LLM calls).
+        impact_headline = _extract_impact_headline(cluster.impact_json)
+
         stories.append(
             BriefingStory(
                 title=cluster.title,
@@ -471,6 +494,7 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
                 source_count=len(source_names),
                 coherence=coherence,
                 is_read=is_read,
+                impact_headline=impact_headline,
             )
         )
 
@@ -739,19 +763,30 @@ async def get_settings(db: AsyncSession = Depends(get_db)):
     )
     setting = result.scalar_one_or_none()
 
-    if not setting or not setting.openai_api_key_encrypted:
-        return UserSettingsOut(has_openai_key=False)
+    if not setting:
+        return UserSettingsOut(has_openai_key=False, has_gemini_key=False)
 
     from app.services.encryption import decrypt_value
 
-    raw_key = decrypt_value(setting.openai_api_key_encrypted)
-    last4 = raw_key[-4:] if len(raw_key) >= 4 else "****"
+    openai_last4 = None
+    if setting.openai_api_key_encrypted:
+        raw_openai = decrypt_value(setting.openai_api_key_encrypted)
+        openai_last4 = raw_openai[-4:] if len(raw_openai) >= 4 else "****"
+
+    gemini_last4 = None
+    if setting.gemini_api_key_encrypted:
+        raw_gemini = decrypt_value(setting.gemini_api_key_encrypted)
+        gemini_last4 = raw_gemini[-4:] if len(raw_gemini) >= 4 else "****"
 
     return UserSettingsOut(
-        has_openai_key=True,
+        has_openai_key=bool(setting.openai_api_key_encrypted),
         openai_key_verified=setting.openai_key_verified,
-        openai_key_last4=last4,
+        openai_key_last4=openai_last4,
         openai_key_verified_at=setting.openai_key_verified_at,
+        has_gemini_key=bool(setting.gemini_api_key_encrypted),
+        gemini_key_verified=setting.gemini_key_verified,
+        gemini_key_last4=gemini_last4,
+        gemini_key_verified_at=setting.gemini_key_verified_at,
     )
 
 
@@ -1099,9 +1134,31 @@ async def cluster_impact(cluster_id: int, db: AsyncSession = Depends(get_db)):
     return await lenses.impact(db, cluster_id, profession, locale)
 
 
+_GEOPOLITICS_TOPIC_TERMS = (
+    "world", "geopolitics", "international", "politics", "conflict", "defense",
+)
+
+
 @router.get("/clusters/{cluster_id}/strategic")
 async def cluster_strategic(cluster_id: int, db: AsyncSession = Depends(get_db)):
     from app.services import lenses
+
+    # E7: topic-gate. Only offer the strategic/game-theory lens for geopolitics-ish
+    # stories. Load the cluster's topic names (articles -> ArticleTopic -> Topic).
+    topic_rows = (
+        await db.execute(
+            select(Topic.name)
+            .join(ArticleTopic, ArticleTopic.topic_id == Topic.id)
+            .join(ClusterArticle, ClusterArticle.article_id == ArticleTopic.article_id)
+            .where(ClusterArticle.cluster_id == cluster_id)
+        )
+    ).all()
+    topic_names = [r[0].lower() for r in topic_rows if r[0]]
+    is_geopolitical = any(
+        term in name for name in topic_names for term in _GEOPOLITICS_TOPIC_TERMS
+    )
+    if not is_geopolitical:
+        return {"unavailable": True, "reason": "not_offered_for_topic"}
 
     return await lenses.strategic(db, cluster_id)
 
@@ -1163,25 +1220,37 @@ async def list_sources(db: AsyncSession = Depends(get_db)):
 @router.post("/admin/sources")
 async def create_source(body: dict, db: AsyncSession = Depends(get_db)):
     from fastapi import HTTPException
+    from sqlalchemy import or_
 
     name = (body.get("name") or "").strip()
     url = (body.get("url") or "").strip()
     if not name or not url:
         raise HTTPException(status_code=400, detail="name and url are required")
+    rss_url = (body.get("rss_url") or "").strip() or None
+
+    # UPSERT: if a source with the same url OR rss_url exists, update it in place.
+    match_clauses = [Source.url == url]
+    if rss_url:
+        match_clauses.append(Source.rss_url == rss_url)
     existing = (
-        await db.execute(select(Source).where(Source.url == url))
+        await db.execute(select(Source).where(or_(*match_clauses)))
     ).scalar_one_or_none()
     if existing is not None:
-        raise HTTPException(status_code=409, detail="source url already exists")
+        existing.name = name
+        existing.region = body.get("region", existing.region)
+        existing.category = body.get("category", existing.category)
+        await db.commit()
+        return {"id": existing.id, "name": existing.name, "updated": True}
+
     s = Source(
-        name=name, url=url, rss_url=(body.get("rss_url") or "").strip() or None,
+        name=name, url=url, rss_url=rss_url,
         is_paywalled=bool(body.get("is_paywalled", False)),
         source_type=body.get("source_type", "other"),
         region=body.get("region", "global"), category=body.get("category"),
     )
     db.add(s)
     await db.commit()
-    return {"id": s.id, "name": s.name}
+    return {"id": s.id, "name": s.name, "updated": False}
 
 
 # ── E4: hybrid search (semantic + keyword; keyword ranks above semantic-only) ──
@@ -1200,10 +1269,11 @@ async def search(
     results: dict[int, dict] = {}
 
     # Semantic (pgvector NN) — lower priority than exact keyword.
-    from app.services.embeddings import generate_embedding
+    # Use the cached query-embedding helper to avoid re-embedding repeated queries.
+    from app.services.embeddings import embed_query_cached
 
     try:
-        emb = await generate_embedding(query_str)
+        emb = await embed_query_cached(query_str)
     except Exception:  # noqa: BLE001
         emb = None
     if emb is not None:
@@ -1251,15 +1321,23 @@ async def search(
     ).all()
     art_to_cluster = {aid: cid for aid, cid in ca}
 
+    # Group/dedup by cluster: keep only the highest-ranked (lowest rank value)
+    # article per cluster_id. Articles with no cluster stay as individual results.
     out = []
+    seen_clusters: set[int] = set()
     for aid, meta in sorted(results.items(), key=lambda kv: kv[1]["rank"]):
         a = art_map.get(aid)
         if not a:
             continue
+        cluster_id = art_to_cluster.get(a.id)
+        if cluster_id is not None:
+            if cluster_id in seen_clusters:
+                continue
+            seen_clusters.add(cluster_id)
         out.append({
             "id": a.id, "title": a.title, "snippet": a.snippet, "url": a.url,
             "source": SourceOut.model_validate(a.source).model_dump(),
-            "cluster_id": art_to_cluster.get(a.id),
+            "cluster_id": cluster_id,
             "matched_on": meta["matched_on"],
         })
     return {"query": query_str, "results": out}

--- a/backend/app/data/sources.json
+++ b/backend/app/data/sources.json
@@ -21,5 +21,10 @@
   {"name": "Moneycontrol", "url": "https://www.moneycontrol.com", "rss_url": "https://www.moneycontrol.com/rss/latestnews.xml", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "business"},
   {"name": "Economic Times - Markets", "url": "https://economictimes.indiatimes.com", "rss_url": "https://economictimes.indiatimes.com/markets/rssfeeds/1977021501.cms", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "business"},
   {"name": "Business Standard", "url": "https://www.business-standard.com", "rss_url": "https://www.business-standard.com/rss/latest.rss", "is_paywalled": false, "source_type": "newspaper", "region": "in", "category": "business"},
-  {"name": "PIB India", "url": "https://pib.gov.in", "rss_url": "https://pib.gov.in/RssMain.aspx?ModId=6&Lang=1&Regid=3", "is_paywalled": false, "source_type": "wire", "region": "in", "category": "policy"}
+  {"name": "PIB India", "url": "https://pib.gov.in", "rss_url": "https://pib.gov.in/RssMain.aspx?ModId=6&Lang=1&Regid=3", "is_paywalled": false, "source_type": "wire", "region": "in", "category": "policy"},
+  {"name": "Reserve Bank of India - Press Releases", "url": "https://www.rbi.org.in", "rss_url": "https://www.rbi.org.in/pressreleases_rss.xml", "is_paywalled": false, "source_type": "wire", "region": "in", "category": "policy"},
+  {"name": "SEBI - Press Releases", "url": "https://www.sebi.gov.in", "rss_url": "https://www.sebi.gov.in/sebirss.xml", "is_paywalled": false, "source_type": "wire", "region": "in", "category": "policy"},
+  {"name": "AP News - Top", "url": "https://apnews.com", "rss_url": "https://feedx.net/rss/ap.xml", "is_paywalled": false, "source_type": "wire", "region": "global", "category": "world"},
+  {"name": "Google News - India Markets", "url": "https://news.google.com/search?q=India+markets", "rss_url": "https://news.google.com/rss/search?q=India+markets&hl=en-IN&gl=IN&ceid=IN:en", "is_paywalled": false, "source_type": "other", "region": "in", "category": "business"},
+  {"name": "Google News - India Top", "url": "https://news.google.com/search?q=India+top+news", "rss_url": "https://news.google.com/rss/search?q=India+top+news&hl=en-IN&gl=IN&ceid=IN:en", "is_paywalled": false, "source_type": "other", "region": "in", "category": "national"}
 ]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,49 +22,24 @@ async def check_db() -> bool:
 
 
 async def init_db():
-    """Create tables, ensure pgvector extension exists, and seed default user."""
+    """Create tables, ensure pgvector extension exists, and seed default user.
+
+    NOTE: Alembic migrations are the authoritative source of schema for prod
+    (see backend/migrations). Base.metadata.create_all below is a convenience
+    bootstrap for local dev / tests only; the ad-hoc CREATE EXTENSION + ALTER
+    TABLE schema-evolution block was removed now that the Alembic baseline owns
+    the schema.
+    """
     from app.database import Base
     import app.models  # noqa: F401 — ensure models are registered
 
-    # Create pgvector extension first (before table creation needs it)
+    # Create pgvector extension first (create_all needs the vector type for local dev)
     async with engine.begin() as conn:
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
 
-    # Create all tables
+    # Create all tables (local dev bootstrap; Alembic is authoritative for prod)
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-
-    # Add new columns if they don't exist (schema evolution)
-    async with engine.begin() as conn:
-        for stmt in [
-            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS coherence FLOAT",
-            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS summary_generated_at TIMESTAMPTZ",
-            # E5/E6/E7/E8: cached LLM lens outputs + source-set hash for invalidation
-            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS analysis_json JSONB",
-            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS impact_json JSONB",
-            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS strategic_json JSONB",
-            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS trivia_json JSONB",
-            "ALTER TABLE story_clusters ADD COLUMN IF NOT EXISTS source_hash VARCHAR(64)",
-            # E3: profession-agnostic personalization
-            "ALTER TABLE users ADD COLUMN IF NOT EXISTS profession VARCHAR(255)",
-            "ALTER TABLE users ADD COLUMN IF NOT EXISTS locale VARCHAR(16) DEFAULT 'IN'",
-            # E1: per-user Gemini key
-            "ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS gemini_api_key_encrypted TEXT",
-            "ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS gemini_key_verified BOOLEAN DEFAULT FALSE",
-            "ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS gemini_key_verified_at TIMESTAMPTZ",
-            # E2: source region + category
-            "ALTER TABLE sources ADD COLUMN IF NOT EXISTS region VARCHAR(16) DEFAULT 'global'",
-            "ALTER TABLE sources ADD COLUMN IF NOT EXISTS category VARCHAR(64)",
-            # E4: HNSW index for fast vector search (clustering + /search)
-            "CREATE INDEX IF NOT EXISTS ix_articles_embedding_hnsw "
-            "ON articles USING hnsw (embedding vector_cosine_ops)",
-            # Add 'read' to feedback_type enum if not present
-            "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'read' AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'feedbacktype')) THEN ALTER TYPE feedbacktype ADD VALUE 'read'; END IF; END $$",
-        ]:
-            try:
-                await conn.execute(text(stmt))
-            except Exception as e:
-                logger.debug("schema_migration_skipped", stmt=stmt[:50], error=str(e))
 
     # Seed default user
     async with async_session() as session:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -55,7 +56,7 @@ class ClusterDetailOut(BaseModel):
     title: str
     summary: str | None
     created_at: datetime
-    coherence: float = 0.0
+    coherence: Optional[float] = None  # real cluster coherence; None when unknown
     sources: list[ClusterSourceCard]  # sorted: free first, then paywalled
 
     model_config = {"from_attributes": True}
@@ -126,6 +127,8 @@ class BriefingStory(BaseModel):
     source_count: int
     coherence: float
     is_read: bool = False
+    # E6: best-effort WIIFM headline from already-cached impact_json (no new LLM calls)
+    impact_headline: str | None = None
 
 
 class BriefingResponse(BaseModel):
@@ -158,6 +161,11 @@ class UserSettingsOut(BaseModel):
     openai_key_verified: bool = False
     openai_key_last4: str | None = None
     openai_key_verified_at: datetime | None = None
+    # E1: mirror the OpenAI key trio for Gemini
+    has_gemini_key: bool = False
+    gemini_key_verified: bool = False
+    gemini_key_last4: str | None = None
+    gemini_key_verified_at: datetime | None = None
 
 
 class UserSettingsUpdate(BaseModel):

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -95,6 +95,35 @@ async def generate_embedding(text: str) -> list[float] | None:
         return None
 
 
+# Cache of query string -> embedding, so repeated searches for the same query
+# reuse one OpenAI call. Bounded to avoid unbounded growth from arbitrary queries.
+_query_embedding_cache: dict[str, list[float]] = {}
+_QUERY_CACHE_MAX = 512
+
+
+async def embed_query_cached(text: str) -> list[float] | None:
+    """Embed a search query, memoized by the exact query string.
+
+    Uses the same embedding path as generate_embedding so search vectors match
+    article vectors. Failures are not cached (so a transient error can retry).
+    """
+    key = (text or "").strip()
+    if not key:
+        return None
+
+    cached = _query_embedding_cache.get(key)
+    if cached is not None:
+        return cached
+
+    embedding = await generate_embedding(key)
+    if embedding is not None:
+        if len(_query_embedding_cache) >= _QUERY_CACHE_MAX:
+            # Simple bound: drop the oldest inserted entry.
+            _query_embedding_cache.pop(next(iter(_query_embedding_cache)), None)
+        _query_embedding_cache[key] = embedding
+    return embedding
+
+
 async def embed_article(article_id: int):
     """Generate and store embedding for a single article."""
     async with async_session() as session:

--- a/backend/app/services/encryption.py
+++ b/backend/app/services/encryption.py
@@ -52,14 +52,20 @@ def encrypt_value(plaintext: str) -> str:
 
 
 def decrypt_value(stored: str) -> str:
-    """Decrypt a stored value. Handles both encrypted (hex) and plaintext fallback."""
+    """Decrypt a stored value.
+
+    With no ENCRYPTION_KEY configured: the value was stored as plaintext, so return
+    it as-is. With a Fernet configured: decryption MUST succeed — on any failure we
+    raise rather than leak the raw stored ciphertext back to the caller.
+    """
     f = _get_fernet()
     if f is None:
         return stored
 
     try:
         return f.decrypt(bytes.fromhex(stored)).decode()
-    except Exception:
-        # Might be plaintext from before encryption was enabled
-        logger.warning("decrypt_fallback_plaintext")
-        return stored
+    except Exception as e:
+        # A Fernet is configured but the stored value could not be decrypted.
+        # Never return the raw ciphertext — fail loudly instead.
+        logger.error("decrypt_failed", error=str(e))
+        raise ValueError("Failed to decrypt stored value") from e

--- a/backend/app/services/gdelt.py
+++ b/backend/app/services/gdelt.py
@@ -149,11 +149,15 @@ async def _get_or_create_source(domain: str, article_url: str) -> Source | None:
         }
         is_paywalled = any(d in domain for d in paywalled_domains)
 
+        # Infer region from the GDELT query scope.
+        region = "in" if "sourcecountry:IN" in (settings.gdelt_query or "") else "global"
+
         source = Source(
             name=domain.replace("www.", "").split(".")[0].title(),
             url=base_url,
             source_type="other",
             is_paywalled=is_paywalled,
+            region=region,
         )
         session.add(source)
         await session.commit()

--- a/backend/app/services/lenses.py
+++ b/backend/app/services/lenses.py
@@ -177,6 +177,11 @@ async def analysis(db, cluster_id, lens: str, profession: str | None = None):
 
 
 async def impact(db, cluster_id, profession: str | None, locale: str = "IN"):
+    # WIIFM impact is profession-specific — without a profession there is no
+    # meaningful answer, so surface that explicitly instead of defaulting to a
+    # generalist read (and before any LLM/get_lens call).
+    if not (profession or "").strip():
+        return {"unavailable": True, "reason": "profession_unset"}
     cluster, articles = await _load(db, cluster_id)
     text = _cluster_text(cluster, articles) if cluster and articles else ""
     return await get_lens(db, cluster_id, column="impact_json",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,7 @@ httpx==0.28.1
 
 # AI/ML
 openai==1.59.5
+google-generativeai==0.8.3
 
 # Scheduling
 apscheduler==3.10.4

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -77,9 +77,96 @@ def fake_llm(monkeypatch):
     """Patch the generation + embedding seams to deterministic values (no network)."""
     calls = {"generate": 0, "embed": 0}
 
+    def _schema_shape(prompt: str) -> dict:
+        """Return realistic lens-shaped JSON keyed off cues in the prompt.
+
+        The real prompt builders (see app/services/lenses.py) embed distinctive
+        instructions per lens; we sniff those so tests see the true response shape
+        rather than an opaque ``{"stub": true}``.
+        """
+        p = (prompt or "").lower()
+        # E7 strategic / game-theory
+        if "game-theory" in p or "game type" in p or '"game_type"' in p:
+            return {
+                "actors": [
+                    {
+                        "name": "Country A",
+                        "incentive": "secure borders",
+                        "likely_move": "escalate pressure",
+                    },
+                    {
+                        "name": "Country B",
+                        "incentive": "preserve status quo",
+                        "likely_move": "seek allies",
+                    },
+                ],
+                "game_type": "chicken",
+                "second_order": [
+                    "regional alignment shifts",
+                    "commodity price volatility",
+                ],
+                "non_obvious_take": "the loud threats are a bargaining posture, not intent",
+            }
+        # E6 WIIFM impact
+        if '"dimensions"' in p or "what's in it for me" in p:
+            return {
+                "headline": "Modest near-term effect; worth monitoring",
+                "dimensions": [
+                    {"key": "finance", "label": "Finance", "body": "Rates may tick up."},
+                    {"key": "profession", "label": "Your field", "body": "Demand steady."},
+                    {"key": "policy", "label": "Policy", "body": "New rules expected."},
+                    {"key": "daily", "label": "Daily life", "body": "Prices stable."},
+                ],
+            }
+        # E8 trivia / quiz
+        if "multiple-choice" in p or '"answer_index"' in p or "quiz" in p:
+            return {
+                "questions": [
+                    {
+                        "question": "What is the main event?",
+                        "options": ["a", "b", "c", "d"],
+                        "answer_index": 1,
+                        "explanation": "Because b is described in the coverage.",
+                    },
+                    {
+                        "question": "Who is involved?",
+                        "options": ["w", "x", "y", "z"],
+                        "answer_index": 0,
+                        "explanation": "w is named as the key actor.",
+                    },
+                    {
+                        "question": "When did it happen?",
+                        "options": ["1", "2", "3", "4"],
+                        "answer_index": 2,
+                        "explanation": "The third option matches the reported date.",
+                    },
+                ]
+            }
+        # E5 analysis: key_facts
+        if '"facts"' in p or "concrete facts" in p:
+            return {"facts": ["First key fact.", "Second key fact.", "Third key fact."]}
+        # E5 analysis: 5 Ws
+        if "five ws" in p or ('"who"' in p and '"why"' in p):
+            return {
+                "who": "Key parties",
+                "what": "An agreement was reached",
+                "when": "This week",
+                "where": "Geneva",
+                "why": "To de-escalate tensions",
+            }
+        # E5 analysis: profession lens
+        if '"points"' in p or "means specifically for" in p:
+            return {
+                "headline": "Here's the one-line takeaway for you",
+                "points": ["Point one.", "Point two.", "Point three."],
+            }
+        return {"result": "generic"}
+
     async def _gen(prompt, *, system=None, schema=None, model=None):
         calls["generate"] += 1
-        return {"stub": True} if schema is not None else "STUB SUMMARY"
+        if schema is None:
+            return "STUB SUMMARY"
+        return _schema_shape(prompt)
 
     async def _embed(_text):
         calls["embed"] += 1

--- a/backend/tests/integration/test_feed.py
+++ b/backend/tests/integration/test_feed.py
@@ -1,5 +1,7 @@
-"""E0: /feed must report real source_count + cluster_id (multi-source visible)."""
+"""E0: /feed must report real source_count + cluster_id (multi-source visible)
+and serve the feed with a bounded query count (no per-article N+1)."""
 import pytest
+from sqlalchemy import event
 
 from app.models import (
     Article,
@@ -8,6 +10,7 @@ from app.models import (
     Source,
     SourceType,
     StoryCluster,
+    User,
 )
 
 
@@ -53,3 +56,77 @@ async def test_feed_reports_real_source_count_and_cluster(aclient, db_session):
     assert s["source_count"] == 1
     assert s["cluster_id"] is None
     assert s["has_ai_summary"] is False
+
+
+@pytest.mark.asyncio
+async def test_feed_no_n_plus_one(aclient, db_session, engine):
+    """The feed resolves cluster membership + source counts in aggregate, so the number
+    of SQL round-trips must NOT grow per article. Count statements via an event listener
+    and assert a small constant bound regardless of how many articles are returned."""
+    # Seed many standalone articles plus one multi-source cluster.
+    src = Source(name="NSrc", url="https://n.example/src", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    cl = StoryCluster(title="Cluster", summary="s")
+    db_session.add(cl)
+    await db_session.flush()
+    for i in range(25):
+        a = Article(
+            title=f"Item {i}", url=f"https://n.example/{i}",
+            source_id=src.id, embedding_status=EmbeddingStatus.complete,
+        )
+        db_session.add(a)
+        await db_session.flush()
+        if i < 4:  # first few share a cluster
+            db_session.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db_session.flush()
+
+    counter = {"n": 0}
+
+    def _before_cursor(conn, cursor, statement, parameters, context, executemany):
+        # Only count real SELECTs the endpoint issues (ignore SAVEPOINT/RELEASE/BEGIN).
+        s = statement.lstrip().upper()
+        if s.startswith("SELECT"):
+            counter["n"] += 1
+
+    sync_engine = engine.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", _before_cursor)
+    try:
+        resp = await aclient.get("/feed?per_page=50")
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _before_cursor)
+
+    assert resp.status_code == 200
+    assert len(resp.json()["articles"]) == 25
+    # Endpoint issues a bounded set of queries: count, page, source selectin,
+    # cluster-membership, per-cluster count, summary set, recent feedback.
+    # Far fewer than 1-per-article (which would be 25+). Allow generous headroom.
+    assert counter["n"] <= 12, f"feed issued {counter['n']} SELECTs (possible N+1)"
+
+
+@pytest.mark.asyncio
+async def test_cluster_response_includes_coherence(aclient, db_session):
+    """GET /clusters/{id} surfaces the real persisted coherence value."""
+    # The default user must exist — get_cluster records a read against DEFAULT_USER_ID.
+    if await db_session.get(User, 1) is None:
+        db_session.add(User(id=1))
+        await db_session.flush()
+    src = Source(name="CSrc", url="https://c.example/src", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    a = Article(
+        title="Cohesive story", snippet="detail", url="https://c.example/a",
+        source_id=src.id, embedding_status=EmbeddingStatus.complete,
+    )
+    db_session.add(a)
+    cl = StoryCluster(title="Cluster", summary="real summary", coherence=0.87)
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db_session.flush()
+
+    resp = await aclient.get(f"/clusters/{cl.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == cl.id
+    assert body["coherence"] == pytest.approx(0.87)

--- a/backend/tests/integration/test_foundation.py
+++ b/backend/tests/integration/test_foundation.py
@@ -1,6 +1,9 @@
 """E★ foundation: prove the pgvector integration harness works end-to-end."""
+import os
+import pathlib
+
 import pytest
-from sqlalchemy import func, select, text
+from sqlalchemy import create_engine, func, inspect, select, text
 
 from app.config import settings
 from app.models import (
@@ -11,6 +14,42 @@ from app.models import (
     SourceType,
     StoryCluster,
 )
+
+# All tables the baseline migration is expected to create.
+EXPECTED_TABLES = {
+    "sources",
+    "story_clusters",
+    "topics",
+    "users",
+    "articles",
+    "user_preferences",
+    "user_settings",
+    "article_topics",
+    "cluster_articles",
+    "user_feedback",
+}
+
+# backend/ root (contains alembic.ini + migrations/), two levels up from this file.
+_BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _alembic_config():
+    """Build an Alembic Config pinned to this project's alembic.ini + sync URL."""
+    from alembic.config import Config
+
+    cfg = Config(str(_BACKEND_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(_BACKEND_ROOT / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", settings.database_url_sync)
+    return cfg
+
+
+def _reset_public_schema():
+    """Drop + recreate the public schema so the DB is empty before migrating."""
+    sync_engine = create_engine(settings.database_url_sync, future=True)
+    with sync_engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    return sync_engine
 
 
 @pytest.mark.asyncio
@@ -87,3 +126,62 @@ async def test_fake_llm_seam(fake_llm, db_session):
     assert out == "STUB SUMMARY"
     assert len(emb) == settings.embedding_dimensions
     assert fake_llm["generate"] == 1 and fake_llm["embed"] == 1
+
+
+# ── Alembic baseline ↔ models contract (E foundation) ──
+# These reset the public schema and drive Alembic directly, so they are synchronous
+# (the sync psycopg2 driver is what alembic env.py uses). They share the integration
+# suite's DB requirement and only run in the Docker harness like the rest of this file.
+@pytest.mark.asyncio
+async def test_alembic_upgrade_from_empty_creates_all_tables():
+    from alembic import command
+
+    _reset_public_schema()
+    command.upgrade(_alembic_config(), "head")
+
+    sync_engine = create_engine(settings.database_url_sync, future=True)
+    insp = inspect(sync_engine)
+    tables = set(insp.get_table_names())
+
+    # All 10 domain tables exist (alembic_version is created by Alembic itself).
+    missing = EXPECTED_TABLES - tables
+    assert not missing, f"baseline upgrade did not create: {sorted(missing)}"
+
+    # pgvector extension was installed by the migration.
+    with sync_engine.connect() as conn:
+        ext = conn.execute(
+            text("select extversion from pg_extension where extname='vector'")
+        ).scalar()
+    assert ext is not None
+
+
+@pytest.mark.asyncio
+async def test_alembic_baseline_matches_models():
+    # After upgrading to head, autogenerate must produce NO operations — i.e. the
+    # baseline migration is in sync with the ORM models.
+    from alembic import command
+    from alembic.autogenerate import compare_metadata
+    from alembic.migration import MigrationContext
+
+    from app.database import Base
+    import app.models  # noqa: F401 — ensure all models are registered on Base.metadata
+
+    _reset_public_schema()
+    command.upgrade(_alembic_config(), "head")
+
+    sync_engine = create_engine(settings.database_url_sync, future=True)
+    with sync_engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        diff = compare_metadata(ctx, Base.metadata)
+
+    # The pgvector HNSW index is created in the baseline migration via raw SQL
+    # (op.execute) and is intentionally NOT declared on the ORM model, so
+    # autogenerate always wants to "remove" it. Ignore that known, deliberate diff.
+    def _is_hnsw(op):
+        try:
+            return getattr(op[1], "name", None) == "ix_articles_embedding_hnsw"
+        except (IndexError, TypeError):
+            return False
+
+    drift = [op for op in diff if not _is_hnsw(op)]
+    assert drift == [], f"models drifted from baseline migration: {drift}"

--- a/backend/tests/integration/test_lenses.py
+++ b/backend/tests/integration/test_lenses.py
@@ -1,18 +1,28 @@
 """E5/E6/E7/E8: cluster lens endpoints — generate + cache + graceful unavailable."""
+import itertools
+
 import pytest
 
 from app.models import (
     Article,
+    ArticleTopic,
     ClusterArticle,
     EmbeddingStatus,
     Source,
     SourceType,
     StoryCluster,
+    Topic,
+    User,
 )
+from app.services import lenses
+
+_src_seq = itertools.count(1)
 
 
 async def _seed_cluster(db_session, n=2):
-    src = Source(name="S", url="https://l.example/src", source_type=SourceType.wire)
+    # Unique source url per call so tests that seed multiple clusters don't collide
+    # on the sources.url unique constraint.
+    src = Source(name="S", url=f"https://l.example/src/{next(_src_seq)}", source_type=SourceType.wire)
     db_session.add(src)
     await db_session.flush()
     arts = []
@@ -29,12 +39,250 @@ async def _seed_cluster(db_session, n=2):
     for a in arts:
         db_session.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
     await db_session.flush()
+    cl._articles = arts  # convenience handle for tests that mutate the source set
     return cl
+
+
+async def _set_profession(db_session, profession):
+    """Ensure the default user (id=1, read by the routes) has the given profession."""
+    u = await db_session.get(User, 1)
+    if u is None:
+        u = User(id=1, profession=profession, locale="IN")
+        db_session.add(u)
+    else:
+        u.profession = profession
+    await db_session.flush()
+    return u
+
+
+async def _tag_cluster_topic(db_session, cluster, topic_name):
+    """Attach a Topic (by name) to every article in the cluster (strategic topic-gate)."""
+    topic = Topic(name=topic_name)
+    db_session.add(topic)
+    await db_session.flush()
+    for a in cluster._articles:
+        db_session.add(
+            ArticleTopic(article_id=a.id, topic_id=topic.id, relevance_score=1.0)
+        )
+    await db_session.flush()
+    return topic
+
+
+# ── E5: analysis lenses (key_facts / 5ws / profession) ──
+@pytest.mark.asyncio
+async def test_analysis_keyfacts_returns_bullets_and_caches(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    r1 = await aclient.get(f"/clusters/{cl.id}/analysis?lens=key_facts")
+    assert r1.status_code == 200
+    body = r1.json()
+    assert body.get("cached") is False
+    assert isinstance(body["facts"], list) and len(body["facts"]) >= 1
+    assert fake_llm["generate"] == 1
+    # second call serves from cache — no new LLM call
+    r2 = await aclient.get(f"/clusters/{cl.id}/analysis?lens=key_facts")
+    assert r2.json().get("cached") is True
+    assert r2.json()["facts"] == body["facts"]
+    assert fake_llm["generate"] == 1
+
+
+@pytest.mark.asyncio
+async def test_analysis_5ws_returns_five_keys(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    r = await aclient.get(f"/clusters/{cl.id}/analysis?lens=5ws")
+    assert r.status_code == 200
+    body = r.json()
+    for key in ("who", "what", "when", "where", "why"):
+        assert key in body and isinstance(body[key], str) and body[key]
+
+
+@pytest.mark.asyncio
+async def test_analysis_profession_lens_uses_profile(aclient, db_session, fake_llm):
+    await _set_profession(db_session, "nurse")
+    cl = await _seed_cluster(db_session)
+    r = await aclient.get(f"/clusters/{cl.id}/analysis?lens=profession")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("cached") is False
+    assert "headline" in body
+    assert isinstance(body["points"], list) and len(body["points"]) >= 1
+    # cache subkey is keyed by the profession hash, so a re-request hits cache
+    r2 = await aclient.get(f"/clusters/{cl.id}/analysis?lens=profession")
+    assert r2.json().get("cached") is True
+    assert fake_llm["generate"] == 1
+
+
+# ── E6: WIIFM impact (profession-hash cache + source-hash invalidation) ──
+@pytest.mark.asyncio
+async def test_impact_reuses_cache_per_profession_hash(aclient, db_session, fake_llm):
+    await _set_profession(db_session, "Software Engineer")
+    cl = await _seed_cluster(db_session)
+    r1 = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r1.status_code == 200
+    assert r1.json().get("cached") is False
+    assert fake_llm["generate"] == 1
+    r2 = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r2.json().get("cached") is True
+    assert fake_llm["generate"] == 1
+    # same profession in a different casing/whitespace hashes identically -> still cached
+    await _set_profession(db_session, "  software engineer ")
+    r3 = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r3.json().get("cached") is True
+    assert fake_llm["generate"] == 1
+
+
+@pytest.mark.asyncio
+async def test_impact_invalidates_on_source_hash_change(aclient, db_session, fake_llm):
+    await _set_profession(db_session, "teacher")
+    cl = await _seed_cluster(db_session)
+    r1 = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r1.json().get("cached") is False
+    assert fake_llm["generate"] == 1
+    # add a new source article -> the source_hash changes -> cache is stale
+    new_art = Article(
+        title="Story NEW", snippet="more detail", url="https://l.example/new",
+        source_id=cl._articles[0].source_id, embedding_status=EmbeddingStatus.complete,
+    )
+    db_session.add(new_art)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=new_art.id))
+    await db_session.flush()
+    r2 = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r2.json().get("cached") is False  # regenerated against the new source set
+    assert fake_llm["generate"] == 2
+
+
+@pytest.mark.asyncio
+async def test_impact_unavailable_when_profession_unset(aclient, db_session, fake_llm):
+    # No profession on the default user -> impact has no meaningful answer.
+    await _set_profession(db_session, None)
+    cl = await _seed_cluster(db_session)
+    r = await aclient.get(f"/clusters/{cl.id}/impact")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("unavailable") is True
+    assert body.get("reason") == "profession_unset"
+    assert fake_llm["generate"] == 0  # short-circuits before any LLM call
+
+
+@pytest.mark.asyncio
+async def test_profession_hash_stable_and_normalized():
+    # Same logical profession (case/whitespace-insensitive) -> same hash.
+    assert lenses.profession_hash("Doctor") == lenses.profession_hash("  doctor ")
+    assert lenses.profession_hash("doctor") != lenses.profession_hash("lawyer")
+    # Empty / None normalize to a stable sentinel.
+    assert lenses.profession_hash(None) == "default"
+    assert lenses.profession_hash("   ") == "default"
+
+
+# ── E7: strategic / game-theory (topic-gated) ──
+@pytest.mark.asyncio
+async def test_strategic_returns_structured_actors_and_game_type(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    await _tag_cluster_topic(db_session, cl, "Geopolitics")
+    r = await aclient.get(f"/clusters/{cl.id}/strategic")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("cached") is False
+    assert isinstance(body["actors"], list) and len(body["actors"]) >= 1
+    for actor in body["actors"]:
+        assert {"name", "incentive", "likely_move"} <= set(actor)
+    assert isinstance(body["game_type"], str) and body["game_type"]
+
+
+@pytest.mark.asyncio
+async def test_strategic_caches(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    await _tag_cluster_topic(db_session, cl, "World")
+    r1 = await aclient.get(f"/clusters/{cl.id}/strategic")
+    assert r1.json().get("cached") is False
+    assert fake_llm["generate"] == 1
+    r2 = await aclient.get(f"/clusters/{cl.id}/strategic")
+    assert r2.json().get("cached") is True
+    assert fake_llm["generate"] == 1
+
+
+@pytest.mark.asyncio
+async def test_strategic_schema_validates_required_fields(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    await _tag_cluster_topic(db_session, cl, "International Politics")
+    body = (await aclient.get(f"/clusters/{cl.id}/strategic")).json()
+    assert {"actors", "game_type", "second_order", "non_obvious_take"} <= set(body)
+    assert isinstance(body["second_order"], list)
+    assert isinstance(body["non_obvious_take"], str)
+
+
+@pytest.mark.asyncio
+async def test_strategic_offered_only_for_geopolitics_topics(aclient, db_session, fake_llm):
+    # Non-geopolitics topic -> the lens is not offered.
+    cl_other = await _seed_cluster(db_session)
+    await _tag_cluster_topic(db_session, cl_other, "Cooking")
+    r_other = await aclient.get(f"/clusters/{cl_other.id}/strategic")
+    assert r_other.status_code == 200
+    body = r_other.json()
+    assert body.get("unavailable") is True
+    assert body.get("reason") == "not_offered_for_topic"
+    assert fake_llm["generate"] == 0
+
+    # Geopolitics topic -> offered + generated.
+    cl_geo = await _seed_cluster(db_session)
+    await _tag_cluster_topic(db_session, cl_geo, "Geopolitics")
+    r_geo = await aclient.get(f"/clusters/{cl_geo.id}/strategic")
+    assert r_geo.status_code == 200
+    assert "unavailable" not in r_geo.json()
+    assert fake_llm["generate"] == 1
+
+
+# ── E8: trivia (easy / medium / hard) ──
+@pytest.mark.asyncio
+async def test_trivia_returns_questions_for_each_difficulty(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    for i, diff in enumerate(("easy", "medium", "hard"), start=1):
+        r = await aclient.get(f"/clusters/{cl.id}/trivia?difficulty={diff}")
+        assert r.status_code == 200
+        questions = r.json()["questions"]
+        assert isinstance(questions, list) and len(questions) >= 1
+        assert fake_llm["generate"] == i  # each difficulty is a distinct subkey
+
+
+@pytest.mark.asyncio
+async def test_trivia_each_question_has_answer_and_explanation(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    body = (await aclient.get(f"/clusters/{cl.id}/trivia?difficulty=medium")).json()
+    for q in body["questions"]:
+        assert isinstance(q["question"], str) and q["question"]
+        assert isinstance(q["options"], list) and len(q["options"]) == 4
+        assert isinstance(q["answer_index"], int)
+        assert 0 <= q["answer_index"] < len(q["options"])
+        assert isinstance(q["explanation"], str) and q["explanation"]
+
+
+@pytest.mark.asyncio
+async def test_trivia_invalid_difficulty_400(aclient, db_session):
+    cl = await _seed_cluster(db_session)
+    r = await aclient.get(f"/clusters/{cl.id}/trivia?difficulty=bogus")
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_trivia_caches_per_difficulty(aclient, db_session, fake_llm):
+    cl = await _seed_cluster(db_session)
+    r1 = await aclient.get(f"/clusters/{cl.id}/trivia?difficulty=hard")
+    assert r1.json().get("cached") is False
+    assert fake_llm["generate"] == 1
+    # same difficulty -> cache hit
+    r2 = await aclient.get(f"/clusters/{cl.id}/trivia?difficulty=hard")
+    assert r2.json().get("cached") is True
+    assert fake_llm["generate"] == 1
+    # different difficulty -> distinct subkey -> regenerates
+    r3 = await aclient.get(f"/clusters/{cl.id}/trivia?difficulty=easy")
+    assert r3.json().get("cached") is False
+    assert fake_llm["generate"] == 2
 
 
 @pytest.mark.asyncio
 async def test_impact_generates_then_serves_from_cache(aclient, db_session, fake_llm):
     cl = await _seed_cluster(db_session)
+    await _set_profession(db_session, "Analyst")  # impact requires a profession to generate
     r1 = await aclient.get(f"/clusters/{cl.id}/impact")
     assert r1.status_code == 200
     assert r1.json().get("cached") is False

--- a/backend/tests/integration/test_profile.py
+++ b/backend/tests/integration/test_profile.py
@@ -1,5 +1,17 @@
 """E3 (profile) + E1 (gemini key) endpoint integration tests."""
 import pytest
+from sqlalchemy import func, select
+
+from app.models import (
+    Article,
+    ClusterArticle,
+    EmbeddingStatus,
+    Source,
+    SourceType,
+    StoryCluster,
+    Topic,
+    UserPreference,
+)
 
 
 @pytest.mark.asyncio
@@ -34,3 +46,94 @@ async def test_set_and_clear_gemini_key(aclient, db_session):
     r2 = await aclient.put("/settings/gemini-key", json={"gemini_api_key": None})
     assert r2.status_code == 200
     assert r2.json()["has_gemini_key"] is False
+
+
+@pytest.mark.asyncio
+async def test_put_profile_sets_profession_locale(aclient, db_session):
+    """PUT /profile persists both profession and a non-default locale, round-tripped via GET."""
+    r = await aclient.put("/profile", json={"profession": "lawyer", "locale": "US"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["profession"] == "lawyer"
+    assert body["locale"] == "US"
+
+    g = await aclient.get("/profile")
+    assert g.status_code == 200
+    assert g.json()["profession"] == "lawyer"
+    assert g.json()["locale"] == "US"
+
+
+@pytest.mark.asyncio
+async def test_interests_persist_as_preferences_not_localstorage(aclient, db_session):
+    """Interests set via PUT /profile must be durable server state (user_preferences),
+    not client-only localStorage. Prove it by reading the rows back from the DB and
+    by getting a fresh /profile that reflects a *replacement* set."""
+    r = await aclient.put(
+        "/profile",
+        json={"profession": "teacher", "interests": ["Economy", "Climate"]},
+    )
+    assert r.status_code == 200
+    assert set(r.json()["interests"]) == {"Economy", "Climate"}
+
+    # Server-side: preferences were written as real rows joined to topics by name.
+    rows = (
+        await db_session.execute(
+            select(Topic.name)
+            .join(UserPreference, UserPreference.topic_id == Topic.id)
+            .where(UserPreference.user_id == 1)
+        )
+    ).all()
+    assert {row[0] for row in rows} == {"Economy", "Climate"}
+
+    # A new interests payload REPLACES the prior set (not append, not localStorage).
+    r2 = await aclient.put("/profile", json={"interests": ["Sports"]})
+    assert r2.status_code == 200
+    assert set(r2.json()["interests"]) == {"Sports"}
+
+    pref_count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(UserPreference)
+            .where(UserPreference.user_id == 1)
+        )
+    ).scalar()
+    assert pref_count == 1
+
+    g = await aclient.get("/profile")
+    assert set(g.json()["interests"]) == {"Sports"}
+
+
+@pytest.mark.asyncio
+async def test_feed_personalizes_after_interests_set(aclient, db_session):
+    """Setting an interest creates a topic + preference; the briefing then ranks a
+    cluster tagged with that interest into the exploit slots (personalization wiring)."""
+    # Set an interest — this creates the "Tech" topic and a weighted preference.
+    r = await aclient.put("/profile", json={"interests": ["Tech"]})
+    assert r.status_code == 200
+    tech = (
+        await db_session.execute(select(Topic).where(Topic.name == "Tech"))
+    ).scalar_one()
+
+    # Seed a cluster whose article is tagged with the "Tech" topic.
+    src = Source(name="S", url="https://p.example/src", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    art = Article(
+        title="Chip breakthrough", snippet="A long enough snippet to render as summary text.",
+        url="https://p.example/a", source_id=src.id,
+        embedding_status=EmbeddingStatus.complete,
+    )
+    db_session.add(art)
+    await db_session.flush()
+    from app.models import ArticleTopic
+    db_session.add(ArticleTopic(article_id=art.id, topic_id=tech.id))
+    cl = StoryCluster(title="Chip story", summary="Real summary exists")
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db_session.flush()
+
+    resp = await aclient.get("/briefing")
+    assert resp.status_code == 200
+    stories = resp.json()["stories"]
+    assert any(s["cluster_id"] == cl.id and s["category"] == "Tech" for s in stories)

--- a/backend/tests/integration/test_search.py
+++ b/backend/tests/integration/test_search.py
@@ -1,8 +1,18 @@
-"""E4 integration: hybrid search (keyword ranks above semantic-only)."""
+"""E4 integration: hybrid search — keyword ranks above semantic-only, the HNSW index
+exists after migration, results are grouped/deduped by cluster, and repeated queries
+reuse one cached query embedding."""
 import pytest
+from sqlalchemy import text
 
 from app.config import settings
-from app.models import Article, EmbeddingStatus, Source, SourceType
+from app.models import (
+    Article,
+    ClusterArticle,
+    EmbeddingStatus,
+    Source,
+    SourceType,
+    StoryCluster,
+)
 
 
 async def _article(db_session, src, title, url, embedding):
@@ -39,3 +49,88 @@ async def test_keyword_ranks_above_semantic_only(aclient, db_session, fake_llm):
 async def test_search_empty_query_rejected(aclient, db_session):
     r = await aclient.get("/search?q=")
     assert r.status_code in (400, 422)
+
+
+@pytest.mark.asyncio
+async def test_hnsw_index_exists_after_migration(db_session):
+    """The semantic-search HNSW index must be present (created by the baseline migration /
+    the integration harness mirror of it). Without it, NN search degrades to a seq scan."""
+    row = (
+        await db_session.execute(
+            text("SELECT indexname FROM pg_indexes WHERE indexname = :n"),
+            {"n": "ix_articles_embedding_hnsw"},
+        )
+    ).scalar_one_or_none()
+    assert row == "ix_articles_embedding_hnsw"
+
+
+@pytest.mark.asyncio
+async def test_search_groups_by_cluster_dedup_articles(aclient, db_session, fake_llm):
+    """When a query matches multiple articles in the same cluster, the result set
+    collapses to one row per cluster (dedup). Two clusters -> exactly two results."""
+    src = Source(name="S", url="https://g.example/se", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    dim = settings.embedding_dimensions
+    vec = [0.0] * dim
+    vec[0] = 1.0
+
+    # Cluster A: two articles both matching the keyword "Mandate".
+    a1 = await _article(db_session, src, "Mandate ruling lands", "https://g.example/a1", vec)
+    a2 = await _article(db_session, src, "Mandate reaction grows", "https://g.example/a2", vec)
+    cl_a = StoryCluster(title="Mandate A", summary="s")
+    db_session.add(cl_a)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl_a.id, article_id=a1.id))
+    db_session.add(ClusterArticle(cluster_id=cl_a.id, article_id=a2.id))
+
+    # Cluster B: one article also matching "Mandate".
+    b1 = await _article(db_session, src, "Mandate appeal filed", "https://g.example/b1", vec)
+    cl_b = StoryCluster(title="Mandate B", summary="s")
+    db_session.add(cl_b)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl_b.id, article_id=b1.id))
+    await db_session.flush()
+
+    r = await aclient.get("/search?q=Mandate")
+    assert r.status_code == 200
+    results = r.json()["results"]
+    cluster_ids = [x["cluster_id"] for x in results]
+    # Exactly one result per cluster — no duplicate cluster_ids.
+    assert sorted(cluster_ids) == sorted({cl_a.id, cl_b.id})
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_query_embedding_cached(aclient, db_session, monkeypatch):
+    """Calling /search twice with the same query embeds the query exactly once —
+    the second call hits the in-process query-embedding cache."""
+    import app.services.embeddings as emb
+
+    # Reset the module-level cache so the count is deterministic across the suite.
+    emb._query_embedding_cache.clear()
+
+    calls = {"n": 0}
+
+    async def _spy_embed(_text):
+        calls["n"] += 1
+        v = [0.0] * settings.embedding_dimensions
+        v[0] = 1.0
+        return v
+
+    monkeypatch.setattr(emb, "generate_embedding", _spy_embed)
+
+    src = Source(name="S", url="https://q.example/se", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    await _article(
+        db_session, src, "Budget session opens", "https://q.example/a",
+        [1.0] + [0.0] * (settings.embedding_dimensions - 1),
+    )
+
+    r1 = await aclient.get("/search?q=Budget")
+    assert r1.status_code == 200
+    r2 = await aclient.get("/search?q=Budget")
+    assert r2.status_code == 200
+
+    assert calls["n"] == 1  # query embedded once, second call served from cache

--- a/backend/tests/integration/test_sources.py
+++ b/backend/tests/integration/test_sources.py
@@ -1,4 +1,6 @@
-"""E2 integration: source upsert + admin endpoints."""
+"""E2 integration: source upsert + admin endpoints + GDELT region inference."""
+import contextlib
+
 import pytest
 from sqlalchemy import func, select
 
@@ -37,9 +39,107 @@ async def test_admin_create_source(aclient, db_session):
               "rss_url": "https://my.example/rss", "region": "in", "category": "tech"},
     )
     assert r.status_code == 200
+    assert r.json()["updated"] is False
+    # Re-posting the same url upserts in place (no duplicate, no 409).
     r_dup = await aclient.post("/admin/sources", json={"name": "Dup", "url": "https://my.example"})
-    assert r_dup.status_code == 409
+    assert r_dup.status_code == 200
+    assert r_dup.json()["updated"] is True
     r_bad = await aclient.post("/admin/sources", json={"name": "x"})
     assert r_bad.status_code == 400
     g = await aclient.get("/admin/sources")
-    assert any(s["url"] == "https://my.example" for s in g.json())
+    matches = [s for s in g.json() if s["url"] == "https://my.example"]
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_post_source_creates_row(aclient, db_session):
+    """POST /admin/sources with a fresh url inserts exactly one persisted source row."""
+    r = await aclient.post(
+        "/admin/sources",
+        json={"name": "Fresh Feed", "url": "https://fresh.example",
+              "rss_url": "https://fresh.example/rss", "region": "in", "category": "business"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["updated"] is False
+    assert body["name"] == "Fresh Feed"
+
+    s = (
+        await db_session.execute(
+            select(Source).where(Source.url == "https://fresh.example")
+        )
+    ).scalar_one()
+    assert s.region == "in"
+    assert s.category == "business"
+    assert s.rss_url == "https://fresh.example/rss"
+
+
+@pytest.mark.asyncio
+async def test_admin_post_source_upserts_existing(aclient, db_session):
+    """Re-POSTing an existing url updates region/category in place (upsert), and the
+    plain /admin/sources path that detects a duplicate name returns 409 — but the
+    canonical upsert (same url, new metadata) must NOT 409; it must update the row."""
+    r1 = await aclient.post(
+        "/admin/sources",
+        json={"name": "Up Feed", "url": "https://up.example",
+              "region": "global", "category": "world"},
+    )
+    assert r1.status_code == 200
+    assert r1.json()["updated"] is False
+    first_id = r1.json()["id"]
+
+    # Same url, new region + category -> upsert (update in place), not a duplicate insert.
+    r2 = await aclient.post(
+        "/admin/sources",
+        json={"name": "Up Feed Renamed", "url": "https://up.example",
+              "region": "in", "category": "tech"},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["updated"] is True
+    assert r2.json()["id"] == first_id
+
+    # Exactly one row, with the updated metadata.
+    rows = (
+        await db_session.execute(
+            select(Source).where(Source.url == "https://up.example")
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].region == "in"
+    assert rows[0].category == "tech"
+    assert rows[0].name == "Up Feed Renamed"
+
+
+@pytest.mark.asyncio
+async def test_gdelt_created_source_gets_region(db_session, monkeypatch):
+    """A source auto-created from GDELT discovery inherits region from the query scope:
+    an India-scoped GDELT query (sourcecountry:IN) yields region 'in'."""
+    from app.config import settings
+    from app.services import gdelt
+
+    # Route gdelt's own-session factory at the test transaction so the write is visible.
+    @contextlib.asynccontextmanager
+    async def _fake_session():
+        yield db_session
+
+    monkeypatch.setattr(gdelt, "async_session", _fake_session)
+    monkeypatch.setattr(settings, "gdelt_query", "sourcecountry:IN")
+
+    src = await gdelt._get_or_create_source(
+        "thehindu.com", "https://thehindu.com/news/article"
+    )
+    assert src is not None
+    assert src.region == "in"
+
+    persisted = (
+        await db_session.execute(
+            select(Source).where(Source.url == "https://thehindu.com")
+        )
+    ).scalar_one()
+    assert persisted.region == "in"
+
+    # Idempotent: a second discovery for the same domain returns the existing row.
+    again = await gdelt._get_or_create_source(
+        "thehindu.com", "https://thehindu.com/news/other"
+    )
+    assert again.id == src.id

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -26,12 +26,18 @@ class FakeUserSetting:
         openai_api_key_encrypted=None,
         openai_key_verified=False,
         openai_key_verified_at=None,
+        gemini_api_key_encrypted=None,
+        gemini_key_verified=False,
+        gemini_key_verified_at=None,
     ):
         self.id = id
         self.user_id = user_id
         self.openai_api_key_encrypted = openai_api_key_encrypted
         self.openai_key_verified = openai_key_verified
         self.openai_key_verified_at = openai_key_verified_at
+        self.gemini_api_key_encrypted = gemini_api_key_encrypted
+        self.gemini_key_verified = gemini_key_verified
+        self.gemini_key_verified_at = gemini_key_verified_at
         self.updated_at = datetime.now(timezone.utc)
 
 
@@ -145,6 +151,34 @@ class TestGetSettings:
         assert response.status_code == 200
         data = response.json()
         assert data["has_openai_key"] is False
+        # No Gemini key configured either.
+        assert data["has_gemini_key"] is False
+        assert data["gemini_key_last4"] is None
+
+    async def test_get_settings_includes_gemini_info(
+        self, settings_client: AsyncClient, settings_session: SettingsMockSession
+    ):
+        """GET /settings surfaces the Gemini key trio mirroring the OpenAI one."""
+        settings_session.setting = FakeUserSetting(
+            openai_api_key_encrypted=None,
+            gemini_api_key_encrypted="gem-encrypted-9876",
+            gemini_key_verified=True,
+            gemini_key_verified_at=datetime.now(timezone.utc),
+        )
+
+        with patch(
+            "app.services.encryption.decrypt_value", return_value="gem-secret-9876"
+        ):
+            response = await settings_client.get("/settings")
+
+        assert response.status_code == 200
+        data = response.json()
+        # OpenAI absent, Gemini present + masked + verified.
+        assert data["has_openai_key"] is False
+        assert data["has_gemini_key"] is True
+        assert data["gemini_key_last4"] == "9876"
+        assert data["gemini_key_verified"] is True
+        assert data["gemini_key_verified_at"] is not None
 
 
 # ─── PUT /settings ───

--- a/backend/tests/unit/test_encryption_safety.py
+++ b/backend/tests/unit/test_encryption_safety.py
@@ -34,3 +34,21 @@ def test_roundtrip_with_key(monkeypatch):
     enc = encryption.encrypt_value("sk-secret")
     assert enc != "sk-secret"
     assert encryption.decrypt_value(enc) == "sk-secret"
+
+
+def test_decrypt_failure_does_not_leak_ciphertext(monkeypatch):
+    # With a real Fernet configured, a corrupted/invalid token must RAISE — never
+    # return the raw stored value back to the caller (would leak ciphertext).
+    monkeypatch.setattr(settings, "encryption_key", Fernet.generate_key().decode())
+    monkeypatch.setattr(settings, "require_encryption", True)
+
+    corrupted = "deadbeef" * 8  # valid hex, but not a real Fernet token
+    with pytest.raises(ValueError) as exc:
+        encryption.decrypt_value(corrupted)
+
+    # The raised error must not echo the ciphertext back.
+    assert corrupted not in str(exc.value)
+
+    # Also covers a non-hex token (bytes.fromhex itself fails) — still raises, no leak.
+    with pytest.raises(ValueError):
+        encryption.decrypt_value("not-hex-zzzz")

--- a/backend/tests/unit/test_llm.py
+++ b/backend/tests/unit/test_llm.py
@@ -72,3 +72,87 @@ class TestGenerateRouting:
         monkeypatch.setattr(emb, "_get_client_async", none_client)
         with pytest.raises(llm.LLMUnavailable):
             await llm.generate("hi")
+
+    async def test_generate_routes_to_provider(self, monkeypatch):
+        # generate() dispatches on settings.generation_provider, defaulting to openai.
+        from app.config import settings
+        seen = {}
+
+        async def fake_gemini(prompt, **kw):
+            seen["provider"] = "gemini"
+            return "G"
+
+        async def fake_openai(prompt, **kw):
+            seen["provider"] = "openai"
+            return "O"
+
+        monkeypatch.setattr(llm, "_generate_gemini", fake_gemini)
+        monkeypatch.setattr(llm, "_generate_openai", fake_openai)
+
+        monkeypatch.setattr(settings, "generation_provider", "gemini")
+        assert await llm.generate("hi") == "G"
+        assert seen["provider"] == "gemini"
+
+        monkeypatch.setattr(settings, "generation_provider", "openai")
+        assert await llm.generate("hi") == "O"
+        assert seen["provider"] == "openai"
+
+        # Unknown / empty provider falls back to openai.
+        monkeypatch.setattr(settings, "generation_provider", "")
+        assert await llm.generate("hi") == "O"
+        assert seen["provider"] == "openai"
+
+
+@pytest.mark.asyncio
+async def test_generate_no_key_returns_unavailable(monkeypatch):
+    # No usable key for the configured provider → LLMUnavailable (callers map to "unavailable").
+    from app.config import settings
+    monkeypatch.setattr(settings, "generation_provider", "gemini")
+    monkeypatch.setattr(settings, "gemini_api_key", "")
+
+    async def no_gem_key():
+        return None
+
+    monkeypatch.setattr(llm, "_resolve_gemini_key", no_gem_key)
+    with pytest.raises(llm.LLMUnavailable):
+        await llm.generate("hi")
+
+
+def test_json_repair_recovers_wrapped_json():
+    # extract_json must recover JSON wrapped in a markdown ```json code fence.
+    fenced = '```json\n{"verdict": "ok", "items": [1, 2, 3]}\n```'
+    assert llm.extract_json(fenced) == {"verdict": "ok", "items": [1, 2, 3]}
+    # Bare triple-backtick fence (no language tag) also works.
+    assert llm.extract_json('```\n{"a": 1}\n```') == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_gemini_key_cache_slot_separate_from_openai(monkeypatch):
+    # The Gemini key cache is its own module-level slot; it must not be polluted by
+    # or shared with the OpenAI client path. Resolving the Gemini key falls back to
+    # the env key and caches it independently.
+    from app.config import settings
+    monkeypatch.setattr(settings, "gemini_api_key", "gem-env-key")
+    # OpenAI key set to a different value to prove the slots don't cross-contaminate.
+    monkeypatch.setattr(settings, "openai_api_key", "sk-openai-key")
+
+    # Reset the Gemini cache slot so the fallback path runs deterministically.
+    monkeypatch.setattr(llm, "_gem_key_cache", None)
+    monkeypatch.setattr(llm, "_gem_key_ts", 0.0)
+
+    key = await llm._resolve_gemini_key()
+    assert key == "gem-env-key"
+    # The dedicated Gemini cache slot now holds the Gemini key, not the OpenAI one.
+    assert llm._gem_key_cache == "gem-env-key"
+    assert llm._gem_key_cache != settings.openai_api_key
+
+
+@pytest.mark.asyncio
+async def test_fake_llm_seam_returns_injected(monkeypatch):
+    # Unit-level proof of the generate() seam: monkeypatch it and assert the injected
+    # value comes back with no network call.
+    async def fake_generate(prompt, **kw):
+        return "INJECTED"
+
+    monkeypatch.setattr(llm, "generate", fake_generate)
+    assert await llm.generate("anything") == "INJECTED"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,25 @@ services:
       timeout: 3s
       retries: 5
 
+  # Test-only Postgres+pgvector. Launch with: docker-compose --profile test up db-test
+  db-test:
+    image: pgvector/pgvector:pg16
+    profiles: ["test"]
+    restart: "no"
+    environment:
+      POSTGRES_DB: newslens_test
+      POSTGRES_USER: newslens
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-newslens_dev}
+    ports:
+      - "${DB_TEST_PORT:-5433}:5432"
+    volumes:
+      - pgdata_test:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U newslens"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   backend:
     build:
       context: ./backend
@@ -47,3 +66,5 @@ services:
 volumes:
   pgdata:
     name: newslens_pgdata
+  pgdata_test:
+    name: newslens_pgdata_test

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { Input } from "@/components/ui/Input";
@@ -29,18 +29,52 @@ function matchedLabel(matchedOn: string): string {
   return "matched: meaning";
 }
 
+const RECENT_KEY = "newslens-recent-searches";
+const RECENT_MAX = 5;
+
+function readRecent(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
 export default function SearchPage() {
   const [query, setQuery] = useState("");
   const [submitted, setSubmitted] = useState("");
   const [filter, setFilter] = useState<FilterKey>("all");
   const [results, setResults] = useState<SearchResultItem[]>([]);
   const [state, setState] = useState<"idle" | "loading" | "done" | "error">("idle");
+  const [recent, setRecent] = useState<string[]>([]);
+
+  useEffect(() => {
+    setRecent(readRecent());
+  }, []);
+
+  function rememberQuery(q: string) {
+    setRecent((prev) => {
+      const next = [q, ...prev.filter((x) => x.toLowerCase() !== q.toLowerCase())].slice(
+        0,
+        RECENT_MAX
+      );
+      if (typeof window !== "undefined") {
+        localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+      }
+      return next;
+    });
+  }
 
   async function runSearch(q: string) {
     const trimmed = q.trim();
     if (!trimmed) return;
     setState("loading");
     setSubmitted(trimmed);
+    setQuery(trimmed);
+    rememberQuery(trimmed);
     try {
       const res = await search(trimmed);
       setResults(res.results);
@@ -96,9 +130,25 @@ export default function SearchPage() {
           </p>
         )}
         {state === "idle" && (
-          <p className="text-small text-[var(--text-muted)]">
-            Search across every source — by topic or by meaning.
-          </p>
+          <div className="flex flex-col gap-[var(--space-lg)]">
+            {recent.length > 0 && (
+              <div>
+                <p className="text-mono text-[var(--text-ghost)] mb-[var(--space-sm)]">
+                  RECENT
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {recent.map((q) => (
+                    <Chip key={q} onClick={() => runSearch(q)}>
+                      {q}
+                    </Chip>
+                  ))}
+                </div>
+              </div>
+            )}
+            <p className="text-small text-[var(--text-muted)]">
+              Search across every source — by topic or by meaning.
+            </p>
+          </div>
         )}
         {state === "done" && (
           <>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -14,6 +14,7 @@ import {
   getStats,
   getTopics,
   updateSettings,
+  updateProfile,
   testApiKey,
   type UserSettings,
   type KeyTestResult,
@@ -97,7 +98,7 @@ export default function ProfilePage() {
     fetchSettings();
   }, [fetchSettings]);
 
-  // Persist topic changes
+  // Persist topic changes — locally (instant) and to the backend (so the feed reflects them)
   const toggleTopic = (topic: string) => {
     setSelectedTopics((prev) => {
       const next = new Set(prev);
@@ -106,7 +107,12 @@ export default function ProfilePage() {
       } else {
         next.add(topic);
       }
-      localStorage.setItem("newslens-topics", JSON.stringify([...next]));
+      const interests = [...next];
+      localStorage.setItem("newslens-topics", JSON.stringify(interests));
+      // Fire-and-forget: persist to profile so topic changes affect the feed.
+      updateProfile({ interests }).catch(() => {
+        /* offline / transient — local state already updated */
+      });
       return next;
     });
   };

--- a/frontend/src/components/ui/AISummaryBox.tsx
+++ b/frontend/src/components/ui/AISummaryBox.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { useEffect, useState, type ReactNode } from "react";
+import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { getClusterAnalysis, type AnalysisLens, type LensResult } from "@/lib/api";
+import {
+  getClusterAnalysis,
+  getProfile,
+  type AnalysisLens,
+  type LensResult,
+} from "@/lib/api";
 
-type Tab = "summary" | "key-facts" | "5ws";
+type Tab = "summary" | "key-facts" | "5ws" | "for-you";
 
 interface AISummaryBoxProps {
   summary: string | null;
@@ -18,6 +24,7 @@ const tabs: { id: Tab; label: string; lens?: AnalysisLens }[] = [
   { id: "summary", label: "Summary" },
   { id: "key-facts", label: "Key Facts", lens: "key_facts" },
   { id: "5ws", label: "5Ws", lens: "5ws" },
+  { id: "for-you", label: "For You", lens: "profession" },
 ];
 
 const Disclaimer = () => (
@@ -29,16 +36,26 @@ const Disclaimer = () => (
 export function AISummaryBox({ summary, coherence, clusterId, className }: AISummaryBoxProps) {
   const [activeTab, setActiveTab] = useState<Tab>("summary");
   const [cache, setCache] = useState<Record<string, LensResult | "loading">>({});
+  // null = still loading the profile; "" = profile loaded but profession unset.
+  const [profession, setProfession] = useState<string | null>(null);
   const isLow = coherence !== undefined && coherence < 0.6;
+
+  useEffect(() => {
+    getProfile()
+      .then((p) => setProfession(p.profession ?? ""))
+      .catch(() => setProfession(""));
+  }, []);
 
   useEffect(() => {
     const lens = tabs.find((t) => t.id === activeTab)?.lens;
     if (!lens || !clusterId || cache[lens]) return;
+    // The profession lens needs a set profession — don't fetch until we have one.
+    if (lens === "profession" && !profession) return;
     setCache((p) => ({ ...p, [lens]: "loading" }));
     getClusterAnalysis(clusterId, lens)
       .then((r) => setCache((p) => ({ ...p, [lens]: r })))
       .catch(() => setCache((p) => ({ ...p, [lens]: { unavailable: true } })));
-  }, [activeTab, clusterId, cache]);
+  }, [activeTab, clusterId, cache, profession]);
 
   const renderLens = (lens: AnalysisLens, body: (r: LensResult) => React.ReactNode) => {
     const state = cache[lens];
@@ -56,13 +73,13 @@ export function AISummaryBox({ summary, coherence, clusterId, className }: AISum
 
   return (
     <div className={cn("rounded-[var(--radius-lg)] glass-light overflow-hidden", className)}>
-      <div className="flex border-b border-[var(--glass-border)]">
+      <div className="flex border-b border-[var(--glass-border)] overflow-x-auto no-scrollbar">
         {tabs.map((tab) => (
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
             className={cn(
-              "relative flex-1 py-3 text-center text-[11px] font-medium uppercase tracking-wide transition-colors",
+              "relative flex-1 min-w-[72px] whitespace-nowrap py-3 text-center text-[11px] font-medium uppercase tracking-wide transition-colors",
               "font-[family-name:var(--font-jetbrains-mono)]",
               activeTab === tab.id
                 ? "text-[var(--accent)]"
@@ -148,6 +165,67 @@ export function AISummaryBox({ summary, coherence, clusterId, className }: AISum
                   </dl>
                 );
               })}
+
+            {activeTab === "for-you" &&
+              (profession === null ? (
+                <div className="skeleton h-16 w-full" />
+              ) : profession === "" ? (
+                <Link
+                  href="/settings"
+                  className="block text-small text-[var(--accent)] hover:underline"
+                >
+                  Set your profession in Settings &rarr;
+                </Link>
+              ) : (
+                renderLens("profession", (r) => {
+                  const headline = typeof r.headline === "string" ? r.headline : null;
+                  const points = Array.isArray(r.points) ? (r.points as string[]) : [];
+                  const dims = Array.isArray(r.dimensions)
+                    ? (r.dimensions as { label?: string; body?: string }[])
+                    : [];
+                  if (!headline && points.length === 0 && dims.length === 0) {
+                    return <Unavailable />;
+                  }
+                  return (
+                    <div className="space-y-3">
+                      {headline && (
+                        <p className="text-small text-[var(--text-secondary)] leading-relaxed">
+                          {headline}
+                        </p>
+                      )}
+                      {points.length > 0 && (
+                        <ul className="space-y-2">
+                          {points.map((p, i) => (
+                            <li
+                              key={i}
+                              className="flex gap-2 text-small text-[var(--text-secondary)]"
+                            >
+                              <span className="text-[var(--accent)] shrink-0">&bull;</span>
+                              <span>{p}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      {dims.length > 0 && (
+                        <dl className="space-y-2">
+                          {dims.map((d, i) => (
+                            <div key={i} className="text-small">
+                              {d.label && (
+                                <dt className="text-mono text-[var(--accent)] uppercase">
+                                  {d.label}
+                                </dt>
+                              )}
+                              {d.body && (
+                                <dd className="text-[var(--text-secondary)]">{d.body}</dd>
+                              )}
+                            </div>
+                          ))}
+                        </dl>
+                      )}
+                    </div>
+                  );
+                })
+              ))}
           </motion.div>
         </AnimatePresence>
       </div>

--- a/frontend/src/components/ui/DailyTriviaCard.tsx
+++ b/frontend/src/components/ui/DailyTriviaCard.tsx
@@ -17,6 +17,55 @@ function todayKey(): string {
   return `newslens-daily-quiz-${new Date().toISOString().slice(0, 10)}`;
 }
 
+const STREAK_KEY = "newslens-daily-quiz-streak";
+
+function ymd(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+interface Streak {
+  lastDate: string;
+  count: number;
+}
+
+function readStreak(): Streak {
+  if (typeof window === "undefined") return { lastDate: "", count: 0 };
+  try {
+    const raw = localStorage.getItem(STREAK_KEY);
+    if (!raw) return { lastDate: "", count: 0 };
+    const parsed = JSON.parse(raw) as Partial<Streak>;
+    return {
+      lastDate: typeof parsed.lastDate === "string" ? parsed.lastDate : "",
+      count: typeof parsed.count === "number" ? parsed.count : 0,
+    };
+  } catch {
+    return { lastDate: "", count: 0 };
+  }
+}
+
+/** Advance the streak on a correct daily answer.
+ *  yesterday → increment, today → unchanged, otherwise → reset to 1. */
+function bumpStreak(): Streak {
+  const today = new Date();
+  const todayStr = ymd(today);
+  const yesterdayStr = ymd(new Date(today.getTime() - 86_400_000));
+  const prev = readStreak();
+
+  let next: Streak;
+  if (prev.lastDate === todayStr) {
+    next = prev;
+  } else if (prev.lastDate === yesterdayStr) {
+    next = { lastDate: todayStr, count: prev.count + 1 };
+  } else {
+    next = { lastDate: todayStr, count: 1 };
+  }
+
+  if (typeof window !== "undefined") {
+    localStorage.setItem(STREAK_KEY, JSON.stringify(next));
+  }
+  return next;
+}
+
 /** E8 — daily quiz as a dismissible Today card (not a tab).
  *  Data: GET /trivia/daily. Tap an option to reveal correct/incorrect + why.
  *  Hides itself when unavailable, empty, or already dismissed today. */
@@ -24,6 +73,11 @@ export function DailyTriviaCard() {
   const [data, setData] = useState<LensResult | "loading">("loading");
   const [pick, setPick] = useState<number | null>(null);
   const [dismissed, setDismissed] = useState(true);
+  const [streak, setStreak] = useState(0);
+
+  useEffect(() => {
+    setStreak(readStreak().count);
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -54,6 +108,15 @@ export function DailyTriviaCard() {
   const q = questions[0];
   const answered = pick !== null;
 
+  function answer(oi: number) {
+    if (pick !== null) return;
+    setPick(oi);
+    // Correct daily answer advances the streak; a wrong answer leaves it untouched.
+    if (q && oi === q.answer_index) {
+      setStreak(bumpStreak().count);
+    }
+  }
+
   return (
     <AnimatePresence>
       <motion.div
@@ -64,7 +127,14 @@ export function DailyTriviaCard() {
         className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface)] p-[var(--space-md)] mb-4"
       >
         <div className="flex items-center justify-between mb-3 gap-2">
-          <span className="text-mono text-[var(--accent)]">DAILY QUIZ</span>
+          <div className="flex items-center gap-2">
+            <span className="text-mono text-[var(--accent)]">DAILY QUIZ</span>
+            {streak > 0 && (
+              <span className="text-mono text-[10px] text-[var(--accent)]">
+                STREAK &middot; {streak}
+              </span>
+            )}
+          </div>
           <button
             onClick={dismiss}
             aria-label="Dismiss daily quiz"
@@ -87,7 +157,7 @@ export function DailyTriviaCard() {
                   <button
                     key={oi}
                     disabled={answered}
-                    onClick={() => setPick(oi)}
+                    onClick={() => answer(oi)}
                     className={cn(
                       "text-left text-small px-3 py-2 rounded-[var(--radius-md)] border transition-colors",
                       !answered &&

--- a/frontend/src/components/ui/ImpactCard.tsx
+++ b/frontend/src/components/ui/ImpactCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { motion } from "framer-motion";
 import { getClusterImpact, type LensResult } from "@/lib/api";
 
@@ -35,6 +36,25 @@ export function ImpactCard({ clusterId }: { clusterId: number }) {
   if (data === "loading") {
     return <div className="skeleton h-24 rounded-[var(--radius-lg)]" />;
   }
+  // When the only thing missing is the user's profession, invite them to set it
+  // instead of silently hiding — this lens is the payoff for filling it in.
+  if (data.reason === "profession_unset") {
+    return (
+      <Link
+        href="/settings"
+        className="block rounded-[var(--radius-lg)] border border-[var(--accent-muted)] bg-[var(--accent-subtle)] p-[var(--space-md)] transition-colors hover:bg-[var(--accent-muted)]"
+      >
+        <div className="flex items-center gap-1.5 text-mono text-[var(--accent)] mb-2">
+          <ClockIcon />
+          WHAT&apos;S IN IT FOR ME
+        </div>
+        <p className="text-small text-[var(--text-primary)] leading-relaxed">
+          Personalize this — set your profession &rarr;
+        </p>
+      </Link>
+    );
+  }
+  // Any other unavailable reason degrades gracefully (hidden).
   if (data.unavailable) return null;
 
   const headline = typeof data.headline === "string" ? data.headline : null;

--- a/frontend/src/components/ui/StrategicCard.tsx
+++ b/frontend/src/components/ui/StrategicCard.tsx
@@ -28,7 +28,8 @@ export function StrategicCard({ clusterId }: { clusterId: number }) {
   if (data === "loading") {
     return <div className="skeleton h-24 rounded-[var(--radius-lg)]" />;
   }
-  if (data.unavailable) return null;
+  // Backend gates this lens by topic; hide for non-geopolitics or any unavailable reason.
+  if (data.unavailable || data.reason === "not_offered_for_topic") return null;
 
   const actors = Array.isArray(data.actors) ? (data.actors as Actor[]) : [];
   const gameType = typeof data.game_type === "string" ? data.game_type : null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -195,6 +195,10 @@ export interface UserSettings {
   openai_key_verified: boolean;
   openai_key_last4: string | null;
   openai_key_verified_at: string | null;
+  has_gemini_key: boolean;
+  gemini_key_verified: boolean;
+  gemini_key_last4: string | null;
+  gemini_key_verified_at: string | null;
 }
 
 export interface KeyTestResult {


### PR DESCRIPTION
A completeness audit found the earlier epic closures were **cosmetic** — real functional gaps + missing acceptance tests in every epic. This makes them genuinely complete.

**Backend suite: 97 passed / 1 skipped** (was 62). Frontend build + `lint:copy` green.

### Functional fixes
- **E0 security:** `decrypt_value` now raises when a Fernet is configured but decryption fails (was leaking ciphertext); dropped hardcoded 0.85/0.70 coherence fallbacks.
- **E1:** declared `google-generativeai` (was imported, undeclared); GET /settings mirrors the OpenAI trio for Gemini.
- **E2:** RBI, SEBI, AP, 2 Google News RSS sources; GDELT region backfill; `POST /admin/sources` upserts (no 409).
- **E3 bug:** Settings "Your Topics" now persists via `updateProfile` (was localStorage-only).
- **E4:** `/search` dedups by cluster + caches query embedding.
- **E5:** "For You" profession tab in AISummaryBox (was inaccessible) + CTA.
- **E6:** impact returns unavailable+reason when profession unset; ImpactCard CTA; briefing carries cached impact headline.
- **E7:** strategic lens topic-gated to geopolitics; fixed fake-LLM fixture masking the shape.
- **E8:** restrained daily-quiz streak.
- **E★:** removed ad-hoc ALTER block from `main.py` (Alembic authoritative); docker-compose `test` profile.

### Tests
PRD-named acceptance tests for E0–E8 + foundation (alembic upgrade-from-empty + no-drift). The fake-LLM fixture now returns lens-shaped data, so lens responses are validated — not just status codes.

Closes #34 #35 #36 #37 #38 #39 #40 #41 #42 #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)