### PR TITLE
Add standing follows: /follows API + Follow UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,9 @@ news-app/
 | GET | /trivia/daily | Daily quiz by topic |
 | GET/POST | /admin/sources | List / upsert sources |
 | GET | /search | Hybrid semantic + keyword search |
+| GET | /follows | List standing follows (newest first) |
+| POST | /follows | Follow a topic/entity/saved_search (idempotent on user+kind+value; 400 on invalid kind) |
+| DELETE | /follows/{id} | Unfollow by id (idempotent 204) |
 
 **Not yet implemented:** `GET /events` (SSE stream), `GET /admin/breadth`
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,6 +1,6 @@
 import structlog
 from datetime import datetime, timezone
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -10,7 +10,9 @@ from app.models import (
     Article,
     ArticleTopic,
     ClusterArticle,
+    FOLLOW_KINDS,
     FeedbackType,
+    Follow,
     Source,
     StoryCluster,
     Topic,
@@ -29,6 +31,8 @@ from app.schemas import (
     FeedbackCreate,
     FeedbackOut,
     FeedResponse,
+    FollowCreate,
+    FollowOut,
     GeminiKeyUpdate,
     HealthResponse,
     KeyTestResult,
@@ -951,6 +955,82 @@ async def unsave_article(
         await db.delete(feedback)
         await db.commit()
         logger.info("article_unsaved", article_id=article_id)
+
+
+# ── Follows ────────────────────────────────────────────
+# Standing follows: a topic, a named entity, or a saved search the user wants to
+# keep tracking. Idempotent on (user, kind, value); invalid kind → 400.
+
+
+@router.get("/follows", response_model=list[FollowOut])
+async def list_follows(db: AsyncSession = Depends(get_db)):
+    """All standing follows for the user, newest first."""
+    result = await db.execute(
+        select(Follow)
+        .where(Follow.user_id == DEFAULT_USER_ID)
+        .order_by(Follow.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+@router.post("/follows", response_model=FollowOut, status_code=201)
+async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
+    """Follow a topic, entity, or saved search.
+
+    Idempotent: re-following an identical (kind, value) returns the existing row
+    instead of creating a duplicate. An unknown ``kind`` is a 400.
+    """
+    kind = (body.kind or "").strip()
+    value = (body.value or "").strip()
+    if kind not in FOLLOW_KINDS:
+        raise HTTPException(status_code=400, detail=f"invalid follow kind: {kind!r}")
+    if not value:
+        raise HTTPException(status_code=400, detail="follow value required")
+
+    existing = (
+        await db.execute(
+            select(Follow).where(
+                Follow.user_id == DEFAULT_USER_ID,
+                Follow.kind == kind,
+                Follow.value == value,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return existing  # idempotent — no duplicate row
+
+    # Single-user MVP: ensure the user row exists before the FK insert
+    # (mirrors the profile / gemini-key routes; the test DB isn't pre-seeded).
+    u = (
+        await db.execute(select(User).where(User.id == DEFAULT_USER_ID))
+    ).scalar_one_or_none()
+    if not u:
+        db.add(User(id=DEFAULT_USER_ID))
+        await db.flush()
+
+    follow = Follow(user_id=DEFAULT_USER_ID, kind=kind, value=value)
+    db.add(follow)
+    await db.commit()
+    await db.refresh(follow)
+    logger.info("follow_created", kind=kind, value=value)
+    return follow
+
+
+@router.delete("/follows/{follow_id}", status_code=204)
+async def delete_follow(follow_id: int, db: AsyncSession = Depends(get_db)):
+    """Unfollow by id. Still 204 if it doesn't exist or isn't this user's."""
+    follow = (
+        await db.execute(
+            select(Follow).where(
+                Follow.id == follow_id,
+                Follow.user_id == DEFAULT_USER_ID,
+            )
+        )
+    ).scalar_one_or_none()
+    if follow:
+        await db.delete(follow)
+        await db.commit()
+        logger.info("follow_deleted", follow_id=follow_id)
 
 
 # ── Stats ──────────────────────────────────────────────

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -250,3 +250,27 @@ class UserSetting(Base):
     )
 
     user: Mapped["User"] = relationship(back_populates="settings")
+
+
+# Allowed kinds for a standing follow. Validated in the route (→ 400), not by a DB
+# enum, so a bad value is a clean client error rather than a DB-level failure.
+FOLLOW_KINDS = ("topic", "entity", "saved_search")
+
+
+class Follow(Base):
+    """A standing follow the user wants to keep tracking: a topic, a named entity
+    (person/org/place), or a saved search query. Idempotent per (user, kind, value)."""
+
+    __tablename__ = "follows"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    kind: Mapped[str] = mapped_column(String(32), nullable=False)  # one of FOLLOW_KINDS
+    value: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "kind", "value", name="uq_follow_user_kind_value"),
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -226,6 +226,21 @@ class SavedListResponse(BaseModel):
     count: int
 
 
+# --- Follows (standing follows: topics, entities, saved searches) ---
+class FollowCreate(BaseModel):
+    kind: str  # one of FOLLOW_KINDS; validated in the route → 400 on a bad value
+    value: str
+
+
+class FollowOut(BaseModel):
+    id: int
+    kind: str
+    value: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
 # --- Stats ---
 class StatsResponse(BaseModel):
     articles_read: int

--- a/backend/migrations/versions/c2a3b4d5e6f7_follows.py
+++ b/backend/migrations/versions/c2a3b4d5e6f7_follows.py
@@ -1,0 +1,43 @@
+"""follows: standing follows (topics, entities, saved searches)
+
+Revision ID: c2a3b4d5e6f7
+Revises: b1f0a2c3d4e5
+Create Date: 2026-06-24 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "c2a3b4d5e6f7"
+down_revision: Union[str, None] = "b1f0a2c3d4e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "follows",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(length=32), nullable=False),
+        sa.Column("value", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id", "kind", "value", name="uq_follow_user_kind_value"
+        ),
+    )
+    op.create_index("ix_follows_user_id", "follows", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_follows_user_id", table_name="follows")
+    op.drop_table("follows")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,6 +21,7 @@ from app.models import (
     ClusterArticle,
     EmbeddingStatus,
     FeedbackType,
+    Follow,
     Source,
     SourceType,
     StoryCluster,
@@ -103,6 +104,17 @@ class FakeTopic:
         self.children = []
 
 
+class FakeFollow:
+    """Mimics Follow ORM model for testing without SQLAlchemy instrumentation."""
+
+    def __init__(self, id=1, kind="topic", value="AI", user_id=1):
+        self.id = id
+        self.user_id = user_id
+        self.kind = kind
+        self.value = value
+        self.created_at = datetime.now(timezone.utc)
+
+
 def make_source(**kwargs) -> FakeSource:
     return FakeSource(**kwargs)
 
@@ -158,7 +170,9 @@ class MockSession:
         self.feed_total: int = 0
         self.cluster: StoryCluster | None = None
         self.topics: list[Topic] = []
+        self.follows: list[Follow] = []
         self.added_objects: list = []
+        self.deleted_objects: list = []
         self.committed = False
         self._last_feedback_id = 100
 
@@ -177,6 +191,15 @@ class MockSession:
                         return MockExecuteResult(rows=self.topics)
                     if entity is Article:
                         return MockExecuteResult(rows=self.feed_articles)
+                    if entity is Follow:
+                        # Serves both `.scalars().all()` (list endpoint) and
+                        # `.scalar_one_or_none()` (idempotency + delete lookups).
+                        # The mock can't honor the WHERE clause, so per-test setup
+                        # of `.follows` decides what a single-row lookup sees.
+                        return MockExecuteResult(
+                            rows=self.follows,
+                            scalar=(self.follows[0] if self.follows else None),
+                        )
 
         # Count query (returns int)
         if 'count' in str(stmt).lower() or 'anon_1' in str(stmt).lower():
@@ -187,6 +210,17 @@ class MockSession:
 
     def add(self, obj):
         self.added_objects.append(obj)
+
+    async def flush(self, *args, **kwargs):
+        # No DB to flush to; ids are assigned on commit (see below).
+        pass
+
+    async def delete(self, obj):
+        self.deleted_objects.append(obj)
+        if obj in self.follows:
+            self.follows.remove(obj)
+        if obj in self.added_objects:
+            self.added_objects.remove(obj)
 
     async def commit(self):
         self.committed = True

--- a/backend/tests/integration/test_follows.py
+++ b/backend/tests/integration/test_follows.py
@@ -1,0 +1,93 @@
+"""Standing follows (/follows) — real-DB integration: CRUD, idempotency, filtering.
+
+MUST RUN IN DOCKER (see tests/integration/conftest.py header)."""
+import pytest
+from sqlalchemy import func, select
+
+from app.models import Follow
+
+
+@pytest.mark.asyncio
+async def test_follow_crud_roundtrip(aclient, db_session):
+    # Starts empty
+    r = await aclient.get("/follows")
+    assert r.status_code == 200
+    assert r.json() == []
+
+    # Follow a topic
+    r = await aclient.post("/follows", json={"kind": "topic", "value": "AI"})
+    assert r.status_code == 201
+    created = r.json()
+    assert created["kind"] == "topic"
+    assert created["value"] == "AI"
+    follow_id = created["id"]
+
+    # Shows up in the list
+    r = await aclient.get("/follows")
+    assert [f["value"] for f in r.json()] == ["AI"]
+
+    # Unfollow
+    r = await aclient.delete(f"/follows/{follow_id}")
+    assert r.status_code == 204
+    r = await aclient.get("/follows")
+    assert r.json() == []
+
+
+@pytest.mark.asyncio
+async def test_follow_is_idempotent_on_user_kind_value(aclient, db_session):
+    a = await aclient.post("/follows", json={"kind": "topic", "value": "Climate"})
+    b = await aclient.post("/follows", json={"kind": "topic", "value": "Climate"})
+    assert a.status_code == 201 and b.status_code == 201
+    assert a.json()["id"] == b.json()["id"]  # same row, not a duplicate
+
+    count = (
+        await db_session.execute(
+            select(func.count()).select_from(Follow).where(Follow.value == "Climate")
+        )
+    ).scalar()
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_same_value_different_kind_are_distinct(aclient, db_session):
+    t = await aclient.post("/follows", json={"kind": "topic", "value": "Tesla"})
+    e = await aclient.post("/follows", json={"kind": "entity", "value": "Tesla"})
+    assert t.json()["id"] != e.json()["id"]
+    r = await aclient.get("/follows")
+    assert len(r.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_saved_search_kind_supported(aclient, db_session):
+    r = await aclient.post(
+        "/follows", json={"kind": "saved_search", "value": "opec production cuts"}
+    )
+    assert r.status_code == 201
+    assert r.json()["kind"] == "saved_search"
+
+
+@pytest.mark.asyncio
+async def test_invalid_kind_rejected_400_and_persists_nothing(aclient, db_session):
+    r = await aclient.post("/follows", json={"kind": "playlist", "value": "x"})
+    assert r.status_code == 400
+    r = await aclient.get("/follows")
+    assert r.json() == []
+
+
+@pytest.mark.asyncio
+async def test_delete_only_targets_the_requested_id(aclient, db_session):
+    """DELETE honors the WHERE id=… (proves it's not deleting an arbitrary row)."""
+    keep = (await aclient.post("/follows", json={"kind": "topic", "value": "Keep"})).json()
+    drop = (await aclient.post("/follows", json={"kind": "topic", "value": "Drop"})).json()
+
+    r = await aclient.delete(f"/follows/{drop['id']}")
+    assert r.status_code == 204
+
+    remaining = (await aclient.get("/follows")).json()
+    assert [f["id"] for f in remaining] == [keep["id"]]
+
+
+@pytest.mark.asyncio
+async def test_delete_unknown_id_is_noop_204(aclient, db_session):
+    r = await aclient.delete("/follows/123456")
+    assert r.status_code == 204

--- a/backend/tests/test_follows.py
+++ b/backend/tests/test_follows.py
@@ -1,0 +1,104 @@
+"""Standing follows (/follows) — behavior through the public HTTP interface.
+
+These use the mock-session harness (no Postgres needed). Kind validation (400),
+idempotency *branch*, and the GET/POST/DELETE shapes live here. Real-DB
+idempotency + WHERE-clause filtering live in tests/integration/test_follows.py.
+"""
+
+from httpx import AsyncClient
+
+from tests.conftest import FakeFollow, MockSession
+
+
+class TestFollowValidation:
+    """POST /follows — kind/value validation returns a clean 400 (not 422/500)."""
+
+    async def test_invalid_kind_returns_400(self, client: AsyncClient):
+        response = await client.post("/follows", json={"kind": "playlist", "value": "AI"})
+        assert response.status_code == 400
+
+    async def test_blank_value_returns_400(self, client: AsyncClient):
+        response = await client.post("/follows", json={"kind": "topic", "value": "   "})
+        assert response.status_code == 400
+
+    async def test_missing_value_returns_422(self, client: AsyncClient):
+        """Schema-level: a missing field is FastAPI's 422, before our 400 check."""
+        response = await client.post("/follows", json={"kind": "topic"})
+        assert response.status_code == 422
+
+
+class TestFollowList:
+    """GET /follows — the user's standing follows."""
+
+    async def test_empty_list(self, client: AsyncClient, mock_session: MockSession):
+        mock_session.follows = []
+        response = await client.get("/follows")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_returns_follows(self, client: AsyncClient, mock_session: MockSession):
+        mock_session.follows = [
+            FakeFollow(id=1, kind="topic", value="AI"),
+            FakeFollow(id=2, kind="saved_search", value="opec cuts"),
+            FakeFollow(id=3, kind="entity", value="Tesla"),
+        ]
+        response = await client.get("/follows")
+        assert response.status_code == 200
+        body = response.json()
+        assert {f["value"] for f in body} == {"AI", "opec cuts", "Tesla"}
+        assert {f["kind"] for f in body} == {"topic", "saved_search", "entity"}
+
+
+class TestFollowCreate:
+    """POST /follows — follow a topic/entity/saved_search."""
+
+    async def test_create_returns_201_with_row(
+        self, client: AsyncClient, mock_session: MockSession
+    ):
+        mock_session.follows = []  # nothing exists yet
+        response = await client.post("/follows", json={"kind": "topic", "value": "Climate"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["kind"] == "topic"
+        assert body["value"] == "Climate"
+        assert "id" in body and "created_at" in body
+        assert mock_session.committed is True  # a row was written
+
+    async def test_create_is_idempotent(
+        self, client: AsyncClient, mock_session: MockSession
+    ):
+        """Re-following an identical (kind, value) returns the existing row, no insert."""
+        mock_session.follows = [FakeFollow(id=7, kind="topic", value="Climate")]
+        response = await client.post("/follows", json={"kind": "topic", "value": "Climate"})
+        assert response.status_code == 201
+        assert response.json()["id"] == 7
+        assert mock_session.committed is False  # nothing new written
+
+    async def test_create_trims_value(
+        self, client: AsyncClient, mock_session: MockSession
+    ):
+        mock_session.follows = []
+        response = await client.post("/follows", json={"kind": "entity", "value": "  Tesla  "})
+        assert response.status_code == 201
+        assert response.json()["value"] == "Tesla"
+
+
+class TestFollowDelete:
+    """DELETE /follows/{id} — unfollow (idempotent: always 204)."""
+
+    async def test_delete_existing_removes_row(
+        self, client: AsyncClient, mock_session: MockSession
+    ):
+        follow = FakeFollow(id=5, kind="topic", value="AI")
+        mock_session.follows = [follow]
+        response = await client.delete("/follows/5")
+        assert response.status_code == 204
+        assert follow in mock_session.deleted_objects
+
+    async def test_delete_missing_is_noop_204(
+        self, client: AsyncClient, mock_session: MockSession
+    ):
+        mock_session.follows = []
+        response = await client.delete("/follows/999")
+        assert response.status_code == 204
+        assert mock_session.deleted_objects == []

--- a/frontend/src/app/following/following.test.tsx
+++ b/frontend/src/app/following/following.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/api", () => ({
+  getFollows: vi.fn(),
+  removeFollow: vi.fn(),
+}));
+
+import FollowingPage from "./page";
+import { getFollows, removeFollow } from "@/lib/api";
+
+describe("Following management view", () => {
+  beforeEach(() => {
+    vi.mocked(removeFollow).mockResolvedValue(undefined);
+    vi.mocked(getFollows).mockResolvedValue([
+      { id: 1, kind: "topic", value: "AI", created_at: "2026-06-24T00:00:00Z" },
+      { id: 2, kind: "saved_search", value: "opec cuts", created_at: "2026-06-24T00:00:00Z" },
+      { id: 3, kind: "entity", value: "Tesla", created_at: "2026-06-24T00:00:00Z" },
+    ]);
+  });
+
+  it("lists every follow, regardless of kind", async () => {
+    render(<FollowingPage />);
+    expect(await screen.findByText("AI")).toBeInTheDocument();
+    expect(screen.getByText("opec cuts")).toBeInTheDocument();
+    expect(screen.getByText("Tesla")).toBeInTheDocument();
+  });
+
+  it("unfollows an item with one tap and drops it from the list", async () => {
+    render(<FollowingPage />);
+    await screen.findByText("AI");
+
+    await userEvent.click(screen.getByRole("button", { name: /unfollow AI/i }));
+    expect(removeFollow).toHaveBeenCalledWith(1);
+
+    await waitFor(() => expect(screen.queryByText("AI")).toBeNull());
+    // The others are untouched.
+    expect(screen.getByText("opec cuts")).toBeInTheDocument();
+    expect(screen.getByText("Tesla")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when nothing is followed", async () => {
+    vi.mocked(getFollows).mockResolvedValue([]);
+    render(<FollowingPage />);
+    expect(
+      await screen.findByText(/not following anything yet/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/following/page.tsx
+++ b/frontend/src/app/following/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Button } from "@/components/ui/Button";
+import {
+  getFollows,
+  removeFollow,
+  type FollowItem,
+  type FollowKind,
+} from "@/lib/api";
+
+type PageState = "loading" | "success" | "empty" | "error";
+
+// Friendly labels — never surface the raw `kind` enum to the reader.
+const KIND_LABEL: Record<FollowKind, string> = {
+  topic: "Topic",
+  entity: "Entity",
+  saved_search: "Search",
+};
+
+export default function FollowingPage() {
+  const [state, setState] = useState<PageState>("loading");
+  const [follows, setFollows] = useState<FollowItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFollows = useCallback(async () => {
+    try {
+      setState("loading");
+      setError(null);
+      const data = await getFollows();
+      if (!data || data.length === 0) {
+        setFollows([]);
+        setState("empty");
+        return;
+      }
+      setFollows(data);
+      setState("success");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load your follows");
+      setState("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFollows();
+  }, [fetchFollows]);
+
+  const handleUnfollow = async (id: number) => {
+    const prev = follows;
+    const next = follows.filter((f) => f.id !== id);
+    setFollows(next); // optimistic
+    if (next.length === 0) setState("empty");
+    try {
+      await removeFollow(id);
+    } catch {
+      setFollows(prev); // rollback
+      setState("success");
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)]">
+      {/* Loading */}
+      {state === "loading" && (
+        <div className="pt-4 space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="skeleton h-16 w-full rounded-[var(--radius-md)]" />
+          ))}
+        </div>
+      )}
+
+      {/* Error */}
+      {state === "error" && (
+        <div className="flex flex-col items-center justify-center pt-[var(--space-3xl)] text-center">
+          <div className="w-12 h-12 rounded-full bg-[var(--dismiss-muted)] flex items-center justify-center mb-3">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--dismiss)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" />
+            </svg>
+          </div>
+          <p className="text-heading text-[var(--text-primary)]">Unable to load your follows</p>
+          {error && <p className="text-mono text-[var(--dismiss)] mt-1">{error}</p>}
+          <Button variant="secondary" onClick={fetchFollows} className="mt-3">
+            Try again
+          </Button>
+        </div>
+      )}
+
+      {/* Empty */}
+      {state === "empty" && (
+        <div className="flex flex-col items-center justify-center pt-[var(--space-3xl)] text-center">
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.3 }}
+            className="w-12 h-12 rounded-full bg-[var(--accent-subtle)] flex items-center justify-center mb-3"
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          </motion.div>
+          <p className="text-heading text-[var(--text-primary)]">Not following anything yet</p>
+          <p className="text-small text-[var(--text-muted)] mt-1.5 max-w-[280px]">
+            Follow a topic from your briefing, or save a search to keep tracking it here.
+          </p>
+          <Button
+            variant="secondary"
+            onClick={() => (window.location.href = "/")}
+            className="mt-4"
+          >
+            Browse stories
+          </Button>
+        </div>
+      )}
+
+      {/* List */}
+      {state === "success" && (
+        <div className="pt-3">
+          <div className="flex items-baseline justify-between mb-3">
+            <h1 className="text-hero text-[var(--text-primary)]">Following</h1>
+            <span className="text-mono text-[var(--text-ghost)]">
+              {follows.length} {follows.length === 1 ? "follow" : "follows"}
+            </span>
+          </div>
+
+          <AnimatePresence>
+            {follows.map((f) => (
+              <motion.div
+                key={f.id}
+                layout
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, x: -100 }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="py-3 border-b border-[var(--border-subtle)]">
+                  <div className="flex items-center gap-3">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-mono text-[var(--text-ghost)] uppercase mb-0.5">
+                        {KIND_LABEL[f.kind]}
+                      </p>
+                      <p className="text-title text-[var(--text-primary)] truncate">
+                        {f.value}
+                      </p>
+                    </div>
+
+                    {/* One-tap unfollow — amber "Following" chip; tapping removes it */}
+                    <button
+                      onClick={() => handleUnfollow(f.id)}
+                      aria-label={`Unfollow ${f.value}`}
+                      className="shrink-0 inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-mono whitespace-nowrap border border-[var(--accent-muted)] bg-[var(--accent-subtle)] text-[var(--accent)] hover:brightness-110 transition-[filter,colors] duration-[var(--duration-short)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                    >
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                      <span>Following</span>
+                    </button>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import { StoryCard } from "@/components/StoryCard";
 import { HeroStoryCard } from "@/components/HeroStoryCard";
 import { Chip } from "@/components/ui/Chip";
+import { FollowButton } from "@/components/ui/FollowButton";
 import { Button } from "@/components/ui/Button";
 import { StoryCardSkeleton } from "@/components/ui/Skeleton";
 import { DailyTriviaCard } from "@/components/ui/DailyTriviaCard";
@@ -172,6 +173,19 @@ export default function BriefingPage() {
                 {cat}
               </Chip>
             ))}
+          </div>
+        )}
+
+      {/* Follow the topic you've filtered to — kept quiet until a topic is picked */}
+      {(state === "success" || state === "refreshing") &&
+        activeCategory !== "All" && (
+          <div className="flex justify-end mb-2">
+            <FollowButton
+              key={activeCategory}
+              kind="topic"
+              value={activeCategory}
+              label="Follow topic"
+            />
           </div>
         )}
 

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { Input } from "@/components/ui/Input";
 import { Chip } from "@/components/ui/Chip";
+import { FollowButton } from "@/components/ui/FollowButton";
 import { search, type SearchResultItem } from "@/lib/api";
 import { storyHref } from "@/lib/utils";
 
@@ -152,10 +153,20 @@ export default function SearchPage() {
         )}
         {state === "done" && (
           <>
-            <p className="text-mono text-[var(--text-muted)] mb-[var(--space-md)]">
-              &ldquo;{submitted}&rdquo; &middot; {filtered.length}{" "}
-              {filtered.length === 1 ? "result" : "results"}
-            </p>
+            <div className="flex items-center justify-between gap-3 mb-[var(--space-md)]">
+              <p className="text-mono text-[var(--text-muted)]">
+                &ldquo;{submitted}&rdquo; &middot; {filtered.length}{" "}
+                {filtered.length === 1 ? "result" : "results"}
+              </p>
+              {submitted && (
+                <FollowButton
+                  key={submitted}
+                  kind="saved_search"
+                  value={submitted}
+                  label="Follow this search"
+                />
+              )}
+            </div>
             {filtered.length === 0 ? (
               <p className="text-small text-[var(--text-muted)]">
                 No stories match &mdash; try a broader query.

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -286,6 +287,38 @@ export default function ProfilePage() {
                   ))}
                 </div>
               </div>
+            </Card>
+          </motion.div>
+
+          {/* Following — manage standing follows */}
+          <motion.div variants={fadeUp} className="mb-4">
+            <Card variant="raised">
+              <Link
+                href="/following"
+                className="flex items-center justify-between p-3.5 group"
+              >
+                <div>
+                  <h2 className="text-heading text-[var(--text-primary)] mb-1">
+                    Following
+                  </h2>
+                  <p className="text-mono text-[var(--text-ghost)]">
+                    Topics, people and saved searches you track
+                  </p>
+                </div>
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="shrink-0 text-[var(--text-muted)] group-hover:text-[var(--text-secondary)] transition-colors"
+                >
+                  <path d="M9 18l6-6-6-6" />
+                </svg>
+              </Link>
             </Card>
           </motion.div>
 

--- a/frontend/src/components/ui/FollowButton.test.tsx
+++ b/frontend/src/components/ui/FollowButton.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/api", () => ({
+  getFollows: vi.fn(),
+  addFollow: vi.fn(),
+  removeFollow: vi.fn(),
+}));
+
+import { FollowButton } from "./FollowButton";
+import { getFollows, addFollow, removeFollow } from "@/lib/api";
+
+describe("FollowButton", () => {
+  beforeEach(() => {
+    vi.mocked(getFollows).mockResolvedValue([]);
+    vi.mocked(addFollow).mockResolvedValue({
+      id: 1,
+      kind: "topic",
+      value: "AI",
+      created_at: "2026-06-24T00:00:00Z",
+    });
+    vi.mocked(removeFollow).mockResolvedValue(undefined);
+  });
+
+  it("follows, then unfollows, reflecting state each way", async () => {
+    render(<FollowButton kind="topic" value="AI" />);
+
+    // Starts unfollowed (getFollows → []).
+    const btn = await screen.findByRole("button", { name: /^follow$/i });
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+
+    // Follow → POST with (kind, value), reflects "Following".
+    await userEvent.click(btn);
+    expect(addFollow).toHaveBeenCalledWith("topic", "AI");
+    await screen.findByRole("button", { name: /following/i });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+
+    // Unfollow → DELETE by the id returned from addFollow, back to "Follow".
+    await userEvent.click(screen.getByRole("button"));
+    expect(removeFollow).toHaveBeenCalledWith(1);
+    await screen.findByRole("button", { name: /^follow$/i });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("reflects an already-followed item on mount and unfollows by its id", async () => {
+    vi.mocked(getFollows).mockResolvedValue([
+      { id: 5, kind: "topic", value: "AI", created_at: "2026-06-24T00:00:00Z" },
+    ]);
+    render(<FollowButton kind="topic" value="AI" />);
+
+    const btn = await screen.findByRole("button", { name: /following/i });
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(btn);
+    expect(removeFollow).toHaveBeenCalledWith(5);
+    await screen.findByRole("button", { name: /^follow$/i });
+  });
+
+  it("matches an existing follow case- and whitespace-insensitively", async () => {
+    vi.mocked(getFollows).mockResolvedValue([
+      { id: 9, kind: "saved_search", value: "opec cuts", created_at: "x" },
+    ]);
+    render(<FollowButton kind="saved_search" value="  OPEC Cuts " label="Follow this search" />);
+    // Already-followed → shows the followed state despite case/whitespace differences.
+    await screen.findByRole("button", { name: /following/i });
+  });
+
+  it("uses a custom label for the unfollowed state", async () => {
+    render(<FollowButton kind="saved_search" value="opec" label="Follow this search" />);
+    await screen.findByRole("button", { name: /follow this search/i });
+  });
+
+  it("rolls back to unfollowed if the follow request fails", async () => {
+    vi.mocked(addFollow).mockRejectedValueOnce(new Error("network"));
+    render(<FollowButton kind="topic" value="AI" />);
+    const btn = await screen.findByRole("button", { name: /^follow$/i });
+
+    await userEvent.click(btn);
+    // After the failed request it returns to the unfollowed state.
+    await screen.findByRole("button", { name: /^follow$/i });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/frontend/src/components/ui/FollowButton.tsx
+++ b/frontend/src/components/ui/FollowButton.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+import {
+  addFollow,
+  getFollows,
+  removeFollow,
+  type FollowItem,
+  type FollowKind,
+} from "@/lib/api";
+
+interface FollowButtonProps {
+  kind: FollowKind;
+  value: string;
+  /** Text for the unfollowed state. Defaults to "Follow". The followed state
+   *  always reads "Following". */
+  label?: string;
+  className?: string;
+  /** Fired after a successful toggle, with the new state. */
+  onToggle?: (following: boolean) => void;
+}
+
+const norm = (s: string) => s.trim().toLowerCase();
+
+const PlusIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+/**
+ * A quiet, in-brand follow toggle. Monochrome until followed; amber only when
+ * active (design-system: "color is earned through action"). Self-discovers
+ * whether `(kind, value)` is already followed via getFollows().
+ */
+export function FollowButton({
+  kind,
+  value,
+  label = "Follow",
+  className,
+  onToggle,
+}: FollowButtonProps) {
+  const [following, setFollowing] = useState(false);
+  const [followId, setFollowId] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Reflect existing follow state on mount (and whenever the target changes).
+  useEffect(() => {
+    let alive = true;
+    getFollows()
+      .then((follows: FollowItem[]) => {
+        if (!alive) return;
+        const match = follows.find(
+          (f) => f.kind === kind && norm(f.value) === norm(value)
+        );
+        setFollowing(!!match);
+        setFollowId(match ? match.id : null);
+      })
+      .catch(() => {
+        /* offline — leave as unfollowed; the toggle still works */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [kind, value]);
+
+  async function toggle() {
+    if (busy) return;
+    setBusy(true);
+    if (following) {
+      // Optimistic unfollow, roll back on failure.
+      const prevId = followId;
+      setFollowing(false);
+      setFollowId(null);
+      try {
+        if (prevId != null) await removeFollow(prevId);
+        onToggle?.(false);
+      } catch {
+        setFollowing(true);
+        setFollowId(prevId);
+      } finally {
+        setBusy(false);
+      }
+    } else {
+      // Optimistic follow, roll back on failure.
+      setFollowing(true);
+      try {
+        const created = await addFollow(kind, value.trim());
+        setFollowId(created.id);
+        onToggle?.(true);
+      } catch {
+        setFollowing(false);
+      } finally {
+        setBusy(false);
+      }
+    }
+  }
+
+  return (
+    <motion.button
+      type="button"
+      whileTap={{ scale: 0.96 }}
+      transition={{ duration: 0.1 }}
+      onClick={toggle}
+      disabled={busy}
+      aria-pressed={following}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-mono whitespace-nowrap",
+        "transition-colors duration-[var(--duration-short)]",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]",
+        "disabled:opacity-60 disabled:pointer-events-none",
+        following
+          ? "border border-[var(--accent-muted)] bg-[var(--accent-subtle)] text-[var(--accent)]"
+          : "border border-[var(--border)] text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:border-[var(--text-muted)]",
+        className
+      )}
+    >
+      {following ? <CheckIcon /> : <PlusIcon />}
+      <span>{following ? "Following" : label}</span>
+    </motion.button>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -436,3 +436,35 @@ export async function createAdminSource(data: {
     body: JSON.stringify(data),
   });
 }
+
+/* ── Follows (standing follows: topics, entities, saved searches) ── */
+
+export type FollowKind = "topic" | "entity" | "saved_search";
+
+export interface FollowItem {
+  id: number;
+  kind: FollowKind;
+  value: string;
+  created_at: string;
+}
+
+/** All of the user's standing follows, newest first. */
+export async function getFollows(): Promise<FollowItem[]> {
+  return fetchJSON("/follows");
+}
+
+/** Follow a topic, entity, or saved search. Idempotent on (kind, value). */
+export async function addFollow(
+  kind: FollowKind,
+  value: string
+): Promise<FollowItem> {
+  return fetchJSON("/follows", {
+    method: "POST",
+    body: JSON.stringify({ kind, value }),
+  });
+}
+
+/** Unfollow by id. */
+export async function removeFollow(id: number): Promise<void> {
+  await fetchJSON(`/follows/${id}`, { method: "DELETE" });
+}


### PR DESCRIPTION
## Summary
Wires up **standing follows** end to end. The `/follows` API did not exist on any branch, so this PR builds the backend foundation **and** the UI.

**Backend**
- `Follow` model (`follows` table; unique on `user_id + kind + value`) + Alembic migration `c2a3b4d5e6f7`
- `GET/POST/DELETE /follows` — POST idempotent on `(user, kind, value)`, **400 on invalid kind**, ensure-user before the FK insert
- `FollowCreate` / `FollowOut` schemas

**Frontend**
- `api.ts`: `FollowItem`, `getFollows` / `addFollow` / `removeFollow`
- `FollowButton` — quiet/in-brand (mono pill, amber only when active); self-reflects followed state via `getFollows`; optimistic toggle with rollback
- **Search** → "Follow this search" (`saved_search`); **Briefing topic chips** → "Follow topic"
- `/following` management view (one-tap unfollow) + a Settings entry point

## Test plan
| Gate | Result |
|---|---|
| `npm run build` | ✅ (new `/following` route, TS clean) |
| `npx vitest run` | ✅ 30 passed (8 new: 5 FollowButton + 3 Following) |
| `npm run lint:copy` | ✅ 0 errors / 0 warnings |
| backend pytest (Docker) | ✅ mock 86 passed · integration 7 passed · migration applies clean end-to-end |

## Note on placement
"Follow topic" lives on the **briefing topic chips** (real category values) rather than `DeepDiveView`, whose cluster-detail response carries no topic/category field — flagged rather than expand a core endpoint. Trivia streak untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)