### PR TITLE
G2 hardening: clamp decay clock-skew + deterministic cast-strip order

### DIFF
--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -40,7 +40,11 @@ async def cluster_entities(db: AsyncSession, cluster_id: int, user_id: int | Non
     )
     cap = settings.graph_max_entities_per_cluster
     if settings.uer_enabled and user_id is not None:
-        age_days = func.extract("epoch", func.now() - UserEntityRelevance.last_event_at) / 86400.0
+        # Clamp age to >= 0: a future last_event_at (clock skew) would otherwise make exp(positive) > 1
+        # and let a followed entity dominate regardless of salience.
+        age_days = func.greatest(
+            0.0, func.extract("epoch", func.now() - UserEntityRelevance.last_event_at) / 86400.0
+        )
         decayed = func.coalesce(
             func.max(UserEntityRelevance.engagement_raw
                      * func.exp(-_LN2 * age_days / settings.uer_half_life_days)),
@@ -48,16 +52,17 @@ async def cluster_entities(db: AsyncSession, cluster_id: int, user_id: int | Non
         )
         rank = settings.uer_rank_alpha * func.max(ArticleEntity.salience) + settings.uer_rank_beta * decayed
         q = (
+            # LEFT JOIN is safe from row fan-out: (user_id, entity_id) is the UER primary key.
             base.outerjoin(
                 UserEntityRelevance,
                 and_(UserEntityRelevance.entity_id == Entity.id,
                      UserEntityRelevance.user_id == user_id),
             )
-            .order_by(rank.desc())
+            .order_by(rank.desc(), Entity.id.asc())  # stable tiebreak → no cast-strip reshuffle
             .limit(cap)
         )
     else:
-        q = base.order_by(func.max(ArticleEntity.salience).desc()).limit(cap)
+        q = base.order_by(func.max(ArticleEntity.salience).desc(), Entity.id.asc()).limit(cap)
     rows = (await db.execute(q)).all()
     return [
         {"id": r.id, "canonical_name": r.canonical_name, "kind": r.kind, "salience": r.salience}

--- a/backend/tests/integration/test_g2_overlay.py
+++ b/backend/tests/integration/test_g2_overlay.py
@@ -96,7 +96,9 @@ async def test_cluster_entities_personalized_ranks_followed_first(aclient, db_se
 
 
 @pytest.mark.asyncio
-async def test_cluster_entities_identical_when_disabled(db_session):
+async def test_cluster_entities_identical_when_disabled(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", False)  # explicit: the disabled branch, regardless of dev env
     await _ensure_user1(db_session)
     src = await _src(db_session)
     a = await _article(db_session, src)
@@ -153,3 +155,53 @@ async def test_relevance_decay_on_read(db_session, monkeypatch):
     await db_session.flush()
     out = await E.cluster_entities(db_session, cl.id, user_id=1)
     assert out[0]["canonical_name"] == "New"  # fresh engagement decays less → ranks above the stale one
+
+
+@pytest.mark.asyncio
+async def test_future_timestamp_does_not_inflate_rank(db_session, monkeypatch):
+    """Clock skew: a last_event_at in the FUTURE must clamp (age>=0, decay<=1), not explode rank."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    a = await _article(db_session, src)
+    cl = await _cluster(db_session, a)
+    e_future = await _entity(db_session, "Future")  # low salience, but its UER row is future-dated
+    e_now = await _entity(db_session, "Now")        # high salience, fresh
+    db_session.add_all([
+        ArticleEntity(article_id=a.id, entity_id=e_future.id, salience=0.1),
+        ArticleEntity(article_id=a.id, entity_id=e_now.id, salience=0.9),
+    ])
+    now = datetime.now(timezone.utc)
+    db_session.add_all([
+        UserEntityRelevance(user_id=1, entity_id=e_future.id, source="follow",
+                            engagement_raw=1.0, last_event_at=now + timedelta(days=365)),
+        UserEntityRelevance(user_id=1, entity_id=e_now.id, source="follow",
+                            engagement_raw=1.0, last_event_at=now),
+    ])
+    await db_session.flush()
+    out = await E.cluster_entities(db_session, cl.id, user_id=1)
+    # Without the clamp, exp(+huge) would rocket "Future" to the top despite salience 0.1.
+    assert out[0]["canonical_name"] == "Now"
+
+
+@pytest.mark.asyncio
+async def test_cluster_entities_tiebreak_is_deterministic(db_session, monkeypatch):
+    """Equal-rank entities (common zero-relevance case) must order by a stable key, not heap order."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    a = await _article(db_session, src)
+    cl = await _cluster(db_session, a)
+    e1 = await _entity(db_session, "Tie one")
+    e2 = await _entity(db_session, "Tie two")
+    e3 = await _entity(db_session, "Tie three")
+    db_session.add_all([
+        ArticleEntity(article_id=a.id, entity_id=e1.id, salience=0.5),
+        ArticleEntity(article_id=a.id, entity_id=e2.id, salience=0.5),
+        ArticleEntity(article_id=a.id, entity_id=e3.id, salience=0.5),
+    ])
+    await db_session.flush()
+    ids = [r["id"] for r in await E.cluster_entities(db_session, cl.id, user_id=1)]
+    assert ids == sorted(ids)  # deterministic ascending-id order on equal rank

--- a/backend/tests/unit/test_config_g2.py
+++ b/backend/tests/unit/test_config_g2.py
@@ -1,9 +1,13 @@
 """G2 S0: the per-user-relevance config knobs exist with safe-off / hypothesis-grade defaults."""
-from app.config import settings
+from app.config import Settings, settings
 
 
-def test_g2_config_defaults():
-    assert settings.uer_enabled is False  # overlay ships dark
+def test_g2_config_defaults(monkeypatch):
+    # Assert the SHIPPED default (the code literal), independent of any ambient UER_ENABLED that a
+    # local docker-compose.override.yml may set for dev — construct a fresh Settings with it unset.
+    monkeypatch.delenv("UER_ENABLED", raising=False)
+    assert Settings().uer_enabled is False  # overlay ships dark
+    # The numeric knobs have no env override in any environment, so the singleton is representative.
     assert settings.uer_half_life_days == 21.0
     assert settings.uer_follow_weight == 1.0
     assert settings.uer_rank_alpha == 0.6


### PR DESCRIPTION
Turning on the G2 personalized cast-strip ranking (`UER_ENABLED=true`, set locally in the gitignored `docker-compose.override.yml`) makes `cluster_entities` a **live, user-dependent read**. An adversarial 4-lens review of that flip (cross-tenant/cache, wiring, query-correctness, RLS-isolation) confirmed it's safe for the app today — and surfaced two genuine latent defects in the merged ranking query, fixed here TDD.

## Fixes
1. **Clock-skew unbounds decay** — a future `last_event_at` made `age_days` negative, so `exp(positive) > 1` inflated a followed entity's rank without limit. Clamped age to `>= 0` (`func.greatest`). → `test_future_timestamp_does_not_inflate_rank`
2. **Non-deterministic tiebreaker** — equal-rank entities (the common zero-relevance case, all `0.6·salience`) reordered across requests, causing cast-strip page-jumping. Added a stable `Entity.id.asc()` secondary sort to **both** ranking branches. → `test_cluster_entities_tiebreak_is_deterministic`

## Also — hermetic default-asserting tests
With `UER_ENABLED`/`GRAPH_EXTRACTION_ENABLED` flipped on in the local dev `docker-compose.override.yml`, those env vars leak into `docker compose run backend pytest` and broke the two tests that assert *default-off* behavior. Made them env-independent: `test_g2_config_defaults` constructs a fresh `Settings()` with the var unset; `test_cluster_entities_identical_when_disabled` sets `uer_enabled=False` explicitly. The suite now passes **even with the override's `UER_ENABLED=true` leaking into the container**.

## Reviewed and intentionally NOT changed
- *Personalize feed / search / briefing / discover* (review flagged as "critical/high") — out-of-G2-scope roadmap items, not defects the flag exposes. No leak, no correctness break.
- *Typed-follow seeding* — the kind-blind string path stays log-only by design (seeding it would violate G2's precision-bias); the UI only taps chips, so it's dormant anyway.
- *Unused `ix_uer_user_score`* — migration churn for a forward-compat column; left as a follow-up.

## Validation
**Backend 219 passed / 1 skipped** (217 + 2 new), green both with flags pinned off *and* with the dev override leaking them on. Also verified live against the running dev DB (rolled-back transaction): following the *less*-salient entity correctly overtakes the more-salient one.

> Heads-up (separate, already applied to the local dev DB, not in this diff): that DB is `create_all`-managed with no `alembic_version`, so the G2 migration's `follows.entity_id` column never landed — the follow-write path would have 500'd. Patched it in place with the exact delta from migration `d1e2f3a4b5c6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)