### PR TITLE
G2 — per-user entity overlay: your followed/read entities rank first

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -361,6 +361,17 @@ async def create_feedback(
         feedback_type=body.feedback_type.value,
     )
 
+    # G2: positive feedback seeds per-user relevance for the article's entities (decay at read time).
+    if body.feedback_type != FeedbackType.less:
+        from app.config import settings
+        from app.services import entities
+
+        n = await entities.bump_relevance_for_article(
+            db, current_user_id(), body.article_id, source="feedback", weight=settings.uer_follow_weight
+        )
+        if n:
+            await db.commit()
+
     return FeedbackOut.model_validate(feedback)
 
 
@@ -1277,10 +1288,11 @@ async def cluster_timeline(cluster_id: int, db: AsyncSession = Depends(get_db)):
 
 @router.get("/clusters/{cluster_id}/entities", dependencies=[Depends(get_current_user)])
 async def cluster_entities_endpoint(cluster_id: int, db: AsyncSession = Depends(get_db)):
-    """G1 cast strip: who/what is in this story (salient entities), highest-salience first."""
+    """G1 cast strip: who/what is in this story (salient entities), highest-salience first.
+    G2: the owner's followed/read entities rank up when uer_enabled."""
     from app.services import entities
 
-    return await entities.cluster_entities(db, cluster_id)
+    return await entities.cluster_entities(db, cluster_id, user_id=current_user_id())
 
 
 @router.get("/entities/{entity_id}/clusters", dependencies=[Depends(get_current_user)])
@@ -1332,17 +1344,27 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
     ).scalar_one_or_none()
     if existing is not None:
         return FollowOut.model_validate(existing)
-    f = Follow(user_id=current_user_id(), kind=kind, value=value)
+    f = Follow(
+        user_id=current_user_id(), kind=kind, value=value,
+        entity_id=(body.entity_id if kind == "entity" else None),
+    )
     db.add(f)
     await db.commit()
     await db.refresh(f)
     if kind == "entity":
-        # G1 S7: opportunistically resolve the followed entity to a graph node (resolution only —
-        # no follows.entity_id column, no merge re-point; both are deferred to G2).
+        from app.config import settings
         from app.services import entities
 
-        eid = await entities.resolve_existing(db, value)
-        logger.info("entity_follow_resolved", value=value, entity_id=eid)
+        if f.entity_id is not None:
+            # G2: trustworthy entity id from the tapped chip → persist + seed the relevance overlay.
+            await entities.bump_relevance(
+                db, current_user_id(), f.entity_id, source="follow", weight=settings.uer_follow_weight
+            )
+            await db.commit()
+        else:
+            # String path: resolve_existing is kind-blind, so stays log-only (no UER write).
+            eid = await entities.resolve_existing(db, value)
+            logger.info("entity_follow_resolved", value=value, entity_id=eid)
     return FollowOut.model_validate(f)
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -77,6 +77,14 @@ class Settings(BaseSettings):
     graph_use_platform_key: bool = True        # extract on the platform key, never the owner's per-user key
     graph_extract_interval_minutes: int = 15   # backfill cadence
 
+    # G2 per-user entity overlay (Wave D Phase 3). Decay/weight constants are HYPOTHESES — no
+    # single-user data can tune them; treat as knobs, not validated values. Ships off by default.
+    uer_enabled: bool = False
+    uer_half_life_days: float = 21.0
+    uer_follow_weight: float = 1.0
+    uer_rank_alpha: float = 0.6   # weight on global salience
+    uer_rank_beta: float = 0.4    # weight on decayed per-user relevance
+
     # DB SSL: verified by default for cloud (Neon/Supabase). Opt out only if a cert
     # chain genuinely can't be verified in your environment.
     db_ssl_insecure: bool = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -237,6 +237,38 @@ def init_firebase() -> bool:
         return False
 
 
+async def check_rls_posture(db=None) -> bool:
+    """Log whether the DB connection bypasses Row-Level Security. RLS enforces ONLY under a
+    non-superuser role; the default `newslens` role is a SUPERUSER, so per-user isolation currently
+    relies on the explicit current_user_id() filter (RLS is defense-in-depth, inert under superuser).
+    Returns True when the connection is a superuser (RLS inert). Provision a restricted app role for
+    production — see backend/scripts/create_app_role.sql."""
+    async def _read(s):
+        return (await s.execute(text("SELECT current_setting('is_superuser')"))).scalar()
+
+    try:
+        if db is not None:
+            su = await _read(db)
+        else:
+            async with async_session() as s:
+                su = await _read(s)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("rls_posture_check_failed", error=str(e))
+        return True
+
+    is_super = su == "on"
+    if is_super:
+        detail = (
+            "DB connection is a superuser → per-user RLS is INERT (the explicit current_user_id() "
+            "filter is the only isolation control). Provision a non-superuser app role for "
+            "production — backend/scripts/create_app_role.sql."
+        )
+        (logger.error if settings.auth_required else logger.warning)("rls_posture_warning", detail=detail)
+    else:
+        logger.info("rls_posture_ok")
+    return is_super
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("starting_newslens")
@@ -249,6 +281,11 @@ async def lifespan(app: FastAPI):
         init_firebase()  # one-time Admin SDK init (no-op if no credential configured)
     except Exception as e:
         logger.error("firebase_init_failed", error=str(e))
+
+    try:
+        await check_rls_posture()  # surface whether RLS is actually enforced (non-superuser role)
+    except Exception as e:
+        logger.warning("rls_posture_check_failed", error=str(e))
 
     scheduler = None
     try:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -287,12 +287,16 @@ class Follow(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     kind: Mapped[str] = mapped_column(String(16), nullable=False)  # topic|entity|saved_search
     value: Mapped[str] = mapped_column(String(255), nullable=False)
+    # G2: the resolved entity behind an entity-follow (from the tapped chip). Nullable keeps uq_follow
+    # live with no orphan window; the string-path follow leaves it NULL.
+    entity_id: Mapped[int | None] = mapped_column(ForeignKey("entities.id", ondelete="SET NULL"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
 
     __table_args__ = (
         UniqueConstraint("user_id", "kind", "value", name="uq_follow"),
+        Index("ix_follows_entity", "entity_id"),
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -380,13 +380,34 @@ class ArticleEntity(Base):
     )
 
 
+class UserEntityRelevance(Base):
+    """G2: per-user affinity on a GLOBAL entity. The only new RLS-scoped table — JOIN/filter only,
+    never a graph-per-user. Drives personalized cast-strip ranking. Decay is computed AT READ TIME
+    from engagement_raw + last_event_at, so `score` is an optional write-time cache, not the key."""
+
+    __tablename__ = "user_entity_relevance"
+
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), primary_key=True)
+    entity_id: Mapped[int] = mapped_column(
+        ForeignKey("entities.id", ondelete="CASCADE"), primary_key=True
+    )
+    source: Mapped[str] = mapped_column(String(16), nullable=False)  # follow | feedback
+    engagement_raw: Mapped[float] = mapped_column(Float, server_default="0", nullable=False)
+    last_event_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    score: Mapped[float | None] = mapped_column(Float)  # optional write-time cache (not the ranking key)
+
+    __table_args__ = (
+        Index("ix_uer_user_score", "user_id", "score"),  # serves the WHERE user_id= filter
+    )
+
+
 # ── Row-Level Security (Wave D Phase A) ──────────────────────────────────────────────
 # Per-user tables are isolated by the `app.user_id` GUC, which get_current_user sets per request
 # (SET LOCAL). "Enforce-when-set": when the GUC is unset — background jobs reading the owner's API
 # key, direct-DB tests — the policy is permissive; when set (every real request) rows are filtered
 # to that user. The explicit current_user_id() filter in queries is the PRIMARY control; RLS is
 # defense-in-depth. Defined here (DDL events) so create_all (tests) matches the production migration.
-_RLS_TABLES = ("user_feedback", "user_preferences", "user_settings", "follows")
+_RLS_TABLES = ("user_feedback", "user_preferences", "user_settings", "follows", "user_entity_relevance")
 
 
 def rls_statements(table: str) -> list[str]:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -325,6 +325,7 @@ class AskAnswer(BaseModel):
 class FollowCreate(BaseModel):
     kind: str  # topic | entity | saved_search
     value: str
+    entity_id: int | None = None  # G2: the tapped chip's entity id (kind=entity) — trustworthy link
 
 
 class FollowOut(BaseModel):

--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -8,31 +8,56 @@ entity ids + content version + persona/depth (+ user scope at G2), or it will se
 answers. The G1 endpoints are uncached pure-SQL reads, so the trap does not bite yet.
 """
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database import async_session
-from app.models import ArticleEntity, ClusterArticle, Entity, EntityAlias, StoryCluster
+from app.models import (
+    ArticleEntity, ClusterArticle, Entity, EntityAlias, StoryCluster, UserEntityRelevance,
+)
 from app.schemas import EntityExtraction
 from app.services import llm, retrieval
 
 logger = structlog.get_logger()
 
 
-async def cluster_entities(db: AsyncSession, cluster_id: int) -> list[dict]:
+_LN2 = 0.6931471805599453  # ln(2) for the half-life decay
+
+
+async def cluster_entities(db: AsyncSession, cluster_id: int, user_id: int | None = None) -> list[dict]:
     """Cast strip: salient entities across this cluster's articles, deduped by entity (max salience),
-    highest-salience first, capped at graph_max_entities_per_cluster."""
+    capped. With uer_enabled + a user_id, the owner's followed/read entities rank up via
+    alpha*salience + beta*decayed_relevance (decay = exp(-ln2 * age_days / half_life), read-time).
+    With uer_enabled off (or no user) the output is byte-identical to G1 (ordered by salience)."""
     sal = func.max(ArticleEntity.salience).label("salience")
-    q = (
+    base = (
         select(Entity.id, Entity.canonical_name, Entity.kind, sal)
         .join(ArticleEntity, ArticleEntity.entity_id == Entity.id)
         .join(ClusterArticle, ClusterArticle.article_id == ArticleEntity.article_id)
         .where(ClusterArticle.cluster_id == cluster_id)
         .group_by(Entity.id, Entity.canonical_name, Entity.kind)
-        .order_by(sal.desc())
-        .limit(settings.graph_max_entities_per_cluster)
     )
+    cap = settings.graph_max_entities_per_cluster
+    if settings.uer_enabled and user_id is not None:
+        age_days = func.extract("epoch", func.now() - UserEntityRelevance.last_event_at) / 86400.0
+        decayed = func.coalesce(
+            func.max(UserEntityRelevance.engagement_raw
+                     * func.exp(-_LN2 * age_days / settings.uer_half_life_days)),
+            0.0,
+        )
+        rank = settings.uer_rank_alpha * func.max(ArticleEntity.salience) + settings.uer_rank_beta * decayed
+        q = (
+            base.outerjoin(
+                UserEntityRelevance,
+                and_(UserEntityRelevance.entity_id == Entity.id,
+                     UserEntityRelevance.user_id == user_id),
+            )
+            .order_by(rank.desc())
+            .limit(cap)
+        )
+    else:
+        q = base.order_by(func.max(ArticleEntity.salience).desc()).limit(cap)
     rows = (await db.execute(q)).all()
     return [
         {"id": r.id, "canonical_name": r.canonical_name, "kind": r.kind, "salience": r.salience}
@@ -66,6 +91,41 @@ async def resolve_existing(db: AsyncSession, value: str) -> int | None:
         return ent.id
     ea = (await db.execute(select(EntityAlias).where(EntityAlias.alias_norm == q))).scalars().first()
     return ea.entity_id if ea is not None else None
+
+
+async def bump_relevance(db: AsyncSession, user_id: int, entity_id: int, *, source: str, weight: float) -> None:
+    """G2: upsert the per-user affinity row for (user, entity) — add `weight`, refresh last_event_at.
+    Called on follow (source='follow') + reading feedback (source='feedback'). Decay is computed at
+    READ time from engagement_raw + last_event_at (no cron), so this only accumulates raw signal."""
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    row = (
+        await db.execute(
+            select(UserEntityRelevance).where(
+                UserEntityRelevance.user_id == user_id,
+                UserEntityRelevance.entity_id == entity_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        db.add(UserEntityRelevance(user_id=user_id, entity_id=entity_id, source=source,
+                                   engagement_raw=weight, last_event_at=now))
+    else:
+        row.engagement_raw = (row.engagement_raw or 0.0) + weight
+        row.last_event_at = now
+
+
+async def bump_relevance_for_article(db: AsyncSession, user_id: int, article_id: int, *,
+                                     source: str, weight: float) -> int:
+    """G2 S4: bump per-user relevance for every entity mentioned in an article (a feedback signal).
+    Returns the number of entities bumped."""
+    ent_ids = (
+        await db.execute(select(ArticleEntity.entity_id).where(ArticleEntity.article_id == article_id))
+    ).scalars().all()
+    for eid in ent_ids:
+        await bump_relevance(db, user_id, eid, source=source, weight=weight)
+    return len(ent_ids)
 
 
 # ── Extraction + resolution (G1 S3-S4) ──────────────────────────────────────────────

--- a/backend/migrations/versions/c0d1e2f3a4b5_g2_user_entity_relevance.py
+++ b/backend/migrations/versions/c0d1e2f3a4b5_g2_user_entity_relevance.py
@@ -1,0 +1,45 @@
+"""g2: user_entity_relevance overlay (RLS-scoped)
+
+Revision ID: c0d1e2f3a4b5
+Revises: e1f2a3b4c5d6
+Create Date: 2026-06-26 09:00:00.000000
+
+The only new RLS-scoped table — mirrors the c9d0e1f2a3b4 RLS migration via rls_statements().
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.models import rls_statements
+
+revision: str = "c0d1e2f3a4b5"
+down_revision: Union[str, None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_entity_relevance",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("source", sa.String(length=16), nullable=False),
+        sa.Column("engagement_raw", sa.Float(), server_default="0", nullable=False),
+        sa.Column("last_event_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["entity_id"], ["entities.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "entity_id"),
+    )
+    op.create_index("ix_uer_user_score", "user_entity_relevance", ["user_id", "score"])
+    for stmt in rls_statements("user_entity_relevance"):
+        op.execute(stmt)
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS user_entity_relevance_user_isolation ON user_entity_relevance")
+    op.execute("ALTER TABLE user_entity_relevance NO FORCE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE user_entity_relevance DISABLE ROW LEVEL SECURITY")
+    op.drop_index("ix_uer_user_score", table_name="user_entity_relevance")
+    op.drop_table("user_entity_relevance")

--- a/backend/migrations/versions/c9d0e1f2a3b4_wave_d_rls.py
+++ b/backend/migrations/versions/c9d0e1f2a3b4_wave_d_rls.py
@@ -13,22 +13,26 @@ from typing import Sequence, Union
 
 from alembic import op
 
-from app.models import _RLS_TABLES, rls_statements
+from app.models import rls_statements
 
 revision: str = "c9d0e1f2a3b4"
 down_revision: Union[str, None] = "b8c9d0e1f2a3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+# Pinned to the tables that existed at THIS migration — do NOT import the live models._RLS_TABLES,
+# which later migrations extend (e.g. G2's user_entity_relevance, created in a later revision).
+_TABLES = ("user_feedback", "user_preferences", "user_settings", "follows")
+
 
 def upgrade() -> None:
-    for table in _RLS_TABLES:
+    for table in _TABLES:
         for stmt in rls_statements(table):
             op.execute(stmt)
 
 
 def downgrade() -> None:
-    for table in _RLS_TABLES:
+    for table in _TABLES:
         op.execute(f"DROP POLICY IF EXISTS {table}_user_isolation ON {table}")
         op.execute(f"ALTER TABLE {table} NO FORCE ROW LEVEL SECURITY")
         op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")

--- a/backend/migrations/versions/d1e2f3a4b5c6_g2_follow_entity_id.py
+++ b/backend/migrations/versions/d1e2f3a4b5c6_g2_follow_entity_id.py
@@ -1,0 +1,29 @@
+"""g2: follows.entity_id (persist the resolved entity behind an entity-follow)
+
+Revision ID: d1e2f3a4b5c6
+Revises: c0d1e2f3a4b5
+Create Date: 2026-06-26 09:30:00.000000
+
+Nullable add keeps uq_follow(user_id,kind,value) live — no orphan window.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, None] = "c0d1e2f3a4b5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("follows", sa.Column("entity_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(None, "follows", "entities", ["entity_id"], ["id"], ondelete="SET NULL")
+    op.create_index("ix_follows_entity", "follows", ["entity_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_follows_entity", table_name="follows")
+    op.drop_constraint("follows_entity_id_fkey", "follows", type_="foreignkey")
+    op.drop_column("follows", "entity_id")

--- a/backend/scripts/create_app_role.sql
+++ b/backend/scripts/create_app_role.sql
@@ -1,0 +1,24 @@
+-- G2 S0b: provision a NON-SUPERUSER application role so Postgres Row-Level Security is a LIVE
+-- control in production (not theatre). The default `newslens` role is a superuser and bypasses RLS,
+-- so per-user isolation today relies solely on the app's explicit current_user_id() filter. Run
+-- this as a superuser, then point the app's DATABASE_URL at newslens_app.
+--
+-- Usage:
+--   psql "$ADMIN_DATABASE_URL" -v app_password="$NEWSLENS_APP_PASSWORD" -f create_app_role.sql
+--   then set DATABASE_URL=postgresql+asyncpg://newslens_app:<pw>@<host>/newslens
+--
+-- The app role MUST be able to do everything the app needs (DML on every table, sequences, schema
+-- usage) but MUST be NOSUPERUSER + NOBYPASSRLS so the *_user_isolation policies apply to it.
+
+CREATE ROLE newslens_app LOGIN PASSWORD :'app_password' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE;
+
+GRANT USAGE ON SCHEMA public TO newslens_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO newslens_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO newslens_app;
+
+-- Future tables/sequences (migrations create them as the owner) inherit these grants:
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO newslens_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO newslens_app;
+
+-- Verify: this should print 'off'
+-- SET ROLE newslens_app; SELECT current_setting('is_superuser'); RESET ROLE;

--- a/backend/tests/integration/test_foundation.py
+++ b/backend/tests/integration/test_foundation.py
@@ -34,6 +34,8 @@ EXPECTED_TABLES = {
     "entities",
     "entity_aliases",
     "article_entities",
+    # G2 per-user overlay
+    "user_entity_relevance",
 }
 
 # backend/ root (contains alembic.ini + migrations/), two levels up from this file.

--- a/backend/tests/integration/test_g2_overlay.py
+++ b/backend/tests/integration/test_g2_overlay.py
@@ -1,0 +1,155 @@
+"""G2 S2-S4: follow→entity persistence + relevance seeding, personalized ranking, feedback + decay."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Follow, Source, SourceType,
+    StoryCluster, User, UserEntityRelevance,
+)
+from app.services import entities as E
+
+_n = 0
+
+
+async def _ensure_user1(db):
+    if (await db.execute(select(User).where(User.id == 1))).scalar_one_or_none() is None:
+        db.add(User(id=1, locale="IN"))  # UER.user_id FK target (the default user)
+        await db.flush()
+
+
+async def _src(db):
+    global _n
+    _n += 1
+    s = Source(name="S", url=f"https://g2/{_n}", source_type=SourceType.wire)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _article(db, src):
+    global _n
+    _n += 1
+    a = Article(title="A", url=f"https://g2/{_n}/a", source_id=src.id,
+                embedding_status=EmbeddingStatus.complete)
+    db.add(a)
+    await db.flush()
+    return a
+
+
+async def _cluster(db, *arts):
+    cl = StoryCluster(title="C")
+    db.add(cl)
+    await db.flush()
+    for a in arts:
+        db.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db.flush()
+    return cl
+
+
+async def _entity(db, name):
+    e = Entity(canonical_name=name, name_norm=name.lower(), kind="org")
+    db.add(e)
+    await db.flush()
+    return e
+
+
+# ── S2 ──
+@pytest.mark.asyncio
+async def test_entity_follow_persists_entity_id_and_seeds_relevance(aclient, db_session):
+    e = await _entity(db_session, "Acme")
+    r = await aclient.post("/follows", json={"kind": "entity", "value": "Acme", "entity_id": e.id})
+    assert r.status_code == 201
+    follow = (await db_session.execute(select(Follow).where(Follow.value == "Acme"))).scalar_one()
+    assert follow.entity_id == e.id
+    uer = (await db_session.execute(
+        select(UserEntityRelevance).where(UserEntityRelevance.entity_id == e.id))).scalar_one()
+    assert uer.source == "follow" and uer.engagement_raw == 1.0
+    # idempotent re-follow → existing follow returned, no second bump
+    await aclient.post("/follows", json={"kind": "entity", "value": "Acme", "entity_id": e.id})
+    uer2 = (await db_session.execute(
+        select(UserEntityRelevance).where(UserEntityRelevance.entity_id == e.id))).scalar_one()
+    assert uer2.engagement_raw == 1.0
+
+
+# ── S3 ──
+@pytest.mark.asyncio
+async def test_cluster_entities_personalized_ranks_followed_first(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    a = await _article(db_session, src)
+    cl = await _cluster(db_session, a)
+    e1 = await _entity(db_session, "Plain")
+    e2 = await _entity(db_session, "Followed")
+    db_session.add_all([
+        ArticleEntity(article_id=a.id, entity_id=e1.id, salience=0.5),
+        ArticleEntity(article_id=a.id, entity_id=e2.id, salience=0.5),
+    ])
+    db_session.add(UserEntityRelevance(user_id=1, entity_id=e2.id, source="follow",
+                                       engagement_raw=1.0, last_event_at=datetime.now(timezone.utc)))
+    await db_session.flush()
+    body = (await aclient.get(f"/clusters/{cl.id}/entities")).json()
+    assert body[0]["canonical_name"] == "Followed"  # equal salience → the followed entity ranks first
+
+
+@pytest.mark.asyncio
+async def test_cluster_entities_identical_when_disabled(db_session):
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    a = await _article(db_session, src)
+    cl = await _cluster(db_session, a)
+    e_lo = await _entity(db_session, "Lo")
+    e_hi = await _entity(db_session, "Hi")
+    db_session.add_all([
+        ArticleEntity(article_id=a.id, entity_id=e_lo.id, salience=0.2),
+        ArticleEntity(article_id=a.id, entity_id=e_hi.id, salience=0.9),
+    ])
+    db_session.add(UserEntityRelevance(user_id=1, entity_id=e_lo.id, source="follow",
+                                       engagement_raw=5.0, last_event_at=datetime.now(timezone.utc)))
+    await db_session.flush()
+    out = await E.cluster_entities(db_session, cl.id, user_id=1)  # uer_enabled False (default)
+    assert [r["canonical_name"] for r in out] == ["Hi", "Lo"]  # pure salience, UER ignored
+
+
+# ── S4 ──
+@pytest.mark.asyncio
+async def test_feedback_updates_relevance(aclient, db_session):
+    src = await _src(db_session)
+    a = await _article(db_session, src)
+    e = await _entity(db_session, "Mentioned")
+    db_session.add(ArticleEntity(article_id=a.id, entity_id=e.id, salience=0.7))
+    await db_session.flush()
+    r = await aclient.post("/feedback", json={"article_id": a.id, "feedback_type": "save"})
+    assert r.status_code == 201
+    uer = (await db_session.execute(
+        select(UserEntityRelevance).where(UserEntityRelevance.entity_id == e.id))).scalar_one()
+    assert uer.source == "feedback" and uer.engagement_raw == 1.0
+
+
+@pytest.mark.asyncio
+async def test_relevance_decay_on_read(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    a = await _article(db_session, src)
+    cl = await _cluster(db_session, a)
+    e_old = await _entity(db_session, "Old")
+    e_new = await _entity(db_session, "New")
+    db_session.add_all([
+        ArticleEntity(article_id=a.id, entity_id=e_old.id, salience=0.5),
+        ArticleEntity(article_id=a.id, entity_id=e_new.id, salience=0.5),
+    ])
+    now = datetime.now(timezone.utc)
+    db_session.add_all([
+        UserEntityRelevance(user_id=1, entity_id=e_old.id, source="follow",
+                            engagement_raw=1.0, last_event_at=now - timedelta(days=120)),
+        UserEntityRelevance(user_id=1, entity_id=e_new.id, source="follow",
+                            engagement_raw=1.0, last_event_at=now),
+    ])
+    await db_session.flush()
+    out = await E.cluster_entities(db_session, cl.id, user_id=1)
+    assert out[0]["canonical_name"] == "New"  # fresh engagement decays less → ranks above the stale one

--- a/backend/tests/integration/test_rls.py
+++ b/backend/tests/integration/test_rls.py
@@ -16,12 +16,14 @@ _MAKE_PROBE = """
 DO $$ BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
     REVOKE ALL ON user_feedback FROM {role};
+    REVOKE ALL ON user_entity_relevance FROM {role};
     REVOKE ALL ON SCHEMA public FROM {role};
     DROP ROLE {role};
   END IF;
   CREATE ROLE {role} NOLOGIN;
   GRANT USAGE ON SCHEMA public TO {role};
   GRANT SELECT ON user_feedback TO {role};
+  GRANT SELECT ON user_entity_relevance TO {role};
 END $$;
 """
 
@@ -82,3 +84,53 @@ async def test_rls_permissive_when_guc_unset(db_session):
             await db_session.execute(text("RESET ROLE"))
         except Exception:
             pass  # don't mask the real assertion/SQL error from the try block
+
+
+@pytest.mark.asyncio
+async def test_uer_rls_isolation_for_restricted_role(db_session):
+    """G2 S1: user_entity_relevance is RLS-scoped — a restricted role sees only its own rows."""
+    from datetime import datetime, timezone
+
+    from app.models import Entity, UserEntityRelevance
+
+    db_session.add_all([User(id=601, locale="IN"), User(id=602, locale="IN")])
+    e = Entity(canonical_name="X", name_norm="x", kind="org")
+    db_session.add(e)
+    await db_session.flush()
+    db_session.add(UserEntityRelevance(
+        user_id=601, entity_id=e.id, source="follow", engagement_raw=1.0,
+        last_event_at=datetime.now(timezone.utc)))
+    await db_session.flush()
+
+    await db_session.execute(text(_MAKE_PROBE.format(role="uer_probe")))
+    try:
+        await db_session.execute(text("SET ROLE uer_probe"))
+        await db_session.execute(text("SELECT set_config('app.user_id', '602', true)"))
+        seen = (await db_session.execute(select(UserEntityRelevance))).scalars().all()
+        assert not any(r.user_id == 601 for r in seen)  # user 601's affinity hidden from 602
+
+        await db_session.execute(text("SELECT set_config('app.user_id', '601', true)"))
+        seen601 = (await db_session.execute(select(UserEntityRelevance))).scalars().all()
+        assert any(r.user_id == 601 for r in seen601)
+    finally:
+        try:
+            await db_session.execute(text("RESET ROLE"))
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_rls_posture_detects_superuser_vs_restricted(db_session):
+    """G2 S0b: the startup posture check reports whether the connection bypasses RLS."""
+    from app.main import check_rls_posture
+
+    assert await check_rls_posture(db_session) is True  # default test role IS a superuser → RLS inert
+    await db_session.execute(text(_MAKE_PROBE.format(role="rls_posture_probe")))
+    try:
+        await db_session.execute(text("SET ROLE rls_posture_probe"))
+        assert await check_rls_posture(db_session) is False  # restricted role → RLS would enforce
+    finally:
+        try:
+            await db_session.execute(text("RESET ROLE"))
+        except Exception:
+            pass

--- a/backend/tests/unit/test_config_g2.py
+++ b/backend/tests/unit/test_config_g2.py
@@ -1,0 +1,10 @@
+"""G2 S0: the per-user-relevance config knobs exist with safe-off / hypothesis-grade defaults."""
+from app.config import settings
+
+
+def test_g2_config_defaults():
+    assert settings.uer_enabled is False  # overlay ships dark
+    assert settings.uer_half_life_days == 21.0
+    assert settings.uer_follow_weight == 1.0
+    assert settings.uer_rank_alpha == 0.6
+    assert settings.uer_rank_beta == 0.4

--- a/docs/moat/g2-economics-onepager.md
+++ b/docs/moat/g2-economics-onepager.md
@@ -1,0 +1,23 @@
+# G2 economics — the N* break-even (Gate-2 deliverable)
+
+The GraphRAG investment only pays off above a user count where the **one-time, content-cost**
+extraction amortizes across enough users versus the **per-user** vector baseline.
+
+```
+N*  =  extraction_cost_per_day  /  vector_baseline_cost_per_user_per_day
+```
+
+- **extraction_cost_per_day** — the G1 entity-extraction LLM spend: one JSON pass per *settled,
+  changed* cluster (not per article, not per tick), on the platform key, cheap model. From real
+  ingest: `clusters_extracted_per_day × tokens_per_cluster × $/token`.
+- **vector_baseline_cost_per_user_per_day** — what a pure pgvector retrieval (no graph) costs to
+  serve one active user per day.
+
+**Interpretation:** below N* users, the graph is a cost with no offsetting scale; above it, the
+shared global graph (extracted once) is cheaper per marginal user than re-running vector retrieval
+for each. G1 keeps the **numerator low** (extract-once, on-change, salient-only) so N* lands low.
+
+**Status:** this is a *paper* deliverable to evaluate before committing to G3 (the multi-hop engine).
+G2's overlay adds **zero** new extraction (it only JOINs the existing global graph per user), so it
+does not move the numerator. Plug in real token/ingest numbers when WAU exists; until then the gate
+(~50–100 WAU + ≥15–20% multi-hop demand) is unmet and G3 stays deferred.

--- a/frontend/src/components/ui/EntityChips.test.tsx
+++ b/frontend/src/components/ui/EntityChips.test.tsx
@@ -9,7 +9,10 @@ vi.mock("@/lib/api", () => ({
   getEntityClusters: vi
     .fn()
     .mockResolvedValue([{ cluster_id: 9, title: "Older related story", created_at: "x" }]),
+  addFollow: vi.fn().mockResolvedValue({ id: 1, kind: "entity", value: "Reserve Bank" }),
 }));
+
+import * as api from "@/lib/api";
 
 const entities: ClusterEntity[] = [
   { id: 1, canonical_name: "Reserve Bank", kind: "org", salience: 0.9 },
@@ -32,5 +35,12 @@ describe("EntityChips (G1)", () => {
     render(<EntityChips clusterId={1} data={entities} />);
     await userEvent.click(screen.getByText("Reserve Bank"));
     expect(await screen.findByText("Older related story")).toBeInTheDocument();
+  });
+
+  it("Follow passes the entity id (G2)", async () => {
+    render(<EntityChips clusterId={1} data={entities} />);
+    await userEvent.click(screen.getByText("Reserve Bank"));
+    await userEvent.click(await screen.findByText("Follow"));
+    expect(vi.mocked(api.addFollow)).toHaveBeenCalledWith("entity", "Reserve Bank", 1);
   });
 });

--- a/frontend/src/components/ui/EntityChips.tsx
+++ b/frontend/src/components/ui/EntityChips.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import {
+  addFollow,
   getClusterEntities,
   getEntityClusters,
   type ClusterEntity,
@@ -22,6 +23,16 @@ export function EntityChips({
   const [data, setData] = useState<ClusterEntity[] | "loading">(provided ?? "loading");
   const [openId, setOpenId] = useState<number | null>(null);
   const [appearsIn, setAppearsIn] = useState<EntityCluster[] | "loading">("loading");
+  const [followed, setFollowed] = useState<number[]>([]);
+
+  async function follow(e: ClusterEntity) {
+    try {
+      await addFollow("entity", e.canonical_name, e.id);  // passes entity_id → real graph link + relevance
+      setFollowed((prev) => [...prev, e.id]);
+    } catch {
+      /* non-fatal */
+    }
+  }
 
   useEffect(() => {
     if (provided !== undefined) {
@@ -73,6 +84,17 @@ export function EntityChips({
       </div>
       {openId !== null && (
         <div className="text-small mt-3 pl-3 border-l-2 border-[var(--accent)]">
+          <button
+            type="button"
+            onClick={() => {
+              const e = data.find((x) => x.id === openId);
+              if (e) follow(e);
+            }}
+            disabled={followed.includes(openId)}
+            className="text-mono mb-2 rounded-full border border-[var(--border)] px-3 py-1 text-[var(--text-secondary)] disabled:opacity-50"
+          >
+            {followed.includes(openId) ? "Following" : "Follow"}
+          </button>
           {appearsIn === "loading" ? (
             <span className="text-[var(--text-tertiary)]">Loading…</span>
           ) : appearsIn.length === 0 ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -506,8 +506,12 @@ export interface FollowItem {
 export async function getFollows(): Promise<FollowItem[]> {
   return fetchJSON("/follows");
 }
-export async function addFollow(kind: string, value: string): Promise<FollowItem> {
-  return fetchJSON("/follows", { method: "POST", body: JSON.stringify({ kind, value }) });
+export async function addFollow(kind: string, value: string, entityId?: number): Promise<FollowItem> {
+  return fetchJSON("/follows", {
+    method: "POST",
+    // G2: pass the tapped chip's entity_id so the follow links to a real graph node (+ seeds relevance).
+    body: JSON.stringify({ kind, value, ...(entityId != null ? { entity_id: entityId } : {}) }),
+  });
 }
 export async function removeFollow(id: number): Promise<void> {
   await fetchJSON(`/follows/${id}`, { method: "DELETE" });


### PR DESCRIPTION
The thin, single-user-valuable cut of the per-user graph overlay on top of G1. TDD; built from an adversarially-reviewed plan (`docs/moat/09`) that deliberately **defers** embedding-NN/auto-merge as unjustified at this volume.

## What it does
- **The cast strip personalizes**: in a story's "IN THIS STORY" chips, the entities you **follow** or have **read about** rank first (`alpha*salience + beta*decayed_relevance`, decay = `exp(-ln2*age/half_life)` computed at read time). With `UER_ENABLED=false` (default) output is **byte-identical to G1**.
- **Following an entity** from a chip now persists a real `follows.entity_id` (from the tapped chip, not kind-blind string matching) and seeds the relevance overlay.
- **Reading/saving** an article feeds relevance for its entities.

## How it's built
- `user_entity_relevance` (PK `user_id,entity_id`) — the **only** new RLS-scoped table (appended to `_RLS_TABLES`; entities/aliases/mentions stay global). RLS isolation proven via the restricted probe role.
- `follows.entity_id` nullable FK (keeps `uq_follow` live, no orphan window).
- Migrations chained linearly onto the Wave E head; fixed a latent bug where the old RLS migration imported the **live** `_RLS_TABLES` (pinned it to its 4 original tables).

## ⚠️ S0b — makes RLS real (operator action)
A startup **RLS-posture assertion** now logs a loud warning (error if `AUTH_REQUIRED`) when the DB connection is a **superuser** — because RLS is bypassed under superuser, which dev/`docker-compose` currently uses. `backend/scripts/create_app_role.sql` is the prod recipe: a non-superuser `newslens_app` role to point `DATABASE_URL` at. Until then, the explicit `current_user_id()` filter is the always-on isolation control (RLS is defense-in-depth).

## Deliberately deferred (not built)
Embedding-NN resolution + reversible auto-merge + `entity_merge_log` (G1's "two thin chips" blemish remains). Re-entry needs a co-typed-homonym precision fixture **and** the prod role — see the plan's risks. The N* economics note (`docs/moat/g2-economics-onepager.md`) is the Gate-2 deliverable for G3.

## Validation
**Backend 217 passed / 1 skipped** (UER RLS isolation, posture, follow-persist+seed, personalized ranking, feedback+decay) · **frontend build + 51 vitest + lint** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)