### PR TITLE
Wire follows UI onto the Wave C /follows API

### DIFF
--- a/frontend/src/app/following/following.test.tsx
+++ b/frontend/src/app/following/following.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/api", () => ({
+  getFollows: vi.fn(),
+  removeFollow: vi.fn(),
+}));
+
+import FollowingPage from "./page";
+import { getFollows, removeFollow } from "@/lib/api";
+
+describe("Following management view", () => {
+  beforeEach(() => {
+    vi.mocked(removeFollow).mockResolvedValue(undefined);
+    vi.mocked(getFollows).mockResolvedValue([
+      { id: 1, kind: "topic", value: "AI" },
+      { id: 2, kind: "saved_search", value: "opec cuts" },
+      { id: 3, kind: "entity", value: "Tesla" },
+    ]);
+  });
+
+  it("lists every follow, regardless of kind", async () => {
+    render(<FollowingPage />);
+    expect(await screen.findByText("AI")).toBeInTheDocument();
+    expect(screen.getByText("opec cuts")).toBeInTheDocument();
+    expect(screen.getByText("Tesla")).toBeInTheDocument();
+  });
+
+  it("unfollows an item with one tap and drops it from the list", async () => {
+    render(<FollowingPage />);
+    await screen.findByText("AI");
+
+    await userEvent.click(screen.getByRole("button", { name: /unfollow AI/i }));
+    expect(removeFollow).toHaveBeenCalledWith(1);
+
+    await waitFor(() => expect(screen.queryByText("AI")).toBeNull());
+    // The others are untouched.
+    expect(screen.getByText("opec cuts")).toBeInTheDocument();
+    expect(screen.getByText("Tesla")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when nothing is followed", async () => {
+    vi.mocked(getFollows).mockResolvedValue([]);
+    render(<FollowingPage />);
+    expect(
+      await screen.findByText(/not following anything yet/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/following/page.tsx
+++ b/frontend/src/app/following/page.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Button } from "@/components/ui/Button";
+import { getFollows, removeFollow, type FollowItem } from "@/lib/api";
+
+type PageState = "loading" | "success" | "empty" | "error";
+
+// Friendly labels — never surface the raw `kind` to the reader.
+// FollowItem.kind is a plain string; map known kinds, fall back to the raw value.
+const KIND_LABEL: Record<string, string> = {
+  topic: "Topic",
+  entity: "Entity",
+  saved_search: "Search",
+};
+
+export default function FollowingPage() {
+  const [state, setState] = useState<PageState>("loading");
+  const [follows, setFollows] = useState<FollowItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFollows = useCallback(async () => {
+    try {
+      setState("loading");
+      setError(null);
+      const data = await getFollows();
+      if (!data || data.length === 0) {
+        setFollows([]);
+        setState("empty");
+        return;
+      }
+      setFollows(data);
+      setState("success");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load your follows");
+      setState("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFollows();
+  }, [fetchFollows]);
+
+  const handleUnfollow = async (id: number) => {
+    const prev = follows;
+    const next = follows.filter((f) => f.id !== id);
+    setFollows(next); // optimistic
+    if (next.length === 0) setState("empty");
+    try {
+      await removeFollow(id);
+    } catch {
+      setFollows(prev); // rollback
+      setState("success");
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)]">
+      {/* Loading */}
+      {state === "loading" && (
+        <div className="pt-4 space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="skeleton h-16 w-full rounded-[var(--radius-md)]" />
+          ))}
+        </div>
+      )}
+
+      {/* Error */}
+      {state === "error" && (
+        <div className="flex flex-col items-center justify-center pt-[var(--space-3xl)] text-center">
+          <div className="w-12 h-12 rounded-full bg-[var(--dismiss-muted)] flex items-center justify-center mb-3">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--dismiss)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" />
+            </svg>
+          </div>
+          <p className="text-heading text-[var(--text-primary)]">Unable to load your follows</p>
+          {error && <p className="text-mono text-[var(--dismiss)] mt-1">{error}</p>}
+          <Button variant="secondary" onClick={fetchFollows} className="mt-3">
+            Try again
+          </Button>
+        </div>
+      )}
+
+      {/* Empty */}
+      {state === "empty" && (
+        <div className="flex flex-col items-center justify-center pt-[var(--space-3xl)] text-center">
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.3 }}
+            className="w-12 h-12 rounded-full bg-[var(--accent-subtle)] flex items-center justify-center mb-3"
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          </motion.div>
+          <p className="text-heading text-[var(--text-primary)]">Not following anything yet</p>
+          <p className="text-small text-[var(--text-muted)] mt-1.5 max-w-[280px]">
+            Follow a topic from your briefing, or save a search to keep tracking it here.
+          </p>
+          <Button
+            variant="secondary"
+            onClick={() => (window.location.href = "/")}
+            className="mt-4"
+          >
+            Browse stories
+          </Button>
+        </div>
+      )}
+
+      {/* List */}
+      {state === "success" && (
+        <div className="pt-3">
+          <div className="flex items-baseline justify-between mb-3">
+            <h1 className="text-hero text-[var(--text-primary)]">Following</h1>
+            <span className="text-mono text-[var(--text-ghost)]">
+              {follows.length} {follows.length === 1 ? "follow" : "follows"}
+            </span>
+          </div>
+
+          <AnimatePresence>
+            {follows.map((f) => (
+              <motion.div
+                key={f.id}
+                layout
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, x: -100 }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="py-3 border-b border-[var(--border-subtle)]">
+                  <div className="flex items-center gap-3">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-mono text-[var(--text-ghost)] uppercase mb-0.5">
+                        {KIND_LABEL[f.kind] ?? f.kind}
+                      </p>
+                      <p className="text-title text-[var(--text-primary)] truncate">
+                        {f.value}
+                      </p>
+                    </div>
+
+                    {/* One-tap unfollow — amber "Following" chip; tapping removes it */}
+                    <button
+                      onClick={() => handleUnfollow(f.id)}
+                      aria-label={`Unfollow ${f.value}`}
+                      className="shrink-0 inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-mono whitespace-nowrap border border-[var(--accent-muted)] bg-[var(--accent-subtle)] text-[var(--accent)] hover:brightness-110 transition-[filter,colors] duration-[var(--duration-short)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                    >
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                      <span>Following</span>
+                    </button>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import { StoryCard } from "@/components/StoryCard";
 import { HeroStoryCard } from "@/components/HeroStoryCard";
 import { Chip } from "@/components/ui/Chip";
+import { FollowButton } from "@/components/ui/FollowButton";
 import { Button } from "@/components/ui/Button";
 import { StoryCardSkeleton } from "@/components/ui/Skeleton";
 import { DailyTriviaCard } from "@/components/ui/DailyTriviaCard";
@@ -173,6 +174,19 @@ export default function BriefingPage() {
                 {cat}
               </Chip>
             ))}
+          </div>
+        )}
+
+      {/* Follow the topic you've filtered to — kept quiet until a topic is picked */}
+      {(state === "success" || state === "refreshing") &&
+        activeCategory !== "All" && (
+          <div className="flex justify-end mb-2">
+            <FollowButton
+              key={activeCategory}
+              kind="topic"
+              value={activeCategory}
+              label="Follow topic"
+            />
           </div>
         )}
 

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { Input } from "@/components/ui/Input";
 import { Chip } from "@/components/ui/Chip";
+import { FollowButton } from "@/components/ui/FollowButton";
 import { search, type SearchResultItem } from "@/lib/api";
 import { storyHref } from "@/lib/utils";
 
@@ -152,10 +153,20 @@ export default function SearchPage() {
         )}
         {state === "done" && (
           <>
-            <p className="text-mono text-[var(--text-muted)] mb-[var(--space-md)]">
-              &ldquo;{submitted}&rdquo; &middot; {filtered.length}{" "}
-              {filtered.length === 1 ? "result" : "results"}
-            </p>
+            <div className="flex items-center justify-between gap-3 mb-[var(--space-md)]">
+              <p className="text-mono text-[var(--text-muted)]">
+                &ldquo;{submitted}&rdquo; &middot; {filtered.length}{" "}
+                {filtered.length === 1 ? "result" : "results"}
+              </p>
+              {submitted && (
+                <FollowButton
+                  key={submitted}
+                  kind="saved_search"
+                  value={submitted}
+                  label="Follow this search"
+                />
+              )}
+            </div>
             {filtered.length === 0 ? (
               <p className="text-small text-[var(--text-muted)]">
                 No stories match &mdash; try a broader query.

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -286,6 +287,38 @@ export default function ProfilePage() {
                   ))}
                 </div>
               </div>
+            </Card>
+          </motion.div>
+
+          {/* Following — manage standing follows */}
+          <motion.div variants={fadeUp} className="mb-4">
+            <Card variant="raised">
+              <Link
+                href="/following"
+                className="flex items-center justify-between p-3.5 group"
+              >
+                <div>
+                  <h2 className="text-heading text-[var(--text-primary)] mb-1">
+                    Following
+                  </h2>
+                  <p className="text-mono text-[var(--text-ghost)]">
+                    Topics, people and saved searches you track
+                  </p>
+                </div>
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="shrink-0 text-[var(--text-muted)] group-hover:text-[var(--text-secondary)] transition-colors"
+                >
+                  <path d="M9 18l6-6-6-6" />
+                </svg>
+              </Link>
             </Card>
           </motion.div>
 

--- a/frontend/src/components/ui/FollowButton.test.tsx
+++ b/frontend/src/components/ui/FollowButton.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/api", () => ({
+  getFollows: vi.fn(),
+  addFollow: vi.fn(),
+  removeFollow: vi.fn(),
+}));
+
+import { FollowButton } from "./FollowButton";
+import { getFollows, addFollow, removeFollow } from "@/lib/api";
+
+describe("FollowButton", () => {
+  beforeEach(() => {
+    vi.mocked(getFollows).mockResolvedValue([]);
+    vi.mocked(addFollow).mockResolvedValue({ id: 1, kind: "topic", value: "AI" });
+    vi.mocked(removeFollow).mockResolvedValue(undefined);
+  });
+
+  it("follows, then unfollows, reflecting state each way", async () => {
+    render(<FollowButton kind="topic" value="AI" />);
+
+    // Starts unfollowed (getFollows → []).
+    const btn = await screen.findByRole("button", { name: /^follow$/i });
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+
+    // Follow → POST with (kind, value), reflects "Following".
+    await userEvent.click(btn);
+    expect(addFollow).toHaveBeenCalledWith("topic", "AI");
+    await screen.findByRole("button", { name: /following/i });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+
+    // Unfollow → DELETE by the id returned from addFollow, back to "Follow".
+    await userEvent.click(screen.getByRole("button"));
+    expect(removeFollow).toHaveBeenCalledWith(1);
+    await screen.findByRole("button", { name: /^follow$/i });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("reflects an already-followed item on mount and unfollows by its id", async () => {
+    vi.mocked(getFollows).mockResolvedValue([
+      { id: 5, kind: "topic", value: "AI" },
+    ]);
+    render(<FollowButton kind="topic" value="AI" />);
+
+    const btn = await screen.findByRole("button", { name: /following/i });
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(btn);
+    expect(removeFollow).toHaveBeenCalledWith(5);
+    await screen.findByRole("button", { name: /^follow$/i });
+  });
+
+  it("matches an existing follow case- and whitespace-insensitively", async () => {
+    vi.mocked(getFollows).mockResolvedValue([
+      { id: 9, kind: "saved_search", value: "opec cuts" },
+    ]);
+    render(<FollowButton kind="saved_search" value="  OPEC Cuts " label="Follow this search" />);
+    // Already-followed → shows the followed state despite case/whitespace differences.
+    await screen.findByRole("button", { name: /following/i });
+  });
+
+  it("uses a custom label for the unfollowed state", async () => {
+    render(<FollowButton kind="saved_search" value="opec" label="Follow this search" />);
+    await screen.findByRole("button", { name: /follow this search/i });
+  });
+
+  it("rolls back to unfollowed if the follow request fails", async () => {
+    vi.mocked(addFollow).mockRejectedValueOnce(new Error("network"));
+    render(<FollowButton kind="topic" value="AI" />);
+    const btn = await screen.findByRole("button", { name: /^follow$/i });
+
+    await userEvent.click(btn);
+    // After the failed request it returns to the unfollowed state.
+    await screen.findByRole("button", { name: /^follow$/i });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/frontend/src/components/ui/FollowButton.tsx
+++ b/frontend/src/components/ui/FollowButton.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+import { addFollow, getFollows, removeFollow, type FollowItem } from "@/lib/api";
+
+// The API client types `kind` as a plain string; constrain it here for the UI.
+type FollowKind = "topic" | "entity" | "saved_search";
+
+interface FollowButtonProps {
+  kind: FollowKind;
+  value: string;
+  /** Text for the unfollowed state. Defaults to "Follow". The followed state
+   *  always reads "Following". */
+  label?: string;
+  className?: string;
+  /** Fired after a successful toggle, with the new state. */
+  onToggle?: (following: boolean) => void;
+}
+
+const norm = (s: string) => s.trim().toLowerCase();
+
+const PlusIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+/**
+ * A quiet, in-brand follow toggle. Monochrome until followed; amber only when
+ * active (design-system: "color is earned through action"). Self-discovers
+ * whether `(kind, value)` is already followed via getFollows().
+ */
+export function FollowButton({
+  kind,
+  value,
+  label = "Follow",
+  className,
+  onToggle,
+}: FollowButtonProps) {
+  const [following, setFollowing] = useState(false);
+  const [followId, setFollowId] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Reflect existing follow state on mount (and whenever the target changes).
+  useEffect(() => {
+    let alive = true;
+    getFollows()
+      .then((follows: FollowItem[]) => {
+        if (!alive) return;
+        const match = follows.find(
+          (f) => f.kind === kind && norm(f.value) === norm(value)
+        );
+        setFollowing(!!match);
+        setFollowId(match ? match.id : null);
+      })
+      .catch(() => {
+        /* offline — leave as unfollowed; the toggle still works */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [kind, value]);
+
+  async function toggle() {
+    if (busy) return;
+    setBusy(true);
+    if (following) {
+      // Optimistic unfollow, roll back on failure.
+      const prevId = followId;
+      setFollowing(false);
+      setFollowId(null);
+      try {
+        if (prevId != null) await removeFollow(prevId);
+        onToggle?.(false);
+      } catch {
+        setFollowing(true);
+        setFollowId(prevId);
+      } finally {
+        setBusy(false);
+      }
+    } else {
+      // Optimistic follow, roll back on failure.
+      setFollowing(true);
+      try {
+        const created = await addFollow(kind, value.trim());
+        setFollowId(created.id);
+        onToggle?.(true);
+      } catch {
+        setFollowing(false);
+      } finally {
+        setBusy(false);
+      }
+    }
+  }
+
+  return (
+    <motion.button
+      type="button"
+      whileTap={{ scale: 0.96 }}
+      transition={{ duration: 0.1 }}
+      onClick={toggle}
+      disabled={busy}
+      aria-pressed={following}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-mono whitespace-nowrap",
+        "transition-colors duration-[var(--duration-short)]",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]",
+        "disabled:opacity-60 disabled:pointer-events-none",
+        following
+          ? "border border-[var(--accent-muted)] bg-[var(--accent-subtle)] text-[var(--accent)]"
+          : "border border-[var(--border)] text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:border-[var(--text-muted)]",
+        className
+      )}
+    >
+      {following ? <CheckIcon /> : <PlusIcon />}
+      <span>{following ? "Following" : label}</span>
+    </motion.button>
+  );
+}


### PR DESCRIPTION
## Summary
Builds the **standing-follows UI** on top of the existing **Wave C `/follows` API** (`getFollows` / `addFollow` / `removeFollow`). UI-only — no backend or `api.ts` changes.

- `FollowButton` — quiet/in-brand (mono pill, amber only when active); reflects followed state via `getFollows`; optimistic toggle with rollback
- **Search** → "Follow this search" (`saved_search`)
- **Briefing topic chips** → "Follow topic" (the selected category)
- `/following` management view (one-tap unfollow) + a Settings entry point

## Test plan
| Gate | Result |
|---|---|
| `npm run build` | ✅ (new `/following` route, TS clean against the real API) |
| `npx vitest run` | ✅ 44 passed (14 files; +8 new: 5 FollowButton, 3 Following) |
| `npm run lint:copy` | ✅ 0 errors / 0 warnings |

## Context
Supersedes #58 — that PR branched off a stale local `master` (pre-Wave-C) and rebuilt a duplicate `/follows` backend that conflicted with the canonical Wave C API. This PR keeps only the UI, on top of the existing API. "Follow topic" lives on the briefing topic chips (real category values); `DeepDiveView` carries no topic field. Trivia streak untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)