### PR TITLE
docs: sync brand + Android work across all docs (post #60/#61)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -232,6 +232,8 @@ flowchart LR
 
 Web builds use `rewrites()` to proxy `/api/*` to the backend. Capacitor builds use `NEXT_PUBLIC_API_BASE_URL` env var to point directly to the backend host.
 
+**Brand assets & splash.** The launcher icon, web/PWA favicons, and the native splash all derive from the official NewsLens brand kit (the single source of truth). They're generated **deterministically** (PowerShell `System.Drawing` high-quality resize) rather than via `@capacitor/assets`/`sharp`, which fail to load on Windows ARM (the current `@capacitor/assets` also emits broken adaptive output). The native splash is held by `@capacitor/splash-screen` (`launchAutoHide: false`, `#0C0C0E`) and hidden with a ~250 ms fade from `frontend/src/components/SplashScreen.tsx` once the web app paints — a controlled native-splash → WebView hand-off with no bare-WebView flash.
+
 ## Decision Log
 
 | Decision | Chosen | Alternative | Rationale |
@@ -246,3 +248,6 @@ Web builds use `rewrites()` to proxy `/api/*` to the backend. Capacitor builds u
 | Encryption | Fernet (symmetric) | RSA / AES-GCM | Simple, battle-tested; good for per-user key storage |
 | CSS | Tailwind CSS 4 | CSS Modules / styled-components | Utility-first; design token integration; small bundle |
 | Motion | Framer Motion | CSS animations | Complex gesture physics (swipe cards); declarative API |
+| Brand assets | Single source of truth (official NewsLens brand kit) | Ad-hoc per-surface art | One canonical mark/lockup; icons + splash regenerate from it, no drift |
+| Icon/splash generation | Deterministic `System.Drawing` resize | `@capacitor/assets` / `sharp` | sharp won't load on Windows ARM; current `@capacitor/assets` emits broken adaptive output (dangling background ref, undersized foregrounds) |
+| Splash control | `@capacitor/splash-screen` controlled fade | Default launch auto-hide | Holds the native splash until the WebView paints, then cross-fades — no white flash or hard cut |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ cd frontend && npm run apk:debug               # Build debug APK via Gradle
 
 NewsLens is an AI-powered news intelligence platform. Two-language stack: Python backend (data pipeline + ML) and TypeScript frontend (UI). They communicate via REST JSON — no shared types needed. Mobile builds use Capacitor to wrap the Next.js static export into a native Android WebView app.
 
-**Stack:** Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Python FastAPI, PostgreSQL + pgvector, OpenAI API, APScheduler, Capacitor (Android)
+**Stack:** Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Python FastAPI, PostgreSQL + pgvector, OpenAI API, APScheduler, Capacitor (Android) + `@capacitor/splash-screen`
 
 **Key architectural decisions:**
 - pgvector nearest-neighbor SQL for clustering (not Python pairwise — O(n) vs O(n²))
@@ -53,6 +53,8 @@ NewsLens is an AI-powered news intelligence platform. Two-language stack: Python
 - Per-user OpenAI API key with Fernet encryption + env var fallback
 - Capacitor static export with conditional `next.config.ts` (`BUILD_TARGET=capacitor`)
 - Dual story routes: `/story/[clusterId]` (web dynamic) + `/story?id=X` (Capacitor static export)
+- Brand assets (adaptive launcher icon, native splash, favicons) regenerate from one official brand kit via deterministic `System.Drawing` resize — `@capacitor/assets`/`sharp` are broken on Windows ARM (see Windows ARM Notes)
+- `@capacitor/splash-screen` holds the native splash (`launchAutoHide: false`) and cross-fades into the in-app splash on native
 
 ## Directory Structure
 
@@ -94,7 +96,8 @@ news-app/
 │   │   │   │   └── page.tsx          # OpenAI API key management
 │   │   │   └── story/
 │   │   │       ├── [clusterId]/
-│   │   │       │   └── page.tsx      # Deep dive (web — dynamic route)
+│   │   │       │   ├── page.tsx      # Deep dive (web — dynamic route)
+│   │   │       │   └── loading.tsx   # Route loading skeleton (StoryLoadingSkeleton)
 │   │   │       ├── page.tsx          # Deep dive (Capacitor — query param)
 │   │   │       └── StoryContent.tsx  # Client component for query-param routing
 │   │   ├── components/
@@ -108,7 +111,7 @@ news-app/
 │   │   │       ├── AISummaryBox.tsx  # AI-generated summary display
 │   │   │       ├── Badge.tsx         # Topic/category badge
 │   │   │       ├── ConfidenceScore.tsx # src:N · coh:0.XX display
-│   │   │       └── Skeleton.tsx      # Loading skeleton shimmer
+│   │   │       └── Skeleton.tsx      # Skeletons: StoryCard / DeepDive / StoryLoading
 │   │   └── lib/
 │   │       ├── api.ts                # API client (env-aware base URL)
 │   │       └── utils.ts              # cn() utility (clsx + tailwind-merge)
@@ -183,7 +186,7 @@ Implementation lives in `frontend/src/app/globals.css`.
 Do not deviate without explicit user approval.
 In QA mode, flag any code that doesn't match design-system.md.
 
-Key tokens: dark bg `#0C0C0E`, accent amber `#F97316`, fonts Instrument Serif (display) + DM Sans (body) + JetBrains Mono (data).
+Key tokens: dark bg `#0C0C0E`, accent amber `#F97316`, fonts **Fraunces** (display/wordmark — the app's override of the kit's Instrument Serif) + DM Sans (body) + JetBrains Mono (data). Brand assets come from the official NewsLens brand kit (single source of truth); see design-system.md → "Brand & App Identity".
 
 ## Windows ARM Notes
 
@@ -193,6 +196,7 @@ This project is developed on Windows 11 ARM (win32/arm64). Several tools have co
 - **Backend:** `greenlet` DLL load failure breaks SQLAlchemy async on native Windows ARM. Run backend in Docker instead.
 - **Android emulator:** Does not work on Windows ARM — QEMU2 can't run ARM64 guest images on x86_64 host binary (via WOW64), and x86_64 guests need Intel/AMD hardware virtualization. Use a physical Android device for testing.
 - **JDK:** Capacitor Android builds require JDK 21 (JDK 17 insufficient).
+- **Icon/splash generation:** `sharp`/`@capacitor/assets` don't load on Windows ARM (QEMU amd64 emulation segfaults libvips), and the current `@capacitor/assets` emits broken adaptive output (dangling `@mipmap/ic_launcher_background`, undersized 48px foregrounds). Regenerate launcher icons + splash deterministically via PowerShell `System.Drawing` (high-quality resize) from the official brand kit — never hand-edit the per-density PNGs.
 
 ## Mobile / Android Build
 
@@ -212,7 +216,9 @@ cd frontend && npm run apk:debug      # Step 5
 # Output: frontend/android/app/build/outputs/apk/debug/app-debug.apk
 ```
 
-**Capacitor config:** `frontend/capacitor.config.ts` — appId: `com.newslens.app`, webDir: `out`
+**Capacitor config:** `frontend/capacitor.config.ts` — appId: `com.newslens.app`, webDir: `out`, `SplashScreen` plugin (`launchAutoHide: false` → controlled fade; `SplashScreen.tsx` calls `hide()` on native).
+
+**After building, verify on a physical device** (no emulator on Windows ARM) — see the [on-device checklist in CONTRIBUTING.md](CONTRIBUTING.md#on-device-verification-after-an-android-build).
 
 ## Build & Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,30 @@ npm run apk:debug                  # Gradle build
 
 > **Windows ARM:** Android emulator doesn't work. Test on a physical device by transferring the APK.
 
+> The launcher icon, web/PWA favicons, and splash images come from the official NewsLens brand kit and are generated **deterministically** (PowerShell `System.Drawing` high-quality resize) — `sharp`/`@capacitor/assets` don't load on Windows ARM, and the current `@capacitor/assets` emits broken adaptive output. Regenerate via that pipeline; don't hand-edit the per-density PNGs.
+
+## On-Device Verification (after an Android build)
+
+The Android emulator does not run on Windows ARM, so a built APK must be checked on a **physical device**. After `npm run build:android && npm run apk:debug`, install `frontend/android/app/build/outputs/apk/debug/app-debug.apk` (USB transfer or `adb install`) and walk this checklist:
+
+**Launcher icon**
+- [ ] Shows the NewsLens mark (square brackets + amber dot) on the dark `#0C0C0E` tile — not the old generic / Android-robot icon.
+- [ ] Under every shape the launcher applies (circle, squircle, rounded square), the mark stays centered and is **not cropped** — the adaptive safe zone holds.
+- [ ] Crisp at launcher, app-switcher, and Settings → Apps sizes (per-density assets, no upscaling blur).
+
+**Cold-start splash**
+- [ ] A cold launch shows the mark + "NewsLens" wordmark centered on `#0C0C0E`.
+- [ ] No white/black flash before the splash paints (brand-dark window background).
+- [ ] The native splash holds until the app is ready, then cross-fades (~250 ms) into the in-app splash — no hard cut or blank gap.
+- [ ] Renders centered in both portrait and landscape.
+
+**First-run & loading**
+- [ ] `/welcome` → `/onboarding` reads as one flow (same mono eyebrow + italic Fraunces headline); welcome slide 1 shows the framed spotlight (mark in a ring with outer source ticks).
+- [ ] Opening a story shows a content-shaped skeleton (title / summary / source rows), not a generic spinner.
+
+**Smoke**
+- [ ] Briefing, Discover, and a Deep Dive load against the configured backend (`build:android` → `http://10.0.2.2:8000`; `build:android:prod` → the deployed backend).
+
 ## Code Style
 
 - **Python:** Enforced by `ruff` — run `cd backend && ruff check .`

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -109,5 +109,5 @@ Data Retention
 - **SSE real-time updates** — APScheduler refreshes every 10 min, sufficient for MVP
 - **Admin endpoints** — Developer-only monitoring, not user-facing
 - **Landscape orientation** — Mobile news readers used in portrait 95%+ of the time
-- **Custom app icon** — Cosmetic, zero impact on product value
+- **Custom app icon** — ✅ shipped anyway: full brand alignment (adaptive launcher icon, native splash, favicons) from the official NewsLens brand kit; the default Capacitor robot is gone
 - **Multi-language** — English-only MVP is appropriate for initial user base

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An AI-powered news intelligence platform. NewsLens ingests articles from RSS fee
 | Backend | Python, FastAPI, APScheduler |
 | Database | PostgreSQL + pgvector |
 | ML | OpenAI `text-embedding-3-small`, pgvector cosine clustering |
-| Mobile | Capacitor (Android) |
+| Mobile | Capacitor (Android) + `@capacitor/splash-screen` |
 
 ## Quick start
 
@@ -65,6 +65,8 @@ npm run apk:debug       # build debug APK via Gradle
 
 `npm run build:android:prod` points the APK at the deployed backend instead of localhost. Requires JDK 21. The Android emulator does not work on Windows ARM — test on a physical device.
 
+The app ships the official NewsLens brand: an adaptive launcher icon and a cold-start splash (the mark + "NewsLens" wordmark on `#0C0C0E`) that `@capacitor/splash-screen` holds until the web app paints, then cross-fades into the in-app splash. After building, walk the [on-device verification checklist](CONTRIBUTING.md#on-device-verification-after-an-android-build).
+
 ## Testing
 
 ```bash
@@ -79,7 +81,7 @@ cd frontend && npx playwright test  # E2E
 |-----|--------------|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | System, pipeline, and DB diagrams; decision log |
 | [DEPLOY.md](DEPLOY.md) | Deploying to Render or Fly.io; env var reference |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | Developer onboarding |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Developer onboarding + on-device APK verification checklist |
 | [design-system.md](design-system.md) | Colors, typography, spacing — read before any UI change |
 | [ROADMAP.md](ROADMAP.md) / [PRODUCT_ROADMAP.md](PRODUCT_ROADMAP.md) | Feature roadmap + known limitations |
 | [CLAUDE.md](CLAUDE.md) | Commands, architecture notes, platform caveats |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,7 @@
 - Feedback-driven explore/exploit (0.3 is now only a cold-start fallback; swipes move weights)
 - Design system: Full spec + CSS token implementation
 - Mobile: Capacitor Android APK builds
+- Brand: authentic NewsLens launcher icon (adaptive) + native splash (mark + Fraunces wordmark on #0C0C0E) + web/PWA favicons, all from the official brand kit; `@capacitor/splash-screen` controlled splash → WebView fade
 - Per-user OpenAI + Gemini API key management with Fernet encryption
 
 **Still stubbed / heuristic:**
@@ -76,8 +77,8 @@ Implement in briefing screen. Full spec exists in `design-system.md` (threshold:
 ### 3.4 Orientation Handling
 Landscape card sizing per design-system.md: `min(360px, 60vh)` card height, percentage-based swipe thresholds.
 
-### 3.5 Custom App Icon
-Replace default Capacitor launcher icon with NewsLens branding. Current icon is the default Android bot.
+### 3.5 Custom App Icon ✅ Shipped
+The default Capacitor robot is gone — adaptive launcher icon, native splash, and web/PWA favicons are regenerated from the official NewsLens brand kit. See [Brand & App Identity](design-system.md#brand--app-identity).
 
 ---
 
@@ -90,3 +91,4 @@ Replace default Capacitor launcher icon with NewsLens branding. Current icon is 
 | Android emulator doesn't work | Use physical device or skip | QEMU2 + WOW64 incompatibility on ARM |
 | Dynamic routes fail in Capacitor build | Dual routing: `[clusterId]` (web) + `?id=X` (Capacitor) | Next.js static export can't handle dynamic segments |
 | JDK 17 insufficient for Capacitor | JDK 21 required | Capacitor Android Gradle config targets Java 21 |
+| `@capacitor/assets` / `sharp` can't generate icons | Deterministic `System.Drawing` resize from the brand kit | sharp won't load on Windows ARM; current `@capacitor/assets` emits broken adaptive output |

--- a/design-system.md
+++ b/design-system.md
@@ -16,22 +16,33 @@
 - **Core principle:** Monochromatic until the user interacts — color is earned through action, not decoration
 - **Anti-patterns:** No purple gradients, no 3-column icon grids, no centered everything, no uniform bubbly border-radius, no stock photo hero sections
 
+## Brand & App Identity
+
+> **Single source of truth:** all brand assets derive from the official NewsLens brand kit. Icons and splash are regenerated from it — never hand-drawn per surface.
+
+- **The mark.** Two editorial brackets `[ ]` close in on a field of faint source ticks and hold a single amber dot — "ten headlines, one story." Middle tick brighter (`--text-primary`), top/bottom ghost (`--text-ghost`), focal dot amber (`--accent`). At small sizes the ticks drop and it resolves to `[ • ]`. Never recolour the brackets; amber lives only on the dot (or on "Lens") — one accent per composition. Implemented as `BrandMark` in `frontend/src/components/ui/BrandMark.tsx`.
+- **Logo lockup.** `Logo` = mark + "NewsLens" wordmark — **News** in `--text-primary`, **Lens** in `--accent`, in **Fraunces, upright** (see Typography). Body headlines use *italic* Fraunces; the wordmark/logotype stays upright as house style.
+- **App / launcher icon.** A flat `#0C0C0E` tile with the mark inset to ~44% — the OS applies the mask. Android adaptive icon = `@color/ic_launcher_background` (`#0C0C0E`) + a transparent mark foreground (`@mipmap/ic_launcher_foreground`); the ~44% inset keeps the mark inside the adaptive safe zone (no cropping under circle / squircle / rounded-square masks). Per-density assets in `frontend/android/app/src/main/res/mipmap-*`.
+- **Favicon.** Bolder, **ticks dropped** (`frontend/public/favicon.svg`) so the mark reads at 16 px; the web app icon (`frontend/src/app/icon.svg`) keeps the ticks.
+- **Native splash.** Mark + "NewsLens" wordmark centered on `#0C0C0E` (`frontend/android/.../res/drawable*/splash.png`). The launch window is backed with `#0C0C0E` so nothing flashes before it paints; `@capacitor/splash-screen` holds it and cross-fades into the in-app splash once the web app is ready.
+- **Brand colours.** BG `#0C0C0E` · text `#E4E4E7` · amber `#F97316` (dark) / `#EA580C` (light) · ghost ticks `#3F3F46`. (Full token table under [Color](#color).)
+
 ## Typography
-- **Display/Hero:** Instrument Serif (italic) — editorial broadsheet elegance with hand-set quality. Used for all headlines, story titles, briefing headers
+- **Display/Hero:** Fraunces — editorial broadsheet elegance with hand-set quality. Used for all headlines, story titles, briefing headers, and the wordmark. Default upright; *italic* is used selectively for emphasis (welcome/onboarding headlines, the deep-dive lead, pull-quotes). _The official brand kit specifies Instrument Serif for the wordmark; the app deliberately implements **Fraunces** as a house-style choice — the wordmark/logotype renders upright._
 - **Body:** DM Sans — geometric sans with warmth. Slightly wider than typical UI fonts for a declassified-document feel. Used for summaries, descriptions, UI text
 - **UI/Labels:** DM Sans (same as body, 500 weight for emphasis)
 - **Data/Tables:** JetBrains Mono — tabular figures, ligatures make data feel intentional. Used for timestamps, source counts, confidence scores, metadata
 - **Code:** JetBrains Mono
-- **Loading:** Google Fonts CDN — `https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=JetBrains+Mono:wght@400;500&display=swap`
+- **Loading:** `next/font/google` in `frontend/src/app/layout.tsx` — Fraunces (400–700, normal + italic), DM Sans, JetBrains Mono — self-hosted, exposed as CSS vars `--font-fraunces` / `--font-dm-sans` / `--font-jetbrains-mono`
 - **Scale:**
-  - Hero: 28px / 1.2 line-height / -0.02em tracking (Instrument Serif italic)
-  - Title: 22px / 1.3 line-height / -0.01em tracking (Instrument Serif italic)
-  - Heading: 17px / 1.35 line-height (Instrument Serif italic)
+  - Hero: 28px / 1.2 line-height / -0.02em tracking (Fraunces)
+  - Title: 22px / 1.3 line-height / -0.01em tracking (Fraunces)
+  - Heading: 17px / 1.35 line-height (Fraunces)
   - Body: 15px / 1.7 line-height (DM Sans)
   - Small: 13px / 1.5 line-height (DM Sans)
   - Caption: 12px / 1.4 line-height (DM Sans)
   - Mono: 11px / 1.6 line-height / 0.05em tracking (JetBrains Mono)
-  - Category label: 12px / uppercase / 0.15em tracking (Instrument Serif)
+  - Category label: 12px / uppercase / 0.15em tracking (Fraunces)
 
 ## Color
 
@@ -118,7 +129,7 @@ One chromatic accent (warm amber) + monochrome neutrals. Semantic colors appear 
 
 ### Story Card (Briefing)
 - Unread amber dot (6px) before title
-- Title in Instrument Serif italic (17px)
+- Title in Fraunces italic (17px)
 - 1-2 sentence summary in DM Sans (14px, secondary color)
 - Metadata row: `src:N` in accent, `coh:0.XX` in muted, relative time in ghost
 - 1px hairline separator, 32px vertical gap between stories
@@ -126,7 +137,7 @@ One chromatic accent (warm amber) + monochrome neutrals. Semantic colors appear 
 ### Discover Card (Swipe)
 - No images — text-only cards
 - Topic badge (top-right, colored by category)
-- Tension line: single sentence in Instrument Serif italic (22px) — the core conflict
+- Tension line: single sentence in Fraunces italic (22px) — the core conflict
 - 3 bullet sourced facts in DM Sans (14px)
 - Footer: source names (mono 11px) + confidence score (mono 11px ghost)
 - Stack: 3 cards visible (top active, 2 behind at 0.97/0.94 scale, 0.6/0.3 opacity)
@@ -154,7 +165,7 @@ One chromatic accent (warm amber) + monochrome neutrals. Semantic colors appear 
 - Active segment: amber fill
 - Inactive segments: surface-raised fill
 - Segments represent: Briefing | Discover | Deep Dive
-- Brand "NewsLens" in header: Instrument Serif 28px, "News" in primary, "Lens" in accent
+- Brand "NewsLens" in header: Fraunces (upright), "News" in primary, "Lens" in accent
 
 ### Loading States
 - Skeleton shimmer matching content layout
@@ -637,3 +648,5 @@ returned → resting (snap back with spring)
 | 2026-03-26 | Mobile viewport specs added | Pixel-precise per-screen layouts, safe areas, device tiers, responsive card heights |
 | 2026-03-26 | Settings screen as utility page | Gear icon in NavBar (not a nav segment) — settings is utility, not primary workflow |
 | 2026-03-26 | Per-user encrypted API key storage | Fernet encryption in DB, env var fallback, forward-compatible with multi-user |
+| 2026-06-24 | Fraunces (not Instrument Serif) as display/wordmark font | House-style override of the brand kit; wordmark renders upright, body headlines use italic Fraunces |
+| 2026-06-24 | Brand assets from one official kit, generated deterministically | Removed the default Capacitor robot; adaptive launcher + native splash + favicons regenerate from the kit (System.Drawing on Windows ARM) |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -4,7 +4,7 @@ Frontend-specific guidance for Claude Code. See also `../CLAUDE.md` for full-sta
 
 ## Stack
 
-Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Capacitor (Android).
+Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Capacitor (Android) + `@capacitor/splash-screen`.
 
 **Important:** Always use `--webpack` flag for builds — Turbopack is broken on Windows ARM. This is already configured in `package.json` scripts.
 
@@ -44,7 +44,7 @@ layout.tsx (NavBar)
 
 Visual specs live in `../design-system.md`. CSS token implementation in `src/app/globals.css`.
 
-Key tokens: dark bg `#0C0C0E`, accent amber `#F97316`, fonts Instrument Serif (display) + DM Sans (body) + JetBrains Mono (data).
+Key tokens: dark bg `#0C0C0E`, accent amber `#F97316`, fonts **Fraunces** (display/wordmark — overrides the kit's Instrument Serif) + DM Sans (body) + JetBrains Mono (data). Brand assets (icons/splash) come from the official NewsLens brand kit.
 
 ## Capacitor / Static Export
 
@@ -57,3 +57,5 @@ Build commands:
 npm run build:android    # Static export + cap sync
 npm run apk:debug       # Gradle assembleDebug
 ```
+
+**Splash:** `@capacitor/splash-screen` holds the native splash (`launchAutoHide: false`, `#0C0C0E`) and `src/components/SplashScreen.tsx` calls `SplashScreen.hide({ fadeOutDuration: 250 })` on native once the web overlay paints — a controlled native-splash → WebView fade. Native splash images + launcher icon come from the official brand kit. Verify on a physical device after building (no emulator on Windows ARM).


### PR DESCRIPTION
Post-ship documentation sync for the brand + Android work shipped in #60 and #61. Docs only — no code changes.

## What changed
- **design-system.md** — new **Brand & App Identity** section (mark, logo lockup, launcher icon, favicon, native splash, palette); display font corrected Instrument Serif → **Fraunces** (the app's documented house-style override — wordmark upright, body headlines italic); decision-log rows.
- **CONTRIBUTING.md** — new **On-Device Verification** checklist to run after `npm run build:android && npm run apk:debug` (launcher icon under adaptive masks, cold-start splash + controlled fade, welcome → onboarding flow, smoke) — there's no Android emulator on Windows ARM.
- **README / ARCHITECTURE / CLAUDE.md / frontend/CLAUDE.md** — brand kit as single source of truth; `@capacitor/splash-screen` controlled native-splash → WebView fade; deterministic icon/splash generation via `System.Drawing` (`sharp` / `@capacitor/assets` are broken on Windows ARM); new files (story `loading.tsx`, `colors.xml`, `StoryLoadingSkeleton`); stack + Windows-ARM notes.
- **ROADMAP / PRODUCT_ROADMAP** — custom-app-icon item marked shipped; Windows-ARM icon-generation limitation added.

## Documentation health
| Doc | Status |
|-----|--------|
| README.md | Updated — mobile/brand note + checklist link |
| ARCHITECTURE.md | Updated — splash plugin para + 3 decision-log rows |
| CONTRIBUTING.md | Updated — on-device verification checklist |
| design-system.md | Updated — Brand & App Identity + Fraunces correction |
| ROADMAP.md / PRODUCT_ROADMAP.md | Updated — icon shipped + Win-ARM limitation |
| CLAUDE.md / frontend/CLAUDE.md | Updated — brand kit, splash, Win-ARM notes |
| CHANGELOG / VERSION | N/A (neither exists in the repo) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
