### PR TITLE
Wave D Phase 3 — G1: global entity backbone (who/what is in a story + how stories connect)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1275,6 +1275,13 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
     db.add(f)
     await db.commit()
     await db.refresh(f)
+    if kind == "entity":
+        # G1 S7: opportunistically resolve the followed entity to a graph node (resolution only —
+        # no follows.entity_id column, no merge re-point; both are deferred to G2).
+        from app.services import entities
+
+        eid = await entities.resolve_existing(db, value)
+        logger.info("entity_follow_resolved", value=value, entity_id=eid)
     return FollowOut.model_validate(f)
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1214,6 +1214,22 @@ async def cluster_timeline(cluster_id: int, db: AsyncSession = Depends(get_db)):
     return await lenses.timeline(db, cluster_id)
 
 
+@router.get("/clusters/{cluster_id}/entities", dependencies=[Depends(get_current_user)])
+async def cluster_entities_endpoint(cluster_id: int, db: AsyncSession = Depends(get_db)):
+    """G1 cast strip: who/what is in this story (salient entities), highest-salience first."""
+    from app.services import entities
+
+    return await entities.cluster_entities(db, cluster_id)
+
+
+@router.get("/entities/{entity_id}/clusters", dependencies=[Depends(get_current_user)])
+async def entity_clusters_endpoint(entity_id: int, db: AsyncSession = Depends(get_db)):
+    """G1 'appears in' rail: other recent stories touching this entity."""
+    from app.services import entities
+
+    return await entities.entity_clusters(db, entity_id)
+
+
 @router.get("/auth/me")
 async def auth_me(user: User = Depends(get_current_user)):
     """Resolve the caller from the Firebase ID token (or the default user when unauthenticated).

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -72,6 +72,7 @@ class Settings(BaseSettings):
     graph_extract_batch_size: int = 20         # clusters per backfill run
     graph_extract_min_sources: int = 2         # only extract "settled" clusters (>= this many sources)
     graph_use_platform_key: bool = True        # extract on the platform key, never the owner's per-user key
+    graph_extract_interval_minutes: int = 15   # backfill cadence
 
     # DB SSL: verified by default for cloud (Neon/Supabase). Opt out only if a cert
     # chain genuinely can't be verified in your environment.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -64,6 +64,15 @@ class Settings(BaseSettings):
     # default false keeps single-user dev + the rollout window working.
     auth_required: bool = False
 
+    # G1 entity backbone (Wave D Phase 3). Extraction ships DARK (enable after monitoring skip rate).
+    graph_extraction_enabled: bool = False
+    graph_extraction_model: str = "gpt-4o-mini"
+    graph_max_entities_per_cluster: int = 12   # cast-strip cap + extraction salience cap
+    graph_salience_floor: float = 0.3          # drop entities below this salience at extraction
+    graph_extract_batch_size: int = 20         # clusters per backfill run
+    graph_extract_min_sources: int = 2         # only extract "settled" clusters (>= this many sources)
+    graph_use_platform_key: bool = True        # extract on the platform key, never the owner's per-user key
+
     # DB SSL: verified by default for cloud (Neon/Supabase). Opt out only if a cert
     # chain genuinely can't be verified in your environment.
     db_ssl_insecure: bool = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -137,6 +137,7 @@ async def start_scheduler():
     from app.services.clustering import run_clustering
     from app.services.summarizer import backfill_summaries
     from app.services.fetcher import backfill_topic_assignments
+    from app.services.entities import backfill_entities
 
     scheduler = AsyncIOScheduler()
     # One-shot: seed topic embeddings 10s after startup (non-blocking)
@@ -189,6 +190,18 @@ async def start_scheduler():
         minutes=settings.rss_fetch_interval_minutes,
         id="topic_assignment_backfill",
         replace_existing=True,
+    )
+    # G1: decoupled entity extraction on its own interval — max_instances=1 + coalesce so a slow
+    # LLM batch can never overlap itself or starve the clustering loop. Dark unless enabled.
+    scheduler.add_job(
+        backfill_entities,
+        "interval",
+        minutes=settings.graph_extract_interval_minutes,
+        id="entity_backfill",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=300,
     )
     scheduler.start()
     logger.info("scheduler_started", jobs=len(scheduler.get_jobs()))

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -312,6 +312,66 @@ class ClusterEdge(Base):
     )
 
 
+# ── G1: global entity backbone (Wave D Phase 3) ──────────────────────────────────────
+# Global, content-scoped (shared across users like articles/clusters) — NOT in _RLS_TABLES.
+# Resolution is case-insensitive via normalized columns (*_norm = value.lower()) + plain b-tree
+# indexes — avoids functional lower() indexes that trip Alembic autogenerate parity. No embedding
+# column in G1 (the NN tie-breaker + auto-merge are deferred to G2).
+
+
+class Entity(Base):
+    __tablename__ = "entities"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    canonical_name: Mapped[str] = mapped_column(Text, nullable=False)  # display form
+    name_norm: Mapped[str] = mapped_column(Text, nullable=False)  # lower(canonical_name) for lookup
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)  # person|org|place|other (convention)
+    description: Mapped[str | None] = mapped_column(Text)
+    first_seen: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_seen: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    mention_count: Mapped[int] = mapped_column(Integer, default=0)
+
+    __table_args__ = (
+        Index("ix_entities_kind_name", "kind", "name_norm"),  # exact resolution pre-filter
+    )
+
+
+class EntityAlias(Base):
+    __tablename__ = "entity_aliases"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    entity_id: Mapped[int] = mapped_column(
+        ForeignKey("entities.id", ondelete="CASCADE"), nullable=False
+    )
+    alias: Mapped[str] = mapped_column(Text, nullable=False)
+    alias_norm: Mapped[str] = mapped_column(Text, nullable=False)  # lower(alias)
+    source: Mapped[str | None] = mapped_column(String(32))
+
+    __table_args__ = (
+        UniqueConstraint("entity_id", "alias_norm", name="uq_entity_alias"),
+        Index("ix_entity_aliases_alias", "alias_norm"),
+    )
+
+
+class ArticleEntity(Base):
+    __tablename__ = "article_entities"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    article_id: Mapped[int] = mapped_column(
+        ForeignKey("articles.id", ondelete="CASCADE"), nullable=False
+    )
+    entity_id: Mapped[int] = mapped_column(
+        ForeignKey("entities.id", ondelete="CASCADE"), nullable=False
+    )
+    salience: Mapped[float] = mapped_column(Float, default=0.0)
+    confidence: Mapped[float] = mapped_column(Float, default=0.0)
+
+    __table_args__ = (
+        UniqueConstraint("article_id", "entity_id", name="uq_article_entity"),  # idempotent re-extract
+        Index("ix_article_entities_entity", "entity_id"),  # reverse "appears in" lookup
+    )
+
+
 # ── Row-Level Security (Wave D Phase A) ──────────────────────────────────────────────
 # Per-user tables are isolated by the `app.user_id` GUC, which get_current_user sets per request
 # (SET LOCAL). "Enforce-when-set": when the GUC is unset — background jobs reading the owner's API

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Annotated, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.models import EmbeddingStatus, FeedbackType, SourceType
 
@@ -332,3 +332,40 @@ class DigestResponse(BaseModel):
     count: int
     since: str
     items: list[DigestItem]
+
+
+# --- G1 entity extraction (Wave D Phase 3) ---
+_ENTITY_KINDS = {"person", "org", "place", "other"}
+
+
+class ExtractedEntity(BaseModel):
+    canonical_name: str
+    kind: str = "other"
+    salience: float = 0.0
+    aliases: list[str] = Field(default_factory=list)
+
+    @field_validator("canonical_name")
+    @classmethod
+    def _nonempty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("empty canonical_name")
+        return v.strip()
+
+    @field_validator("kind", mode="before")
+    @classmethod
+    def _norm_kind(cls, v) -> str:
+        s = str(v or "").strip().lower()
+        return s if s in _ENTITY_KINDS else "other"
+
+    @field_validator("salience", mode="before")
+    @classmethod
+    def _clamp_salience(cls, v) -> float:
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return 0.0
+        return max(0.0, min(1.0, f))
+
+
+class EntityExtraction(BaseModel):
+    entities: list[ExtractedEntity] = Field(default_factory=list)

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -67,6 +67,12 @@ def _get_client() -> AsyncOpenAI | None:
     return AsyncOpenAI(api_key=settings.openai_api_key)
 
 
+def _get_client_platform() -> AsyncOpenAI | None:
+    """Platform (env) key ONLY — never the per-user key. Background graph extraction uses this so it
+    bills the platform, not the owner's personal key (which _get_client_async would pick up)."""
+    return _get_client()
+
+
 async def _get_client_async() -> AsyncOpenAI | None:
     """Get OpenAI client: per-user DB key first, env var fallback."""
     user_key = await _get_user_api_key()

--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -7,11 +7,16 @@ G2 BREADCRUMB: any future LENS that reads graph output must widen its `_source_h
 entity ids + content version + persona/depth (+ user scope at G2), or it will serve stale/cross-tenant
 answers. The G1 endpoints are uncached pure-SQL reads, so the trap does not bite yet.
 """
+import structlog
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.models import ArticleEntity, ClusterArticle, Entity, StoryCluster
+from app.models import ArticleEntity, ClusterArticle, Entity, EntityAlias, StoryCluster
+from app.schemas import EntityExtraction
+from app.services import llm, retrieval
+
+logger = structlog.get_logger()
 
 
 async def cluster_entities(db: AsyncSession, cluster_id: int) -> list[dict]:
@@ -47,3 +52,94 @@ async def entity_clusters(db: AsyncSession, entity_id: int, limit: int = 10) -> 
     )
     rows = (await db.execute(q)).all()
     return [{"cluster_id": r.id, "title": r.title, "created_at": r.created_at} for r in rows]
+
+
+# ── Extraction + resolution (G1 S3-S4) ──────────────────────────────────────────────
+
+def build_extraction_prompt(cluster_text: str) -> str:
+    """The JSON shape lives in the PROMPT — llm.generate's `schema` arg only flips JSON mode on,
+    it does not enforce structure (EntityExtraction.model_validate is the real guard)."""
+    return (
+        "Extract the salient named entities from the news coverage below — only the people, "
+        "organizations, and places that genuinely matter to the story (not every proper noun).\n\n"
+        f"<coverage>\n{cluster_text}\n</coverage>\n\n"
+        "Respond ONLY as JSON of this exact shape:\n"
+        '{"entities": [{"canonical_name": "<full canonical name>", '
+        '"kind": "person|org|place|other", "salience": <0..1 importance to THIS story>, '
+        '"aliases": ["<other surface forms>"]}]}\n'
+        f"Return at most {settings.graph_max_entities_per_cluster} entities, highest salience first."
+    )
+
+
+async def extract_entities(cluster: StoryCluster, articles: list) -> EntityExtraction | None:
+    """One JSON-mode LLM pass over the cluster's full bodies (D1 seam). Returns the validated
+    extraction, or None when the model returns valid JSON of the wrong shape (logged + skipped)."""
+    text_ = retrieval.cluster_text(cluster, articles, depth_pref="standard")
+    raw = await llm.generate(
+        build_extraction_prompt(text_),
+        schema={"entities": []},  # truthy → JSON mode; contents ignored by llm.generate
+        model=settings.graph_extraction_model,
+    )
+    try:
+        return EntityExtraction.model_validate(raw)
+    except Exception as e:  # noqa: BLE001 — wrong-shape JSON is skipped, never fatal
+        logger.warning("entity_extraction_invalid", cluster_id=getattr(cluster, "id", None), error=str(e))
+        return None
+
+
+async def resolve_and_persist(db: AsyncSession, articles: list, extraction: EntityExtraction) -> None:
+    """Resolve each extracted entity (exact name → alias → create), attach its aliases, and link it
+    to the cluster's articles. Idempotent (uq_article_entity); precision-biased (no embedding NN /
+    auto-merge in G1). Flushes only — the caller owns the transaction/commit."""
+    article_ids = [a.id for a in articles]
+    selected = sorted(
+        (e for e in extraction.entities if e.salience >= settings.graph_salience_floor),
+        key=lambda e: e.salience,
+        reverse=True,
+    )[: settings.graph_max_entities_per_cluster]
+
+    for ext in selected:
+        q = ext.canonical_name.lower()
+        # 1. exact (kind, name_norm) — uses ix_entities_kind_name
+        entity = (
+            await db.execute(select(Entity).where(Entity.kind == ext.kind, Entity.name_norm == q))
+        ).scalar_one_or_none()
+        # 2. alias: the extracted name is a known alias of an existing entity
+        if entity is None:
+            ea = (
+                await db.execute(select(EntityAlias).where(EntityAlias.alias_norm == q))
+            ).scalars().first()
+            if ea is not None:
+                entity = await db.get(Entity, ea.entity_id)
+        # 3. create
+        if entity is None:
+            entity = Entity(canonical_name=ext.canonical_name, name_norm=q, kind=ext.kind)
+            db.add(entity)
+            await db.flush()
+
+        for al in ext.aliases:
+            aln = al.strip().lower()
+            if not aln or aln == entity.name_norm:
+                continue
+            dup = (
+                await db.execute(
+                    select(EntityAlias).where(
+                        EntityAlias.entity_id == entity.id, EntityAlias.alias_norm == aln
+                    )
+                )
+            ).scalar_one_or_none()
+            if dup is None:
+                db.add(EntityAlias(entity_id=entity.id, alias=al.strip(), alias_norm=aln, source="extraction"))
+
+        for aid in article_ids:
+            link = (
+                await db.execute(
+                    select(ArticleEntity).where(
+                        ArticleEntity.article_id == aid, ArticleEntity.entity_id == entity.id
+                    )
+                )
+            ).scalar_one_or_none()
+            if link is None:
+                db.add(ArticleEntity(article_id=aid, entity_id=entity.id,
+                                     salience=ext.salience, confidence=ext.salience))
+    await db.flush()

--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -55,6 +55,19 @@ async def entity_clusters(db: AsyncSession, entity_id: int, limit: int = 10) -> 
     return [{"cluster_id": r.id, "title": r.title, "created_at": r.created_at} for r in rows]
 
 
+async def resolve_existing(db: AsyncSession, value: str) -> int | None:
+    """G1 S7: exact-or-alias lookup for an entity by surface form → entity id, or None. A cheap
+    forward-compat hook for entity follows (resolution only — no follows schema change, no merge)."""
+    q = (value or "").strip().lower()
+    if not q:
+        return None
+    ent = (await db.execute(select(Entity).where(Entity.name_norm == q))).scalars().first()
+    if ent is not None:
+        return ent.id
+    ea = (await db.execute(select(EntityAlias).where(EntityAlias.alias_norm == q))).scalars().first()
+    return ea.entity_id if ea is not None else None
+
+
 # ── Extraction + resolution (G1 S3-S4) ──────────────────────────────────────────────
 
 def build_extraction_prompt(cluster_text: str) -> str:

--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.database import async_session
 from app.models import ArticleEntity, ClusterArticle, Entity, EntityAlias, StoryCluster
 from app.schemas import EntityExtraction
 from app.services import llm, retrieval
@@ -79,6 +80,7 @@ async def extract_entities(cluster: StoryCluster, articles: list) -> EntityExtra
         build_extraction_prompt(text_),
         schema={"entities": []},  # truthy → JSON mode; contents ignored by llm.generate
         model=settings.graph_extraction_model,
+        force_platform_key=settings.graph_use_platform_key,  # bill the platform, not the owner's key
     )
     try:
         return EntityExtraction.model_validate(raw)
@@ -143,3 +145,53 @@ async def resolve_and_persist(db: AsyncSession, articles: list, extraction: Enti
                 db.add(ArticleEntity(article_id=aid, entity_id=entity.id,
                                      salience=ext.salience, confidence=ext.salience))
     await db.flush()
+
+
+# ── Decoupled backfill job (G1 S5) ──────────────────────────────────────────────────
+
+async def backfill_entities() -> None:
+    """APScheduler job: extract entities for SETTLED, CHANGED clusters. Modeled on
+    summarizer.backfill_summaries — selects candidate ids in one session, then processes each in
+    its OWN session/transaction (independent of the already-committed clustering loop). On-change
+    skip via the source_hash stored in extra_json.graph. Dark unless graph_extraction_enabled."""
+    from app.services import lenses  # lazy — avoids any import-time weight/cycle
+
+    if not settings.graph_extraction_enabled:
+        return
+
+    async with async_session() as session:
+        rows = (
+            await session.execute(
+                select(StoryCluster.id)
+                .join(ClusterArticle, ClusterArticle.cluster_id == StoryCluster.id)
+                .group_by(StoryCluster.id)
+                .having(func.count(ClusterArticle.id) >= settings.graph_extract_min_sources)
+                .order_by(StoryCluster.created_at.desc())
+                .limit(settings.graph_extract_batch_size)
+            )
+        ).all()
+        cluster_ids = [r[0] for r in rows]
+
+    if not cluster_ids:
+        return
+
+    extracted = 0
+    for cid in cluster_ids:
+        async with async_session() as s:  # own session + transaction per cluster
+            cluster, articles = await lenses._load(s, cid)
+            if cluster is None or not articles:
+                continue
+            sh = lenses._source_hash(articles)
+            stored = (cluster.extra_json or {}).get("graph", {}).get("source_hash")
+            if stored == sh:
+                continue  # settled + unchanged → no-op (no LLM call)
+            ext = await extract_entities(cluster, articles)
+            if ext is None:
+                continue
+            await resolve_and_persist(s, articles, ext)
+            # write the on-change marker + commit (one commit per cluster, via the lens JSONB merge)
+            await lenses._cache_write(s, cluster, "extra_json", "graph", sh,
+                                      {"entities": len(ext.entities)})
+            extracted += 1
+
+    logger.info("entity_backfill_complete", candidates=len(cluster_ids), extracted=extracted)

--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -1,0 +1,49 @@
+"""G1: the global entity backbone.
+
+This module owns reading AND (in later slices) writing the backbone. The two read helpers below are
+pure SQL — they surface "who/what is in this story" + "what else touches them", no LLM.
+
+G2 BREADCRUMB: any future LENS that reads graph output must widen its `_source_hash` to include
+entity ids + content version + persona/depth (+ user scope at G2), or it will serve stale/cross-tenant
+answers. The G1 endpoints are uncached pure-SQL reads, so the trap does not bite yet.
+"""
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models import ArticleEntity, ClusterArticle, Entity, StoryCluster
+
+
+async def cluster_entities(db: AsyncSession, cluster_id: int) -> list[dict]:
+    """Cast strip: salient entities across this cluster's articles, deduped by entity (max salience),
+    highest-salience first, capped at graph_max_entities_per_cluster."""
+    sal = func.max(ArticleEntity.salience).label("salience")
+    q = (
+        select(Entity.id, Entity.canonical_name, Entity.kind, sal)
+        .join(ArticleEntity, ArticleEntity.entity_id == Entity.id)
+        .join(ClusterArticle, ClusterArticle.article_id == ArticleEntity.article_id)
+        .where(ClusterArticle.cluster_id == cluster_id)
+        .group_by(Entity.id, Entity.canonical_name, Entity.kind)
+        .order_by(sal.desc())
+        .limit(settings.graph_max_entities_per_cluster)
+    )
+    rows = (await db.execute(q)).all()
+    return [
+        {"id": r.id, "canonical_name": r.canonical_name, "kind": r.kind, "salience": r.salience}
+        for r in rows
+    ]
+
+
+async def entity_clusters(db: AsyncSession, entity_id: int, limit: int = 10) -> list[dict]:
+    """'Appears in' rail: other recent clusters whose articles mention this entity, newest first."""
+    q = (
+        select(StoryCluster.id, StoryCluster.title, StoryCluster.created_at)
+        .join(ClusterArticle, ClusterArticle.cluster_id == StoryCluster.id)
+        .join(ArticleEntity, ArticleEntity.article_id == ClusterArticle.article_id)
+        .where(ArticleEntity.entity_id == entity_id)
+        .group_by(StoryCluster.id, StoryCluster.title, StoryCluster.created_at)
+        .order_by(StoryCluster.created_at.desc())
+        .limit(limit)
+    )
+    rows = (await db.execute(q)).all()
+    return [{"cluster_id": r.id, "title": r.title, "created_at": r.created_at} for r in rows]

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -97,10 +97,17 @@ async def _resolve_gemini_key() -> str | None:
 
 async def _generate_openai(prompt: str, *, system: str | None = None,
                            schema=None, model: str | None = None,
-                           max_tokens: int | None = None):
+                           max_tokens: int | None = None,
+                           force_platform_key: bool = False):
     # Module ref (not a bound import) so tests can patch embeddings._get_client_async.
     from app.services import embeddings
-    client = await embeddings._get_client_async()
+    # force_platform_key: background jobs (graph extraction) bill the platform/env key, never the
+    # per-user key that _get_client_async resolves.
+    client = (
+        embeddings._get_client_platform()
+        if force_platform_key
+        else await embeddings._get_client_async()
+    )
     if client is None:
         raise LLMUnavailable("no OpenAI key configured")
     messages = []
@@ -122,8 +129,9 @@ async def _generate_openai(prompt: str, *, system: str | None = None,
 
 async def _generate_gemini(prompt: str, *, system: str | None = None,
                            schema=None, model: str | None = None,
-                           max_tokens: int | None = None):
-    key = await _resolve_gemini_key()
+                           max_tokens: int | None = None,
+                           force_platform_key: bool = False):
+    key = settings.gemini_api_key if force_platform_key else await _resolve_gemini_key()
     if not key:
         raise LLMUnavailable("no Gemini key configured")
     import google.generativeai as genai  # lazy import — only needed on the gemini path
@@ -144,16 +152,20 @@ async def _generate_gemini(prompt: str, *, system: str | None = None,
 
 async def generate(prompt: str, *, system: str | None = None,
                    schema=None, model: str | None = None,
-                   max_tokens: int | None = None):
+                   max_tokens: int | None = None,
+                   force_platform_key: bool = False):
     """Generate text (or parsed JSON when ``schema`` is given) via the configured provider.
 
+    ``force_platform_key`` routes to the platform/env key (background jobs), never a per-user key.
     Raises ``LLMUnavailable`` when no key is configured.
     """
     provider = (settings.generation_provider or "openai").lower()
     if provider == "gemini":
         return await _generate_gemini(
-            prompt, system=system, schema=schema, model=model, max_tokens=max_tokens
+            prompt, system=system, schema=schema, model=model, max_tokens=max_tokens,
+            force_platform_key=force_platform_key,
         )
     return await _generate_openai(
-        prompt, system=system, schema=schema, model=model, max_tokens=max_tokens
+        prompt, system=system, schema=schema, model=model, max_tokens=max_tokens,
+        force_platform_key=force_platform_key,
     )

--- a/backend/migrations/versions/d0e1f2a3b4c5_g1_entity_backbone.py
+++ b/backend/migrations/versions/d0e1f2a3b4c5_g1_entity_backbone.py
@@ -1,0 +1,70 @@
+"""g1: entity backbone (entities, entity_aliases, article_entities)
+
+Revision ID: d0e1f2a3b4c5
+Revises: c9d0e1f2a3b4
+Create Date: 2026-06-25 12:00:00.000000
+
+Global, content-scoped tables (shared like articles/clusters) — NOT RLS-scoped. Case-insensitive
+resolution via normalized *_norm columns + plain b-tree indexes. No embedding column in G1.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "d0e1f2a3b4c5"
+down_revision: Union[str, None] = "c9d0e1f2a3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "entities",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("canonical_name", sa.Text(), nullable=False),
+        sa.Column("name_norm", sa.Text(), nullable=False),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("first_seen", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_seen", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("mention_count", sa.Integer(), server_default="0", nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_entities_kind_name", "entities", ["kind", "name_norm"])
+
+    op.create_table(
+        "entity_aliases",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("alias", sa.Text(), nullable=False),
+        sa.Column("alias_norm", sa.Text(), nullable=False),
+        sa.Column("source", sa.String(length=32), nullable=True),
+        sa.ForeignKeyConstraint(["entity_id"], ["entities.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("entity_id", "alias_norm", name="uq_entity_alias"),
+    )
+    op.create_index("ix_entity_aliases_alias", "entity_aliases", ["alias_norm"])
+
+    op.create_table(
+        "article_entities",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("article_id", sa.Integer(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("salience", sa.Float(), server_default="0", nullable=False),
+        sa.Column("confidence", sa.Float(), server_default="0", nullable=False),
+        sa.ForeignKeyConstraint(["article_id"], ["articles.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["entity_id"], ["entities.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("article_id", "entity_id", name="uq_article_entity"),
+    )
+    op.create_index("ix_article_entities_entity", "article_entities", ["entity_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_article_entities_entity", table_name="article_entities")
+    op.drop_table("article_entities")
+    op.drop_index("ix_entity_aliases_alias", table_name="entity_aliases")
+    op.drop_table("entity_aliases")
+    op.drop_index("ix_entities_kind_name", table_name="entities")
+    op.drop_table("entities")

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -191,9 +191,18 @@ def fake_llm(monkeypatch):
                 "headline": "Here's the one-line takeaway for you",
                 "points": ["Point one.", "Point two.", "Point three."],
             }
+        # G1 entity extraction
+        if '"canonical_name"' in p or "salient named entities" in p:
+            return {
+                "entities": [
+                    {"canonical_name": "Reserve Bank of India", "kind": "org",
+                     "salience": 0.9, "aliases": ["RBI"]},
+                    {"canonical_name": "Geneva", "kind": "place", "salience": 0.5, "aliases": []},
+                ]
+            }
         return {"result": "generic"}
 
-    async def _gen(prompt, *, system=None, schema=None, model=None, max_tokens=None):
+    async def _gen(prompt, *, system=None, schema=None, model=None, max_tokens=None, force_platform_key=False):
         calls["generate"] += 1
         if schema is None:
             return "STUB SUMMARY"

--- a/backend/tests/integration/test_entities_api.py
+++ b/backend/tests/integration/test_entities_api.py
@@ -4,8 +4,10 @@ from datetime import datetime, timezone
 import pytest
 
 from app.models import (
-    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Source, SourceType, StoryCluster,
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, EntityAlias, Source,
+    SourceType, StoryCluster,
 )
+from app.services import entities as E
 
 _n = 0
 
@@ -94,3 +96,20 @@ async def test_entity_clusters_recency_and_absence(aclient, db_session):
     body = (await aclient.get(f"/entities/{e.id}/clusters")).json()
     titles = [c["title"] for c in body]
     assert titles == ["Newer", "Older"]   # newest-first, and "Other" (E not mentioned) absent
+
+
+@pytest.mark.asyncio
+async def test_resolve_existing_by_name_and_alias(db_session):
+    e = await _entity(db_session, "Reserve Bank")
+    db_session.add(EntityAlias(entity_id=e.id, alias="RBI", alias_norm="rbi"))
+    await db_session.flush()
+    assert await E.resolve_existing(db_session, "Reserve Bank") == e.id  # exact name
+    assert await E.resolve_existing(db_session, "rbi") == e.id            # alias, case-insensitive
+    assert await E.resolve_existing(db_session, "Nope") is None
+
+
+@pytest.mark.asyncio
+async def test_entity_follow_creation_succeeds(aclient, db_session):
+    await _entity(db_session, "Acme")
+    r = await aclient.post("/follows", json={"kind": "entity", "value": "Acme"})
+    assert r.status_code == 201  # the S7 resolution hook runs without breaking follow creation

--- a/backend/tests/integration/test_entities_api.py
+++ b/backend/tests/integration/test_entities_api.py
@@ -1,0 +1,96 @@
+"""G1 S1-S2: the cast-strip + 'appears in' read endpoints (pure SQL, real DB harness)."""
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Source, SourceType, StoryCluster,
+)
+
+_n = 0
+
+
+async def _src(db):
+    global _n
+    _n += 1
+    s = Source(name="S", url=f"https://ge/{_n}", source_type=SourceType.wire)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _article(db, src):
+    global _n
+    _n += 1
+    a = Article(title="A", url=f"https://ge/{_n}/a", source_id=src.id,
+                embedding_status=EmbeddingStatus.complete)
+    db.add(a)
+    await db.flush()
+    return a
+
+
+async def _cluster(db, *articles, title="C", created_at=None):
+    cl = StoryCluster(title=title)
+    if created_at is not None:
+        cl.created_at = created_at
+    db.add(cl)
+    await db.flush()
+    for a in articles:
+        db.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db.flush()
+    return cl
+
+
+async def _entity(db, name, kind="org"):
+    e = Entity(canonical_name=name, name_norm=name.lower(), kind=kind)
+    db.add(e)
+    await db.flush()
+    return e
+
+
+@pytest.mark.asyncio
+async def test_cluster_entities_dedup_order_cap(aclient, db_session):
+    src = await _src(db_session)
+    a1, a2 = await _article(db_session, src), await _article(db_session, src)
+    cl = await _cluster(db_session, a1, a2)
+    e_high = await _entity(db_session, "Reserve Bank")
+    e_mid = await _entity(db_session, "Finance Ministry")
+    e_low = await _entity(db_session, "Some Bank")
+    db_session.add_all([
+        ArticleEntity(article_id=a1.id, entity_id=e_high.id, salience=0.6),  # same entity, two
+        ArticleEntity(article_id=a2.id, entity_id=e_high.id, salience=0.9),  # articles → dedup to max
+        ArticleEntity(article_id=a1.id, entity_id=e_mid.id, salience=0.5),
+        ArticleEntity(article_id=a1.id, entity_id=e_low.id, salience=0.2),
+    ])
+    await db_session.flush()
+
+    body = (await aclient.get(f"/clusters/{cl.id}/entities")).json()
+    names = [e["canonical_name"] for e in body]
+    assert names[0] == "Reserve Bank"            # highest salience (max 0.9) first
+    assert names.count("Reserve Bank") == 1      # deduped across articles
+    sal = [e["salience"] for e in body]
+    assert sal == sorted(sal, reverse=True)      # ordered desc
+    assert set(body[0].keys()) == {"id", "canonical_name", "kind", "salience"}
+
+
+@pytest.mark.asyncio
+async def test_entity_clusters_recency_and_absence(aclient, db_session):
+    src = await _src(db_session)
+    e = await _entity(db_session, "Acme Corp")
+    other = await _entity(db_session, "Unrelated")
+    a_old = await _article(db_session, src)
+    a_new = await _article(db_session, src)
+    a_other = await _article(db_session, src)
+    await _cluster(db_session, a_old, title="Older", created_at=datetime(2026, 6, 1, tzinfo=timezone.utc))
+    await _cluster(db_session, a_new, title="Newer", created_at=datetime(2026, 6, 20, tzinfo=timezone.utc))
+    await _cluster(db_session, a_other, title="Other", created_at=datetime(2026, 6, 25, tzinfo=timezone.utc))
+    db_session.add_all([
+        ArticleEntity(article_id=a_old.id, entity_id=e.id, salience=0.8),
+        ArticleEntity(article_id=a_new.id, entity_id=e.id, salience=0.7),
+        ArticleEntity(article_id=a_other.id, entity_id=other.id, salience=0.9),  # different entity
+    ])
+    await db_session.flush()
+
+    body = (await aclient.get(f"/entities/{e.id}/clusters")).json()
+    titles = [c["title"] for c in body]
+    assert titles == ["Newer", "Older"]   # newest-first, and "Other" (E not mentioned) absent

--- a/backend/tests/integration/test_entities_backfill.py
+++ b/backend/tests/integration/test_entities_backfill.py
@@ -1,0 +1,132 @@
+"""G1 S5-S6: decoupled backfill job (settled + on-change) + platform-key seam."""
+import contextlib
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Source, SourceType, StoryCluster,
+)
+
+_n = 0
+
+
+async def _src(db):
+    global _n
+    _n += 1
+    s = Source(name="S", url=f"https://bf/{_n}", source_type=SourceType.wire)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _article(db, src):
+    global _n
+    _n += 1
+    a = Article(title="T", snippet="s", extracted_text="full body about the central bank and a city",
+                url=f"https://bf/{_n}/a", source_id=src.id, embedding_status=EmbeddingStatus.complete)
+    db.add(a)
+    await db.flush()
+    return a
+
+
+async def _cluster(db, *arts, title="C"):
+    cl = StoryCluster(title=title, summary="x")
+    db.add(cl)
+    await db.flush()
+    for a in arts:
+        db.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db.flush()
+    return cl
+
+
+def _route_session_to_test(monkeypatch, db_session):
+    from app.services import entities as E
+
+    @contextlib.asynccontextmanager
+    async def _fake():
+        yield db_session  # don't close the shared session on exit
+
+    monkeypatch.setattr(E, "async_session", _fake)
+
+
+@pytest.mark.asyncio
+async def test_backfill_extracts_settled_ignores_unsettled(fake_llm, db_session, monkeypatch):
+    from app.config import settings as s
+    from app.services import entities as E
+
+    monkeypatch.setattr(s, "graph_extraction_enabled", True)
+    _route_session_to_test(monkeypatch, db_session)
+
+    src = await _src(db_session)
+    a1, a2 = await _article(db_session, src), await _article(db_session, src)
+    await _cluster(db_session, a1, a2)            # settled (2 sources) → extracted
+    a3 = await _article(db_session, src)
+    await _cluster(db_session, a3)                # unsettled (1 source) → ignored
+
+    await E.backfill_entities()
+
+    assert fake_llm["generate"] == 1             # only the settled cluster called the LLM
+    settled = (await db_session.execute(select(func.count()).select_from(ArticleEntity).where(
+        ArticleEntity.article_id.in_([a1.id, a2.id])))).scalar()
+    unsettled = (await db_session.execute(select(func.count()).select_from(ArticleEntity).where(
+        ArticleEntity.article_id == a3.id))).scalar()
+    assert settled > 0 and unsettled == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_unchanged(fake_llm, db_session, monkeypatch):
+    from app.config import settings as s
+    from app.services import entities as E, lenses
+
+    monkeypatch.setattr(s, "graph_extraction_enabled", True)
+    _route_session_to_test(monkeypatch, db_session)
+
+    src = await _src(db_session)
+    a1, a2 = await _article(db_session, src), await _article(db_session, src)
+    cl = await _cluster(db_session, a1, a2)
+    _, articles = await lenses._load(db_session, cl.id)
+    sh = lenses._source_hash(articles)
+    await lenses._cache_write(db_session, cl, "extra_json", "graph", sh, {"entities": 0})  # already done
+
+    await E.backfill_entities()
+
+    assert fake_llm["generate"] == 0             # unchanged → no LLM call
+    assert (await db_session.execute(select(func.count()).select_from(ArticleEntity))).scalar() == 0
+
+
+@pytest.mark.asyncio
+async def test_force_platform_key_bypasses_user_key(monkeypatch):
+    """S6: extraction's force_platform_key uses the platform/env key, never the owner's per-user key."""
+    from app.services import embeddings, llm
+
+    class _Resp:
+        class _Choice:
+            class _Msg:
+                content = '{"entities": []}'
+            message = _Msg()
+        choices = [_Choice()]
+
+    class _Client:
+        class chat:
+            class completions:
+                @staticmethod
+                async def create(**kw):
+                    return _Resp()
+
+    used = {"user": 0, "platform": 0}
+
+    async def spy_user():
+        used["user"] += 1
+        return "USER-KEY"
+
+    def spy_platform():
+        used["platform"] += 1
+        return _Client()
+
+    monkeypatch.setattr(embeddings, "_get_user_api_key", spy_user)
+    monkeypatch.setattr(embeddings, "_get_client_platform", spy_platform)
+
+    out = await llm._generate_openai("p", schema={"x": 1}, force_platform_key=True)
+    assert used["platform"] == 1 and used["user"] == 0
+    assert out == {"entities": []}

--- a/backend/tests/integration/test_entities_extract.py
+++ b/backend/tests/integration/test_entities_extract.py
@@ -1,0 +1,76 @@
+"""G1 S3-S4 (integration): extract → resolve → persist; idempotent; alias reuse."""
+import pytest
+from sqlalchemy import func, select
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, EntityAlias, Source,
+    SourceType, StoryCluster,
+)
+from app.schemas import EntityExtraction, ExtractedEntity
+from app.services import entities as E
+
+_n = 0
+
+
+async def _cluster_with_article(db):
+    global _n
+    _n += 1
+    src = Source(name="S", url=f"https://ex/{_n}", source_type=SourceType.wire)
+    db.add(src)
+    await db.flush()
+    art = Article(title="T", snippet="s", extracted_text="full body about the central bank",
+                  url=f"https://ex/{_n}/a", source_id=src.id, embedding_status=EmbeddingStatus.complete)
+    db.add(art)
+    await db.flush()
+    cl = StoryCluster(title="C", summary="S")
+    db.add(cl)
+    await db.flush()
+    db.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db.flush()
+    return cl, art
+
+
+@pytest.mark.asyncio
+async def test_extract_then_persist_then_idempotent(fake_llm, db_session):
+    cl, art = await _cluster_with_article(db_session)
+    ext = await E.extract_entities(cl, [art])
+    assert ext is not None and len(ext.entities) == 2  # fake_llm returns RBI + Geneva
+
+    await E.resolve_and_persist(db_session, [art], ext)
+    n_ent = (await db_session.execute(select(func.count()).select_from(Entity))).scalar()
+    n_link = (await db_session.execute(select(func.count()).select_from(ArticleEntity))).scalar()
+    assert n_ent == 2 and n_link == 2
+
+    await E.resolve_and_persist(db_session, [art], ext)  # re-run is a no-op
+    assert (await db_session.execute(select(func.count()).select_from(Entity))).scalar() == 2
+    assert (await db_session.execute(select(func.count()).select_from(ArticleEntity))).scalar() == 2
+
+
+@pytest.mark.asyncio
+async def test_alias_resolution_reuses_existing_entity(fake_llm, db_session):
+    cl, art = await _cluster_with_article(db_session)
+    e = Entity(canonical_name="Reserve Bank", name_norm="reserve bank", kind="org")
+    db_session.add(e)
+    await db_session.flush()
+    db_session.add(EntityAlias(entity_id=e.id, alias="RBI", alias_norm="rbi"))
+    await db_session.flush()
+
+    # extracted canonical "RBI" matches the existing alias → reuse, don't create a second node
+    ext = EntityExtraction(entities=[ExtractedEntity(canonical_name="RBI", kind="org", salience=0.9)])
+    await E.resolve_and_persist(db_session, [art], ext)
+
+    assert (await db_session.execute(select(func.count()).select_from(Entity))).scalar() == 1
+    links = (await db_session.execute(
+        select(ArticleEntity).where(ArticleEntity.entity_id == e.id))).scalars().all()
+    assert len(links) == 1
+
+
+@pytest.mark.asyncio
+async def test_salience_floor_drops_low_entities(fake_llm, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "graph_salience_floor", 0.7)  # Geneva (0.5) should be dropped
+    cl, art = await _cluster_with_article(db_session)
+    ext = await E.extract_entities(cl, [art])
+    await E.resolve_and_persist(db_session, [art], ext)
+    names = [r[0] for r in (await db_session.execute(select(Entity.canonical_name))).all()]
+    assert "Reserve Bank of India" in names and "Geneva" not in names

--- a/backend/tests/integration/test_foundation.py
+++ b/backend/tests/integration/test_foundation.py
@@ -8,8 +8,11 @@ from sqlalchemy import create_engine, func, inspect, select, text
 from app.config import settings
 from app.models import (
     Article,
+    ArticleEntity,
     ClusterArticle,
     EmbeddingStatus,
+    Entity,
+    EntityAlias,
     Source,
     SourceType,
     StoryCluster,
@@ -27,6 +30,10 @@ EXPECTED_TABLES = {
     "article_topics",
     "cluster_articles",
     "user_feedback",
+    # Wave D Phase 3 — G1 entity backbone
+    "entities",
+    "entity_aliases",
+    "article_entities",
 }
 
 # backend/ root (contains alembic.ini + migrations/), two levels up from this file.
@@ -109,6 +116,34 @@ async def test_embedding_column_accepts_vector(db_session):
     await db_session.flush()
     got = (await db_session.execute(select(Article).where(Article.id == art.id))).scalar_one()
     assert got.embedding is not None
+
+
+@pytest.mark.asyncio
+async def test_entity_backbone_persists_and_dedups(db_session):
+    """G1 S0: entities/aliases/article_entities persist; uq_article_entity is idempotent."""
+    from sqlalchemy.exc import IntegrityError
+
+    src = Source(name="S", url="https://eb/u", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    art = Article(title="A", url="https://eb/a", source_id=src.id,
+                  embedding_status=EmbeddingStatus.complete)
+    db_session.add(art)
+    await db_session.flush()
+    ent = Entity(canonical_name="Reserve Bank of India", name_norm="reserve bank of india", kind="org")
+    db_session.add(ent)
+    await db_session.flush()
+    db_session.add(EntityAlias(entity_id=ent.id, alias="RBI", alias_norm="rbi"))
+    db_session.add(ArticleEntity(article_id=art.id, entity_id=ent.id, salience=0.9))
+    await db_session.flush()
+
+    got = (await db_session.execute(
+        select(ArticleEntity).where(ArticleEntity.article_id == art.id))).scalars().all()
+    assert len(got) == 1 and got[0].entity_id == ent.id
+
+    with pytest.raises(IntegrityError):  # uq_article_entity rejects a duplicate mention
+        async with db_session.begin_nested():
+            db_session.add(ArticleEntity(article_id=art.id, entity_id=ent.id, salience=0.5))
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_entities.py
+++ b/backend/tests/test_entities.py
@@ -1,0 +1,28 @@
+"""G1 S3 (unit): EntityExtraction validation — clamp/normalize, reject empties. No DB."""
+import pytest
+from pydantic import ValidationError
+
+from app.schemas import EntityExtraction
+
+
+def test_entity_extraction_validates_and_clamps():
+    obj = EntityExtraction.model_validate({
+        "entities": [
+            {"canonical_name": "  Reserve Bank  ", "kind": "ORG", "salience": 1.7, "aliases": ["RBI"]},
+            {"canonical_name": "Geneva", "kind": "weird-kind", "salience": -0.2, "aliases": []},
+        ]
+    })
+    assert obj.entities[0].canonical_name == "Reserve Bank"  # stripped
+    assert obj.entities[0].kind == "org"                     # lowercased to a known kind
+    assert obj.entities[0].salience == 1.0                   # clamped to 1
+    assert obj.entities[1].kind == "other"                   # unknown kind → other
+    assert obj.entities[1].salience == 0.0                   # clamped to 0
+
+
+def test_entity_extraction_rejects_empty_name():
+    with pytest.raises(ValidationError):
+        EntityExtraction.model_validate({"entities": [{"canonical_name": "  ", "kind": "org"}]})
+
+
+def test_entity_extraction_empty_list_ok():
+    assert EntityExtraction.model_validate({"entities": []}).entities == []

--- a/docs/moat/07-graph-g1-eng-plan.md
+++ b/docs/moat/07-graph-g1-eng-plan.md
@@ -1,0 +1,208 @@
+﻿# Wave D Phase 3 — G1: Global Entity Backbone (engineering plan)
+
+## NewsLens G1 â€” The Entity Backbone (final engineering plan)
+
+### Positioning: what G1 is, and what it is NOT
+
+G1 is **an entity backbone over the clusters that already exist** â€” *"who/what is in this story, and what other recent stories touch the same people/orgs/places."* It ships the leanest cut that delivers real single-user value: **co-occurrence over exact+alias resolution**, no embedding NN, no auto-merge, no typed-edge graph.
+
+After the engineering and product reviews, the build is deliberately leaner than the draft:
+
+- **DEFERRED to G2/G1.5** (defending scale/sharing that does not exist yet): reversible auto-merge + `entity_merge_log` + tested unmerge (draft S5/S6), the `entities.embedding` column **and its HNSW index**, the embedding-NN tie-breaker, and the followâ†’entity re-point/orphan-guard.
+- **DEFERRED to G3** (gated engine): `entity_edges`, `events`, `user_entity_relevance` + RLS on entity tables, recursive-CTE traversal, intent router, SLO dashboard, the `N*` amortization deliverable.
+
+Final G1 = **3 global content tables** (`entities`, `entity_aliases`, `article_entities`) + **one new service** (`entities.py`) + **one decoupled scheduler job** + **two pure-SQL read endpoints** + **a frontend chip row**. Extraction is a single JSON-mode LLM pass per *settled, changed* cluster, run as its own APScheduler interval job â€” **not** inside the clustering hot loop.
+
+### Gate note (kept visible, honest)
+
+The full graph (G3 multi-hop engine + G2 per-user overlay) is gated on: **auth landed** (done â€” Firebase + `app.user_id` GUC + RLS on the four overlay tables are live), **~50â€“100 WAU**, **>=15â€“20% logged multi-hop demand**, and a **>85% resolution SLO**. G1 ships under the owner's directive as the cheap, single-user-valuable substrate. The `N* = extraction_cost_per_day / vector_baseline_per_user_per_day` amortization number is a **pre-commit deliverable for G3, not for G1** â€” G1 just keeps the numerator low (extract once per settled cluster, on-change only, salient-only, platform key, gpt-4o-mini).
+
+A one-line code-comment breadcrumb goes on `entities.py`: *any future lens that reads graph output must widen its `_source_hash` to include entity ids + content version + persona/depth + (at G2) user scope.* **Zero G1 implementation** â€” both G1 endpoints are uncached pure-SQL reads.
+
+---
+
+### Schema (Alembic-owned in prod; `create_all` builds it in tests â€” existing parity discipline)
+
+Three additive, **global, non-RLS** tables (shared content, exactly like `articles`/`story_clusters`/`cluster_edges`). They are NOT added to `_RLS_TABLES` (models.py:321). New ORM models in `models.py` + one Alembic migration `down_revision="c9d0e1f2a3b4"` (verified head = `wave_d_rls`) whose `upgrade()` mirrors the ORM â€” the `f6a7b8c9d0e1` cluster_edges migration is the precedent.
+
+**PK/FK types match the existing schema:** every current model uses `Integer` PKs/FKs (Article, StoryCluster, ClusterEdge all `mapped_column(Integer, primary_key=True)`). The new tables use `Integer` too, and `article_entities.article_id` is `Integer` to match `articles.id` exactly â€” **no int4/int8 mismatch**, and the parity test (`test_alembic_baseline_matches_models`) stays green.
+
+**`entities`** â€” `kind` is a string-by-convention column (matches `ClusterEdge.kind`/`Follow.kind`), no PG enum. **No `embedding` column in G1** (deferred with the NN tie-breaker to G2) â€” so **no HNSW index**, which means the parity test's hardcoded `_is_hnsw` allowlist (test_foundation.py:182) needs no change in G1.
+
+**`entity_aliases`** â€” `lower(alias)` index is the zero-vector-cost resolution path.
+
+**`article_entities`** â€” the one relation that delivers the headline value. `UniqueConstraint(article_id, entity_id)` makes re-extraction idempotent (mirrors `uq_cluster_article`). `ix_article_entities_entity` powers the reverse "appears in" lookup. `article_id` FK is `ON DELETE CASCADE` (mentions die with the article â€” the sane default for a derived table; confirm articles are not hard-pruned today, but set CASCADE for safety regardless).
+
+`entity_merge_log` is **NOT created in G1** (it lands with auto-merge in G2).
+
+---
+
+### Extraction pipeline â€” decoupled backfill job (corrected seam)
+
+**The draft's seam was wrong.** Hooking extraction into `run_clustering`'s new-cluster `else:` branch (clustering.py:64â€“81) is broken three ways: (1) the cluster is created from a **single seeding article** (`StoryCluster(title=article.title)`, clustering.py:66) and never re-extracted as corroborating sources arrive â€” so entities come from one thin article forever; (2) the surrounding session is **already committed** at clustering.py:75 and `link_cluster` commits **again** at clustering.py:129, so extraction would inherit an indeterminate transaction; (3) it injects LLM latency into the 10-min clustering loop, which on APScheduler defaults (`max_instances=1`) means a slow batch **skips the next clustering run** and silently starves clustering.
+
+**Corrected design â€” model it on `summarizer.backfill_summaries`** (summarizer.py:152â€“188), the existing decoupled-backfill precedent:
+
+- New `backfill_entities()` in `services/entities.py`, registered as its **own** APScheduler interval job in `start_scheduler` (main.py:131â€“195) with explicit `max_instances=1, coalesce=True, misfire_grace_time=...`, so it can never overlap itself or starve clustering.
+- It selects clusters that are **settled** (`source_count >= 2` OR age > N min) **and changed** (stored graph `source_hash` != current `_source_hash(articles)`), capped per run (`graph_extract_batch_size`), exactly like `backfill_summaries` selects stale ids then processes each in its own session.
+- Each cluster is processed in **its own fresh `async with async_session() as s:`** with a single explicit transaction wrapping resolve â†’ persist `article_entities` â†’ write the source-hash â€” one commit. This is independent of the (already-committed) clustering session.
+
+**On-change skip:** reuse the lens cache discipline. Compute `source_hash = lenses._source_hash(articles)` (verified at lenses.py:62), store the last-extracted hash on the cluster in `extra_json` under subkey `graph` via the existing server-side JSONB-merge `_cache_write` (lenses.py:235), and skip when unchanged. A settled, unchanged cluster is a no-op.
+
+**Input:** `retrieval.cluster_text(cluster, articles, depth_pref="standard")` (verified signature, keyword-only `depth_pref`, retrieval.py:36) â€” full `extracted_text` bodies (Wave D1), never headlines.
+
+**Cost levers (priority order):** (1) once per settled cluster, on-change only; (2) salience cap 8â€“12 entities, floor 0.3 â€” salient WHO/WHAT/WHERE only, never every proper noun; (3) **platform key** (see below); (4) gpt-4o-mini + JSON mode; (5) gleaning OFF (single pass).
+
+**LLM call shape â€” corrected framing:** `llm.generate` does **not** enforce a structured schema. The `schema` arg (llm.py:116â€“117) is used **only as a truthy flag** to set `response_format={"type":"json_object"}` (and `response_mime_type` on the Gemini path); the dict contents are ignored. So this is **"JSON-mode + Pydantic validation"**, not "schema-constrained". The prompt text must fully carry the `{entities:[{canonical_name,kind,salience,aliases}]}` shape, and `EntityExtraction.model_validate(raw)` (new in `schemas.py`, mirroring `StoryImpact`) is the **only** real shape guard. On validation failure: log + skip, never raise.
+
+**Platform key â€” corrected (the draft's claim was factually false):** the draft asserted a background job falls back to env `OPENAI_API_KEY` because the GUC is unset. It does **not**. `embeddings._get_user_api_key()` (embeddings.py:24â€“59) queries `UserSetting WHERE user_id==1 AND verified` **unconditionally â€” no GUC check** â€” and returns user 1's per-user key if set. In this single-user app the owner very likely *has* set one, so extraction would bill the owner's personal key, breaking the amortization premise. **Fix:** add a real platform-key seam â€” a `force_platform_key: bool = False` kwarg threaded through `llm.generate` â†’ `_generate_openai`, which when true uses `settings.openai_api_key` directly (a `_get_client_platform()` helper) and **bypasses** `_get_user_api_key`. `entities.py` calls `llm.generate(..., force_platform_key=settings.graph_use_platform_key)`. A test asserts a background extraction does **not** read user 1's key.
+
+**Config additions** (`config.py`, defaults): `graph_extraction_model="gpt-4o-mini"`, `graph_extraction_enabled=False` (ship dark), `graph_max_entities_per_cluster=12`, `graph_salience_floor=0.3`, `graph_extract_batch_size=20`, `graph_extract_min_sources=2`, `graph_use_platform_key=True`.
+
+---
+
+### Entity resolution (G1: exact + alias only, precision-biased)
+
+Per-entity resolution inside the per-cluster extraction transaction:
+1. **Exact canonical match** â€” `lower(canonical_name)` against `ix_entities_kind_name` (kind + name). Zero vector cost.
+2. **Alias match** â€” `lower(alias)` against `ix_entity_aliases_alias`.
+3. **Miss â†’ create a new entity** + insert its aliases.
+
+**No embedding NN, no auto-merge in G1.** Per the product review (and the draft's own cost/benefit): a missed merge just leaves *two thin nodes* â€” cosmetically two chips instead of one â€” which is an acceptable single-user blemish, not a launch blocker. A *false* merge corrupts a shared read, but **there is no shared graph and no second reader yet**. So G1 simply never merges. The embedding column, HNSW index, NN tie-breaker, confidence bands, `entity_merge_log`, reversible unmerge, and the follow re-point all move to **G2**, where entity volume makes dupes visible and the overlay JOINs make precision matter. This removes ~40% of the draft's build and drags zero embedding-generation cost into G1.
+
+---
+
+### Retrieval / endpoint integration
+
+Two read endpoints, mirroring the `/clusters/{cluster_id}/...` + `Depends(get_current_user)` pattern (verified routes.py:1158â€“1214). Both are **pure SQL, no LLM** â€” they read the backbone, not generate it.
+
+1. **`GET /clusters/{cluster_id}/entities`** â€” the cast strip / earliest visible win. Joins `article_entities` â†’ `entities` for the cluster's articles, dedups by entity (max salience), orders by salience, caps at `graph_max_entities_per_cluster`. Returns `[{id, canonical_name, kind, salience}]`. Auth-gated for consistency; data is global.
+
+2. **`GET /entities/{entity_id}/clusters`** â€” the "appears in" rail. Reverse lookup on `ix_article_entities_entity`: other recent clusters whose articles mention this entity, ordered by `story_clusters.created_at` recency, capped at 10. Co-occurrence delivers ~90% of the connecting-tissue value with **zero graph engine and zero edges table**. (The D2 `cluster_edges` timeline remains the temporal-ordering precedent; G1 reuses recency, not a new edge type.)
+
+**Why no recursive CTE / edges:** "how entities connect" is a depth-1 co-occurrence JOIN over `article_entities` â€” that *is* the single-user win. Multi-hop optimizes a workload with zero logged demand â†’ G3, gated.
+
+**Frontend:** add `getClusterEntities(clusterId)` + `getEntityClusters(entityId)` to `frontend/src/lib/api.ts` (mirroring `getFrameworks`); render a tappable chip row in `frontend/src/components/DeepDiveView.tsx` (alongside frameworks/impact) linking each entity to its "appears in" rail. **Slice 1 ships this visible chip row** â€” not invisible plumbing.
+
+---
+
+### Test-harness reality (corrected â€” these were over-claimed in the draft)
+
+- **Endpoint slices are NOT MockSession-testable.** `MockSession.execute` (conftest.py:166â€“187) dispatches only by `column_descriptions` entity for `StoryCluster`/`Topic`/`Article`, else returns `feed_articles`. The new endpoints are column-tuple JOINs over `article_entities`â†’`entities` â€” no recognized entity match â†’ garbage/empty. **All G1 service + endpoint slices use the real async-DB integration harness** (`db_session`/`aclient` in `tests/integration/conftest.py`), like the existing foundation tests.
+- **`fake_llm` needs a new branch.** Integration `fake_llm._schema_shape` (conftest.py:80â€“194) sniffs prompt cues for lens shapes and returns `{"result":"generic"}` otherwise â€” which would fail `EntityExtraction.model_validate`. Add a branch that returns a valid `{entities:[{canonical_name,kind,salience,aliases}]}` payload when it sees the extraction prompt cues.
+- **`EXPECTED_TABLES`** in `tests/integration/test_foundation.py:19` gets the 3 new tables added so the upgrade test covers them.
+- **No `_is_hnsw` change in G1** (the entities embedding/HNSW index is deferred to G2; the allowlist widening moves to G2 with that index).
+
+---
+
+### TDD slice breakdown (ordered for earliest visible win)
+
+Slices 1â€“4 deliver the full visible win ("who/what is in this story" + "what else touches them") using only exact+alias resolution â€” before any embedding/merge/follow complexity. Each slice: a RED test first, then minimum GREEN. Details, RED tests, GREEN impls, and real file paths are in the `slices` field.
+
+Final G1 slice set: **S0** schema + parity, **S1** cast-strip endpoint (visible win), **S2** "appears in" rail endpoint, **S3** extraction prompt + `EntityExtraction` validation + fake_llm branch, **S4** exact+alias resolution + idempotent persist, **S5** decoupled backfill job (on-change, settled-only, own session/txn) + scheduler registration, **S6** platform-key seam, **S7** followâ†’entity resolution hook (resolution only â€” no column, no re-point), **S8** frontend chip row.
+
+---
+
+### Risks
+
+See the `risks` field.
+
+---
+
+## Schema tables
+
+### `entities`
+Global, content-scoped node: a salient person/org/place/other extracted from cluster articles. NOT RLS-scoped (shared content). No embedding column in G1 (NN tie-breaker deferred to G2).
+
+- `id INTEGER PK`
+- `canonical_name TEXT NOT NULL`
+- `kind TEXT NOT NULL  -- string-by-convention {person,org,place,other}, no PG enum`
+- `description TEXT NULL`
+- `first_seen TIMESTAMPTZ`
+- `last_seen TIMESTAMPTZ`
+- `mention_count INT DEFAULT 0`
+- `Index ix_entities_kind_name (kind, lower(canonical_name))  -- exact resolution pre-filter`
+
+### `entity_aliases`
+Alternate surface forms for an entity (e.g. 'RBI' -> 'Reserve Bank of India'). The zero-vector-cost second resolution lookup.
+
+- `id INTEGER PK`
+- `entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE`
+- `alias TEXT NOT NULL`
+- `source TEXT NULL`
+- `UniqueConstraint(entity_id, alias) uq_entity_alias`
+- `Index ix_entity_aliases_alias (lower(alias))`
+
+### `article_entities`
+The one relation that delivers the headline value: which entity is mentioned in which article, with salience. Powers both the cast strip and the reverse 'appears in' rail.
+
+- `id INTEGER PK`
+- `article_id INTEGER NOT NULL REFERENCES articles(id) ON DELETE CASCADE  -- matches articles.id Integer type exactly`
+- `entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE`
+- `salience REAL DEFAULT 0`
+- `confidence REAL DEFAULT 0`
+- `UniqueConstraint(article_id, entity_id) uq_article_entity  -- idempotent re-extraction`
+- `Index ix_article_entities_entity (entity_id)  -- reverse lookup for the appears-in rail`
+
+## TDD slices
+
+### S0 — Schema: entities + entity_aliases + article_entities (ORM + Alembic + parity)
+- **RED:** In tests/integration/test_foundation.py add EXPECTED_TABLES |= {'entities','entity_aliases','article_entities'} and assert test_alembic_upgrade_from_empty_creates_all_tables still finds them after upgrade to head; assert test_alembic_baseline_matches_models yields zero drift (no _is_hnsw change needed â€” no embedding/HNSW index in G1). Add a direct-DB test that inserts an entity, an alias, and an article_entities row and reads them back, asserting the uq_article_entity unique constraint rejects a duplicate (article_id,entity_id).
+- **GREEN:** Add three ORM models to backend/app/models.py using Integer PKs/FKs (matching Article/StoryCluster), kind as String(16) by convention (like ClusterEdge.kind), ON DELETE CASCADE on the two article_id/entity_id FKs, the named unique constraints and the two lower() indexes. Do NOT add them to _RLS_TABLES. Generate one Alembic migration with down_revision='c9d0e1f2a3b4' (verified head wave_d_rls) whose upgrade() mirrors the ORM exactly.
+- **Files:** backend/app/models.py, backend/migrations/versions/<new>_g1_entity_backbone.py, backend/tests/integration/test_foundation.py
+
+### S1 — GET /clusters/{id}/entities â€” the cast strip (earliest visible win)
+- **RED:** Integration test (db_session/aclient + fake_llm): seed a cluster with 2 articles and article_entities rows for 3 entities at varying salience; GET /clusters/{id}/entities; assert 200, entities deduped by entity, ordered by salience desc, capped at graph_max_entities_per_cluster, shape [{id,canonical_name,kind,salience}]. (NOT MockSession â€” column-tuple join is unsupported there.)
+- **GREEN:** Add a pure-SQL reader in entities.py (cluster_entities(db, cluster_id)) joining article_entities->entities for the cluster's articles, GROUP BY entity taking max(salience), ORDER BY salience DESC, LIMIT cap. Add @router.get('/clusters/{cluster_id}/entities', dependencies=[Depends(get_current_user)]) in routes.py mirroring cluster_frameworks.
+- **Files:** backend/app/services/entities.py, backend/app/api/routes.py, backend/tests/integration/test_entities_api.py
+
+### S2 — GET /entities/{id}/clusters â€” the 'appears in' rail
+- **RED:** Integration test: seed entity E mentioned in articles across clusters C1 (older) and C2 (newer); GET /entities/{E}/clusters; assert clusters returned newest-first by story_clusters.created_at, capped at 10, shape [{cluster_id,title,created_at}], and that a cluster where E is NOT mentioned is absent.
+- **GREEN:** Add entity_clusters(db, entity_id) in entities.py: reverse lookup on ix_article_entities_entity joining article_entities->cluster_articles->story_clusters, DISTINCT cluster, ORDER BY created_at DESC LIMIT 10. Add @router.get('/entities/{entity_id}/clusters', dependencies=[Depends(get_current_user)]).
+- **Files:** backend/app/services/entities.py, backend/app/api/routes.py, backend/tests/integration/test_entities_api.py
+
+### S3 — Extraction prompt + EntityExtraction validation + fake_llm branch
+- **RED:** Unit test: EntityExtraction.model_validate on a well-formed {entities:[{canonical_name,kind,salience,aliases}]} payload succeeds and clamps kind to {person,org,place,other}; a malformed payload raises (caller will skip). Integration test: fake_llm._schema_shape returns a valid entities payload when fed the extraction prompt cues (today it returns {'result':'generic'} which would fail validation).
+- **GREEN:** Add EntityExtraction Pydantic model to schemas.py (mirrors StoryImpact). Add build_extraction_prompt(cluster_text) in entities.py that fully specifies the JSON shape in prose (since llm.generate's schema arg is only a json_object truthy flag, not enforcement). Add an entities branch to fake_llm._schema_shape in tests/integration/conftest.py returning a deterministic valid payload.
+- **Files:** backend/app/schemas.py, backend/app/services/entities.py, backend/tests/integration/conftest.py, backend/tests/test_entities.py
+
+### S4 — Exact + alias resolution + idempotent persist (one transaction)
+- **RED:** Integration test: extract entities for a cluster twice over the same article set; assert (a) exact-name + alias resolution reuses the existing entity (no duplicate row), (b) re-running is idempotent (uq_article_entity prevents dup mentions), (c) a new salient entity creates a new row + its aliases. All within one committed transaction per cluster.
+- **GREEN:** resolve_and_persist(s, cluster_id, articles, extraction) in entities.py: per entity, try lower(canonical_name) on ix_entities_kind_name, then lower(alias) on ix_entity_aliases_alias, else INSERT entity + aliases; upsert article_entities (ON CONFLICT DO NOTHING on uq_article_entity). No embedding NN, no merge in G1. One async_session() + one commit.
+- **Files:** backend/app/services/entities.py, backend/tests/integration/test_entities.py
+
+### S5 — Decoupled backfill job: on-change, settled-only, own session/txn + scheduler
+- **RED:** Integration test (model on backfill_summaries): seed one settled cluster (>=2 sources) with no graph source_hash and one whose stored graph hash == current _source_hash(articles); run backfill_entities(); assert only the changed/settled cluster was extracted (fake_llm generate count == 1) and the unchanged one was skipped; assert a single-article (unsettled) cluster is skipped. Assert each cluster runs in its own session and the stored source_hash is written via the JSONB merge.
+- **GREEN:** Add backfill_entities() in entities.py mirroring summarizer.backfill_summaries: select settled (source_count>=graph_extract_min_sources OR age>N) clusters whose stored extra_json.graph.source_hash != lenses._source_hash(articles), capped at graph_extract_batch_size; process each in its OWN async_session() with one transaction (resolve_and_persist + write source_hash via lenses._cache_write into extra_json subkey 'graph'); never touch run_clustering's session. Register in start_scheduler (main.py) as its own interval job id='entity_backfill' with max_instances=1, coalesce=True, misfire_grace_time set. Guard the whole job behind settings.graph_extraction_enabled.
+- **Files:** backend/app/services/entities.py, backend/app/main.py, backend/tests/integration/test_entities.py
+
+### S6 — Real platform-key seam (force_platform_key) â€” fixes the amortization bug
+- **RED:** Integration test: seed UserSetting(user_id=1) with a verified per-user OpenAI key; call the extraction path with a spy on embeddings._get_user_api_key; assert it is NOT invoked and settings.openai_api_key is used (the platform key), proving extraction does not bill the owner. Assert llm.generate(force_platform_key=True) bypasses the per-user resolver.
+- **GREEN:** Add force_platform_key: bool=False kwarg to llm.generate -> _generate_openai; when true, build the client from settings.openai_api_key directly (new _get_client_platform() in embeddings.py) bypassing _get_user_api_key. entities.py calls llm.generate(..., force_platform_key=settings.graph_use_platform_key). (Gemini path: same flag bypasses _resolve_gemini_key, using settings.gemini_api_key.)
+- **Files:** backend/app/services/llm.py, backend/app/services/embeddings.py, backend/app/services/entities.py, backend/tests/integration/test_entities.py
+
+### S7 — Follow -> entity resolution hook (resolution only; no column, no re-point)
+- **RED:** Integration test: create an entity-kind Follow whose value matches an existing entity's canonical_name; assert the follow-creation path resolves it to that entity_id and records the resolution opportunistically WITHOUT requiring a follows.entity_id column and WITHOUT mutating follows in any merge path (no merge exists in G1). Assert no follows schema change is emitted by autogenerate.
+- **GREEN:** On entity-kind follow creation in routes.py, call entities.resolve_existing(value) (exact+alias lookup, returns entity_id or None) and log/return it for the rail; do NOT add a follows.entity_id column and do NOT include follows in any FK re-point (auto-merge is deferred to G2, so there is nothing to re-point). This keeps the cheap forward-compat hook and resolves the draft's S7 contradiction by cutting the merge half.
+- **Files:** backend/app/api/routes.py, backend/app/services/entities.py, backend/tests/integration/test_entities_api.py
+
+### S8 — Frontend: entity chip row in DeepDiveView + api client
+- **RED:** Vitest: getClusterEntities(clusterId) and getEntityClusters(entityId) call the correct paths with the env-aware base URL (mirror the getFrameworks test). Component test: DeepDiveView renders a chip per entity (ordered by salience) and each chip links to the entity's appears-in view; empty/unavailable entity list renders nothing (graceful).
+- **GREEN:** Add getClusterEntities + getEntityClusters to frontend/src/lib/api.ts mirroring getFrameworks. Render a tappable chip row in frontend/src/components/DeepDiveView.tsx alongside the frameworks/impact sections; each chip routes to the entity's appears-in rail. Hide the section when the list is empty.
+- **Files:** frontend/src/lib/api.ts, frontend/src/components/DeepDiveView.tsx, frontend/src/components/DeepDiveView.test.tsx
+
+## Risks
+- Extraction recall is exact+alias-only in G1 (embedding NN deferred). Distinct surface forms the model does not emit as aliases (e.g. 'RBI' vs 'Reserve Bank of India' when only one is produced) create two thin nodes. Accepted, single-user blemish â€” not a launch blocker; the merge/NN machinery earns its place in G2 when entity volume makes dupes visible AND the overlay JOINs make precision matter.
+- Platform-key seam is load-bearing for the cost story and must be a REAL code path. The current llm.generate -> embeddings._get_user_api_key() unconditionally reads user 1's verified key (no GUC check). If S6 is skipped or the force_platform_key flag is not threaded all the way through, every background extraction silently bills the owner's personal key and the amortization framing is false. S6's spy test is the guard.
+- Decoupled backfill job shares the same async_session factory as five other jobs; if graph_extract_batch_size or the LLM latency is large, the entity job's own runs could pile up. Mitigated by max_instances=1 + coalesce=True + a hard per-run cap, and by running on its own interval so it can never starve clustering (the failure mode the draft's coupled seam would have caused).
+- llm.generate offers JSON-mode only, not schema enforcement (the schema arg is a truthy json_object flag). EntityExtraction.model_validate is the sole shape guard, so a model that returns valid JSON of the wrong shape is silently skipped (logged). Acceptable for a dark-shipped backbone; monitor skip rate before flipping graph_extraction_enabled on.
+- ON DELETE CASCADE on article_entities.article_id assumes mentions should die with the article. If the ingestion pipeline ever hard-deletes articles that are still referenced elsewhere, mention counts shift silently. Confirm whether articles are hard-pruned; CASCADE is the safe default either way.
+- The on-change source_hash is stored in extra_json under subkey 'graph' via the same JSONB-merge path the lenses use. A future lens that reads graph output MUST widen its own _source_hash to include entity ids + content version (+ user scope at G2) or it will serve stale/cross-tenant answers. G1's two endpoints are uncached pure-SQL reads so the trap does not bite yet â€” captured as a code-comment breadcrumb only.
+- Deferring the embedding column to G2 means adding it later is a non-trivial migration + backfill (populate embeddings for the existing entity corpus before NN resolution is meaningful). This is the deliberate trade for not dragging embedding-generation cost into G1; flag it in the G2 plan as a backfill prerequisite.
+
+## Cost
+G1 LLM cost is bounded by one gpt-4o-mini JSON-mode pass per SETTLED, CHANGED cluster (not per article, not per clustering tick) â€” collapsing the firehose to ~hundreds of clusters/day at most, each capped at 8-12 salient entities, single pass (gleaning off), on the platform key (env OPENAI_API_KEY via the new force_platform_key seam), never the owner's per-user key. No embedding generation cost in G1 (the entities.embedding column and HNSW index are deferred to G2 with the NN tie-breaker), so G1 adds zero new vector spend. The two read endpoints are pure SQL (no LLM, uncached). The N* amortization number is a G3 pre-commit deliverable, not a G1 artifact; G1's job is to keep the numerator low so that number looks good when G3's gate is evaluated.
+
+---
+_Generated by the graph-g1-eng-plan workflow (8 agents: codebase + scope + research + first-principles → design → eng/product review → finalize). 26 corrections applied._
+

--- a/frontend/src/components/DeepDiveView.tsx
+++ b/frontend/src/components/DeepDiveView.tsx
@@ -8,6 +8,7 @@ import { ImpactCard } from "@/components/ui/ImpactCard";
 import { AskBox } from "@/components/ui/AskBox";
 import { Collapsible } from "@/components/ui/Collapsible";
 import { FrameworksCard } from "@/components/ui/FrameworksCard";
+import { EntityChips } from "@/components/ui/EntityChips";
 import { ConsensusRow } from "@/components/ui/ConsensusRow";
 import { TriviaCard } from "@/components/ui/TriviaCard";
 import { SourceCard } from "@/components/SourceCard";
@@ -266,6 +267,9 @@ export default function DeepDiveView({
             </Collapsible>
             <Collapsible key={`fw-${expandAll}`} label="FRAMEWORKS" preview="How to read this story" defaultOpen={expandAll}>
               <FrameworksCard clusterId={clusterId} />
+            </Collapsible>
+            <Collapsible key={`ent-${expandAll}`} label="IN THIS STORY" preview="People, orgs & places" defaultOpen={expandAll}>
+              <EntityChips clusterId={clusterId} />
             </Collapsible>
             <Collapsible key={`src-${expandAll}`} label="SOURCES" preview={`${freeCount} free · ${paywallCount} paywall`} defaultOpen={expandAll}>
               <SourceSpectrum freeCount={freeCount} paywallCount={paywallCount} />

--- a/frontend/src/components/ui/EntityChips.test.tsx
+++ b/frontend/src/components/ui/EntityChips.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EntityChips } from "./EntityChips";
+import type { ClusterEntity } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  getClusterEntities: vi.fn(),
+  getEntityClusters: vi
+    .fn()
+    .mockResolvedValue([{ cluster_id: 9, title: "Older related story", created_at: "x" }]),
+}));
+
+const entities: ClusterEntity[] = [
+  { id: 1, canonical_name: "Reserve Bank", kind: "org", salience: 0.9 },
+  { id: 2, canonical_name: "Geneva", kind: "place", salience: 0.5 },
+];
+
+describe("EntityChips (G1)", () => {
+  it("renders a chip per entity", () => {
+    render(<EntityChips clusterId={1} data={entities} />);
+    expect(screen.getByText("Reserve Bank")).toBeInTheDocument();
+    expect(screen.getByText("Geneva")).toBeInTheDocument();
+  });
+
+  it("renders nothing when there are no entities", () => {
+    const { container } = render(<EntityChips clusterId={1} data={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the 'appears in' rail when a chip is tapped", async () => {
+    render(<EntityChips clusterId={1} data={entities} />);
+    await userEvent.click(screen.getByText("Reserve Bank"));
+    expect(await screen.findByText("Older related story")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/EntityChips.tsx
+++ b/frontend/src/components/ui/EntityChips.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getClusterEntities,
+  getEntityClusters,
+  type ClusterEntity,
+  type EntityCluster,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+/** G1 cast strip: who/what is in this story (salient entities, highest-salience first). Tap a chip
+ *  to see other recent stories touching the same entity ("appears in"). Self-fetches; hidden when
+ *  no entities (e.g. extraction off or not yet run). */
+export function EntityChips({
+  clusterId,
+  data: provided,
+}: {
+  clusterId: number;
+  data?: ClusterEntity[];
+}) {
+  const [data, setData] = useState<ClusterEntity[] | "loading">(provided ?? "loading");
+  const [openId, setOpenId] = useState<number | null>(null);
+  const [appearsIn, setAppearsIn] = useState<EntityCluster[] | "loading">("loading");
+
+  useEffect(() => {
+    if (provided !== undefined) {
+      setData(provided);
+      return;
+    }
+    let alive = true;
+    getClusterEntities(clusterId)
+      .then((r) => alive && setData(Array.isArray(r) ? r : []))
+      .catch(() => alive && setData([]));
+    return () => {
+      alive = false;
+    };
+  }, [clusterId, provided]);
+
+  if (data === "loading") return <div className="skeleton h-10 rounded-[var(--radius-md)]" />;
+  if (data.length === 0) return null;
+
+  function toggle(id: number) {
+    if (openId === id) {
+      setOpenId(null);
+      return;
+    }
+    setOpenId(id);
+    setAppearsIn("loading");
+    getEntityClusters(id)
+      .then((r) => setAppearsIn(Array.isArray(r) ? r : []))
+      .catch(() => setAppearsIn([]));
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2">
+        {data.map((e) => (
+          <button
+            key={e.id}
+            type="button"
+            onClick={() => toggle(e.id)}
+            className={cn(
+              "text-mono px-3 py-1.5 rounded-full border transition-colors",
+              openId === e.id
+                ? "border-[var(--accent-muted)] bg-[var(--accent-subtle)] text-[var(--accent)]"
+                : "border-[var(--border)] text-[var(--text-secondary)]"
+            )}
+          >
+            {e.canonical_name}
+          </button>
+        ))}
+      </div>
+      {openId !== null && (
+        <div className="text-small mt-3 pl-3 border-l-2 border-[var(--accent)]">
+          {appearsIn === "loading" ? (
+            <span className="text-[var(--text-tertiary)]">Loading…</span>
+          ) : appearsIn.length === 0 ? (
+            <span className="text-[var(--text-tertiary)]">No other recent stories yet.</span>
+          ) : (
+            <>
+              <p className="text-[var(--text-tertiary)] mb-1">Also appears in</p>
+              <ul className="space-y-1">
+                {appearsIn.map((c) => (
+                  <li key={c.cluster_id} className="text-[var(--text-primary)]">
+                    {c.title}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -427,6 +427,26 @@ export async function getFrameworks(clusterId: number): Promise<FrameworksResult
   return fetchJSON(`/clusters/${clusterId}/frameworks`);
 }
 
+// G1 entity backbone
+export interface ClusterEntity {
+  id: number;
+  canonical_name: string;
+  kind: string;
+  salience: number;
+}
+export async function getClusterEntities(clusterId: number): Promise<ClusterEntity[]> {
+  return fetchJSON(`/clusters/${clusterId}/entities`);
+}
+
+export interface EntityCluster {
+  cluster_id: number;
+  title: string;
+  created_at: string;
+}
+export async function getEntityClusters(entityId: number): Promise<EntityCluster[]> {
+  return fetchJSON(`/entities/${entityId}/clusters`);
+}
+
 export interface Dissent {
   outlet: string;
   point: string;


### PR DESCRIPTION
The lean, single-user-valuable cut of the GraphRAG graph — an **entity backbone** over existing clusters. TDD, 9 slices, all green. Built from an 8-agent plan (`docs/moat/07`) with 26 review corrections.

## What it does
- **Cast strip** — `GET /clusters/{id}/entities`: who/what is in this story (salient people/orgs/places, deduped by max salience).
- **"Appears in" rail** — `GET /entities/{id}/clusters`: other recent stories touching the same entity (co-occurrence → the "how stories connect" win with **zero graph engine / no edges table**).
- **Chip row** in the deep dive ("IN THIS STORY"); tap a chip → the appears-in rail. Hidden when empty.

## How it's built (deliberately lean)
- **3 global tables** (`entities`, `entity_aliases`, `article_entities`) — non-RLS shared content; case-insensitive resolution via normalized `*_norm` + plain b-tree indexes (no functional-index drift); `uq_article_entity` for idempotent re-extraction.
- **Incremental extraction** — one JSON-mode LLM pass per **settled + changed** cluster, as a **decoupled** APScheduler job (`entity_backfill`, `max_instances=1`, `coalesce`) that can't overlap or starve clustering. **Ships dark** (`graph_extraction_enabled=False`).
- **Exact + alias resolution only** — precision-biased; embedding-NN, auto-merge, `entity_edges`/`events`, and the per-user overlay are **deferred to G2/G3** (a missed merge is a cosmetic single-user blemish; there's no shared reader yet).
- **Real platform-key seam** — extraction bills the **platform** env key via `force_platform_key`, never the owner's per-user key (the review caught that `_get_user_api_key` reads user 1 unconditionally). Proven by a spy test.
- **Follow→entity** resolution hook (resolution only — no schema change, no merge re-point).

## Validation
**Backend 194 passed / 1 skipped** · **frontend build + 47 vitest + lint:copy** green. Slices: S0 schema/parity · S1-S2 endpoints · S3-S4 extract+resolve+idempotent · S5-S6 backfill+platform-key · S7 follow hook · S8 chip row.

## Gate note (honest)
The full multi-hop graph engine (G3) + per-user overlay (G2) remain gated on traction (~50-100 WAU, ≥15-20% multi-hop demand). G1 ships as the cheap substrate + immediate single-user depth. To populate entities in dev: set `GRAPH_EXTRACTION_ENABLED=true` + a platform `OPENAI_API_KEY` (the job is dark by default, so endpoints return `[]` and the chip row hides until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)