### PR TITLE
Personalize feed / briefing / search with the G2 entity-relevance overlay

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1578,7 +1578,7 @@ async def create_source(body: dict, db: AsyncSession = Depends(get_db)):
 
 
 # ── E4: hybrid search (semantic + keyword; keyword ranks above semantic-only) ──
-@router.get("/search")
+@router.get("/search", dependencies=[Depends(get_current_user)])
 async def search(
     q: str = Query(..., min_length=1),
     limit: int = Query(20, ge=1, le=50),
@@ -1663,5 +1663,29 @@ async def search(
             "source": SourceOut.model_validate(a.source).model_dump(),
             "cluster_id": cluster_id,
             "matched_on": meta["matched_on"],
+            "_rank": meta["rank"],
         })
+
+    # G2: within-tier relevance boost. Dedup ran on the ORIGINAL rank (so the representative article
+    # per cluster is unchanged); now nudge whole clusters the user has affinity for. The boost is
+    # capped well below the 100-point keyword/semantic tier gap, so a boosted semantic result can
+    # outrank an unboosted semantic one but NEVER crosses a keyword result (rank 0). Off → no reorder.
+    from app.config import settings as app_settings
+
+    if app_settings.uer_enabled:
+        from app.services import entities
+
+        cl_ids = [o["cluster_id"] for o in out if o["cluster_id"] is not None]
+        scores = await entities.score_clusters_relevance(db, cl_ids, current_user_id())
+
+        def _effective_rank(o):
+            rel = min(1.0, scores.get(o["cluster_id"], 0.0))
+            boost = (app_settings.uer_search_rerank_boost * rel
+                     if rel >= app_settings.uer_search_relevance_threshold else 0.0)
+            return o["_rank"] - boost
+
+        out.sort(key=_effective_rank)  # stable: ties keep dedup order
+
+    for o in out:
+        o.pop("_rank", None)
     return {"query": query_str, "results": out}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -472,9 +472,16 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
     )
     clusters = result.scalars().all()
 
+    # G2: per-cluster entity relevance for this user (one aggregate; {} when off / zero-signal).
+    from app.services import entities
+
+    cluster_scores = await entities.score_clusters_relevance(
+        db, [c.id for c in clusters], current_user_id()
+    )
+
     # Track stories with their preference weights for explore/exploit sorting
     stories: list[BriefingStory] = []
-    story_weights: dict[int, float] = {}  # cluster_id -> pref_weight
+    story_weights: dict[int, float] = {}  # cluster_id -> blended weight
 
     for cluster in clusters:
         # Count unique sources and gather metadata
@@ -528,9 +535,13 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
         # Check if any article in this cluster has been read
         is_read = any(aid in read_article_ids for aid in cluster_article_ids)
 
-        # Track preference weight for explore/exploit sorting
+        # Track preference weight for explore/exploit sorting. G2: blend entity relevance ADDITIVELY
+        # (orthogonal to the explicit topic preference — a followed-entity story can climb even with
+        # no topic preference; a zero-signal user gets +0, so ordering is identical to today).
         pref_weight = prefs.get(topic_id, 0.0) if topic_id else 0.0
-        story_weights[cluster.id] = pref_weight
+        story_weights[cluster.id] = (
+            pref_weight + app_settings.uer_briefing_blend_weight * cluster_scores.get(cluster.id, 0.0)
+        )
 
         # E6: best-effort WIIFM headline from ALREADY-cached impact_json (no LLM calls).
         impact_headline = _extract_impact_headline(cluster.impact_json)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -94,6 +94,7 @@ async def get_feed(
     db: AsyncSession = Depends(get_db),
 ):
     offset = (page - 1) * per_page
+    from app.config import settings as app_settings
 
     query = (
         select(Article)
@@ -106,13 +107,18 @@ async def get_feed(
             Article.topics.any(topic_id=topic)
         )
 
-    # Get total count
-    count_query = select(func.count()).select_from(query.subquery())
-    total = (await db.execute(count_query)).scalar_one()
-
-    # Get paginated results
-    results = await db.execute(query.offset(offset).limit(per_page))
-    articles = results.scalars().all()
+    # G2: when personalizing, fetch a bounded recent pool and rerank it (recency + entity relevance)
+    # BEFORE paginating, so a high-affinity story can cross page boundaries within the horizon. When
+    # off, take the exact legacy path (count + offset/limit) → byte-identical response.
+    if app_settings.uer_enabled:
+        pool_result = await db.execute(query.limit(app_settings.uer_feed_pool_size))
+        articles = pool_result.scalars().all()
+        total = len(articles)  # personalization horizon = the pool
+    else:
+        count_query = select(func.count()).select_from(query.subquery())
+        total = (await db.execute(count_query)).scalar_one()
+        results = await db.execute(query.offset(offset).limit(per_page))
+        articles = results.scalars().all()
 
     # Resolve cluster membership + per-cluster source count in aggregate (no N+1).
     article_ids = [a.id for a in articles]
@@ -149,8 +155,36 @@ async def get_feed(
             ).all()
             clusters_with_summary = {row[0] for row in sum_rows}
 
+    # G2: rerank the pool by the recency+relevance blend, then slice the requested page. When off,
+    # `articles` is already the legacy page, so page_articles == articles (byte-identical).
+    if app_settings.uer_enabled:
+        from app.services import entities
+
+        rel_cluster_ids = list({cid for cid in art_to_cluster.values()})
+        scores = await entities.score_clusters_relevance(db, rel_cluster_ids, current_user_id())
+        pub_ts = {a.id: (a.published_at.timestamp() if a.published_at else None) for a in articles}
+        present = [t for t in pub_ts.values() if t is not None]
+        lo, hi = (min(present), max(present)) if present else (0.0, 0.0)
+        span = (hi - lo) or 1.0
+        ratio = app_settings.uer_feed_blend_ratio
+
+        def _blend(a: Article) -> float:
+            t = pub_ts[a.id]
+            recency = 0.0 if t is None else (1.0 if hi == lo else (t - lo) / span)
+            rel = min(1.0, scores.get(art_to_cluster.get(a.id), 0.0))
+            return (1 - ratio) * recency + ratio * rel
+
+        blends = {a.id: _blend(a) for a in articles}
+        articles.sort(
+            key=lambda a: (blends[a.id], pub_ts[a.id] if pub_ts[a.id] is not None else float("-inf"), a.id),
+            reverse=True,
+        )
+        page_articles = articles[offset:offset + per_page]
+    else:
+        page_articles = articles
+
     article_outs = []
-    for a in articles:
+    for a in page_articles:
         cl_id = art_to_cluster.get(a.id)
         article_outs.append(
             ArticleOut(
@@ -168,7 +202,6 @@ async def get_feed(
         )
 
     # Compute real explore ratio from recent feedback
-    from app.config import settings as app_settings
     feedback_result = await db.execute(
         select(UserFeedback.feedback_type)
         .where(UserFeedback.user_id == current_user_id())

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -82,8 +82,17 @@ class Settings(BaseSettings):
     uer_enabled: bool = False
     uer_half_life_days: float = 21.0
     uer_follow_weight: float = 1.0
-    uer_rank_alpha: float = 0.6   # weight on global salience
+    uer_rank_alpha: float = 0.6   # weight on global salience (cast strip only)
     uer_rank_beta: float = 0.4    # weight on decayed per-user relevance
+    # Surface personalization (feed/briefing/search). Multipliers/offsets on the shared cluster
+    # relevance score — NOT replacements for the core decay knobs above. Hypothesis-grade; ship dark
+    # behind uer_enabled. The cluster score is AVG(decayed relevance) over a cluster's entities, so a
+    # zero-relevance user scores 0 everywhere → every surface collapses to its baseline (no-op).
+    uer_feed_pool_size: int = 500          # recent-article candidate pool when personalizing the feed
+    uer_feed_blend_ratio: float = 0.3      # weight on relevance vs recency in the feed blend [0..1]
+    uer_briefing_blend_weight: float = 0.2  # additive scaler on cluster relevance into story_weights
+    uer_search_rerank_boost: float = 10.0   # max within-tier rank improvement (must stay < the 100 gap)
+    uer_search_relevance_threshold: float = 0.3  # min relevance before any search boost applies
 
     # DB SSL: verified by default for cloud (Neon/Supabase). Opt out only if a cert
     # chain genuinely can't be verified in your environment.

--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -25,6 +25,21 @@ logger = structlog.get_logger()
 _LN2 = 0.6931471805599453  # ln(2) for the half-life decay
 
 
+def _decayed_relevance_sql():
+    """The shared half-life decay aggregate: coalesce(max(engagement_raw * exp(-ln2*age/half_life)), 0),
+    age clamped >= 0 (clock-skew guard). Used by BOTH cluster_entities (its beta term) and the surface
+    scorer so the two cannot drift. MUST be used inside a query grouped per entity (max over that
+    entity's single UER row)."""
+    age_days = func.greatest(
+        0.0, func.extract("epoch", func.now() - UserEntityRelevance.last_event_at) / 86400.0
+    )
+    return func.coalesce(
+        func.max(UserEntityRelevance.engagement_raw
+                 * func.exp(-_LN2 * age_days / settings.uer_half_life_days)),
+        0.0,
+    )
+
+
 async def cluster_entities(db: AsyncSession, cluster_id: int, user_id: int | None = None) -> list[dict]:
     """Cast strip: salient entities across this cluster's articles, deduped by entity (max salience),
     capped. With uer_enabled + a user_id, the owner's followed/read entities rank up via
@@ -40,16 +55,7 @@ async def cluster_entities(db: AsyncSession, cluster_id: int, user_id: int | Non
     )
     cap = settings.graph_max_entities_per_cluster
     if settings.uer_enabled and user_id is not None:
-        # Clamp age to >= 0: a future last_event_at (clock skew) would otherwise make exp(positive) > 1
-        # and let a followed entity dominate regardless of salience.
-        age_days = func.greatest(
-            0.0, func.extract("epoch", func.now() - UserEntityRelevance.last_event_at) / 86400.0
-        )
-        decayed = func.coalesce(
-            func.max(UserEntityRelevance.engagement_raw
-                     * func.exp(-_LN2 * age_days / settings.uer_half_life_days)),
-            0.0,
-        )
+        decayed = _decayed_relevance_sql()  # shared clock-skew-clamped half-life decay
         rank = settings.uer_rank_alpha * func.max(ArticleEntity.salience) + settings.uer_rank_beta * decayed
         q = (
             # LEFT JOIN is safe from row fan-out: (user_id, entity_id) is the UER primary key.
@@ -131,6 +137,52 @@ async def bump_relevance_for_article(db: AsyncSession, user_id: int, article_id:
     for eid in ent_ids:
         await bump_relevance(db, user_id, eid, source=source, weight=weight)
     return len(ent_ids)
+
+
+# ── Surface personalization (G2 S5): one shared per-cluster relevance score ──────────
+
+
+async def score_clusters_relevance(
+    db: AsyncSession, cluster_ids: list[int], user_id: int | None
+) -> dict[int, float]:
+    """Per-cluster user affinity = AVG over the cluster's entities of the decayed relevance (the SAME
+    decay as the cast strip, via _decayed_relevance_sql). The ONE primitive that feed / briefing /
+    search consume to personalize their ranking. Returns {cluster_id: score}; clusters with entities
+    but no signal score 0.0, clusters with no entities are absent — callers treat absent as 0.0.
+
+    Fast-returns {} when personalization is off, there is no user, or no ids → a disabled flag or a
+    zero-relevance user is a guaranteed no-op on every surface. Deliberately OMITS alpha*salience
+    (unlike cluster_entities): global salience is the baseline each surface already encodes via
+    recency / search rank / topic weight, so re-injecting it here would reorder a no-signal user by
+    popularity and break the no-op invariant. The user_id filter sits on the LEFT JOIN's ON clause
+    (the primary multi-user isolation control; RLS is defense-in-depth). The join cannot fan out:
+    (user_id, entity_id) is the UER primary key."""
+    if not settings.uer_enabled or user_id is None or not cluster_ids:
+        return {}
+    per_entity = (
+        select(
+            ClusterArticle.cluster_id.label("cid"),
+            ArticleEntity.entity_id.label("eid"),
+            _decayed_relevance_sql().label("decayed"),
+        )
+        .join(ArticleEntity, ArticleEntity.article_id == ClusterArticle.article_id)
+        .outerjoin(
+            UserEntityRelevance,
+            and_(UserEntityRelevance.entity_id == ArticleEntity.entity_id,
+                 UserEntityRelevance.user_id == user_id),
+        )
+        .where(ClusterArticle.cluster_id.in_(cluster_ids))
+        .group_by(ClusterArticle.cluster_id, ArticleEntity.entity_id)
+        .subquery()
+    )
+    q = select(per_entity.c.cid, func.avg(per_entity.c.decayed)).group_by(per_entity.c.cid)
+    rows = (await db.execute(q)).all()
+    return {cid: float(score) for cid, score in rows if score is not None}
+
+
+async def score_cluster_relevance(db: AsyncSession, cluster_id: int, user_id: int | None) -> float:
+    """Single-cluster convenience wrapper over score_clusters_relevance (tests / one-off callers)."""
+    return (await score_clusters_relevance(db, [cluster_id], user_id)).get(cluster_id, 0.0)
 
 
 # ── Extraction + resolution (G1 S3-S4) ──────────────────────────────────────────────

--- a/backend/tests/integration/test_briefing_personalized.py
+++ b/backend/tests/integration/test_briefing_personalized.py
@@ -1,0 +1,94 @@
+"""G2 S7: /briefing additive entity-relevance blend into story_weights (exploit/explore untouched)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Source, SourceType,
+    StoryCluster, User, UserEntityRelevance,
+)
+
+_n = 0
+
+
+async def _ensure_user1(db):
+    if (await db.execute(select(User).where(User.id == 1))).scalar_one_or_none() is None:
+        db.add(User(id=1, locale="IN"))
+        await db.flush()
+
+
+async def _src(db):
+    global _n
+    _n += 1
+    s = Source(name="S", url=f"https://brief/{_n}", source_type=SourceType.wire)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _bcluster(db, src, title, created_at, followed=False):
+    global _n
+    _n += 1
+    cl = StoryCluster(title=title, summary=f"{title} summary.", created_at=created_at, coherence=0.8)
+    db.add(cl)
+    await db.flush()
+    a = Article(title=title, url=f"https://brief/{_n}/a", source_id=src.id, snippet="snip.",
+                embedding_status=EmbeddingStatus.complete)
+    db.add(a)
+    await db.flush()
+    db.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    if followed:
+        _n += 1
+        e = Entity(canonical_name="E", name_norm=f"e-{_n}", kind="org")
+        db.add(e)
+        await db.flush()
+        db.add(ArticleEntity(article_id=a.id, entity_id=e.id, salience=0.5))
+        db.add(UserEntityRelevance(user_id=1, entity_id=e.id, source="follow",
+                                   engagement_raw=1.0, last_event_at=datetime.now(timezone.utc)))
+    await db.flush()
+    return cl
+
+
+async def _seed_nine(db, src, now, followed_relevant: bool):
+    """The 'Relevant' cluster is the OLDEST (last by recency); 8 newer 'Plain' clusters, no topic prefs."""
+    await _bcluster(db, src, "Relevant", now - timedelta(hours=20), followed=followed_relevant)
+    for i in range(8):
+        await _bcluster(db, src, f"Plain {i}", now - timedelta(hours=i + 1))
+
+
+@pytest.mark.asyncio
+async def test_briefing_on_relevance_lifts_into_exploit(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    await _seed_nine(db_session, src, datetime.now(timezone.utc), followed_relevant=True)
+    titles = [st["title"] for st in (await aclient.get("/briefing")).json()["stories"]]
+    assert titles[0] == "Relevant"  # relevance (additive, zero topic pref) lifted the oldest to the top
+
+
+@pytest.mark.asyncio
+async def test_briefing_off_relevance_has_no_effect(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", False)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    await _seed_nine(db_session, src, datetime.now(timezone.utc), followed_relevant=True)
+    titles = [st["title"] for st in (await aclient.get("/briefing")).json()["stories"]]
+    assert titles[0] != "Relevant"  # off → oldest cluster with no topic pref stays at the bottom
+
+
+@pytest.mark.asyncio
+async def test_briefing_zero_uer_identical_to_off(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    src = await _src(db_session)
+    now = datetime.now(timezone.utc)
+    await _ensure_user1(db_session)
+    await _seed_nine(db_session, src, now, followed_relevant=False)  # no follows anywhere
+
+    monkeypatch.setattr(s, "uer_enabled", True)
+    on = [st["title"] for st in (await aclient.get("/briefing")).json()["stories"]]
+    monkeypatch.setattr(s, "uer_enabled", False)
+    off = [st["title"] for st in (await aclient.get("/briefing")).json()["stories"]]
+    assert on == off  # no relevance signal → +0 → identical ordering

--- a/backend/tests/integration/test_feed_personalized.py
+++ b/backend/tests/integration/test_feed_personalized.py
@@ -1,0 +1,174 @@
+"""G2 S6: /feed bounded-pool rerank — byte-identical when off, recency+relevance blend when on."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import event, select
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Source, SourceType,
+    StoryCluster, User, UserEntityRelevance,
+)
+
+_n = 0
+
+
+async def _ensure_user1(db):
+    if (await db.execute(select(User).where(User.id == 1))).scalar_one_or_none() is None:
+        db.add(User(id=1, locale="IN"))
+        await db.flush()
+
+
+async def _src(db):
+    global _n
+    _n += 1
+    s = Source(name="S", url=f"https://feed/{_n}", source_type=SourceType.wire)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _article(db, src, when, title):
+    global _n
+    _n += 1
+    a = Article(title=title, url=f"https://feed/{_n}/a", source_id=src.id,
+                embedding_status=EmbeddingStatus.complete, published_at=when)
+    db.add(a)
+    await db.flush()
+    return a
+
+
+async def _follow_articles_entity(db, *arts, user_id=1):
+    """Put the articles in one cluster and make the current user follow its (one) entity."""
+    global _n
+    cl = StoryCluster(title="C")
+    db.add(cl)
+    await db.flush()
+    for a in arts:
+        db.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    _n += 1
+    e = Entity(canonical_name="Followed", name_norm=f"followed-{_n}", kind="org")
+    db.add(e)
+    await db.flush()
+    for a in arts:
+        db.add(ArticleEntity(article_id=a.id, entity_id=e.id, salience=0.5))
+    db.add(UserEntityRelevance(user_id=user_id, entity_id=e.id, source="follow",
+                               engagement_raw=1.0, last_event_at=datetime.now(timezone.utc)))
+    await db.flush()
+    return cl
+
+
+@pytest.mark.asyncio
+async def test_feed_off_is_recency_and_true_total(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", False)
+    src = await _src(db_session)
+    now = datetime.now(timezone.utc)
+    await _article(db_session, src, now - timedelta(days=2), "Old")
+    await _article(db_session, src, now, "New")
+    await db_session.flush()
+    body = (await aclient.get("/feed?per_page=50")).json()
+    titles = [it["title"] for it in body["articles"]]
+    assert titles.index("New") < titles.index("Old")  # pure recency
+    assert body["total"] == 2  # true corpus count when off
+
+
+@pytest.mark.asyncio
+async def test_feed_on_bubbles_followed_entity(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    now = datetime.now(timezone.utc)
+    await _article(db_session, src, now, "Plain")  # newest, unrelated
+    foll = await _article(db_session, src, now, "Followed story")  # same time, followed
+    await _follow_articles_entity(db_session, foll)
+    body = (await aclient.get("/feed?per_page=50")).json()
+    titles = [it["title"] for it in body["articles"]]
+    assert titles.index("Followed story") < titles.index("Plain")  # relevance breaks the recency tie
+
+
+@pytest.mark.asyncio
+async def test_feed_on_recency_dominates_by_default(aclient, db_session, monkeypatch):
+    """Default blend ratio 0.3 keeps recency primary: a much-newer unrelated story beats an old follow."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    now = datetime.now(timezone.utc)
+    await _article(db_session, src, now, "Newest")
+    old = await _article(db_session, src, now - timedelta(days=10), "Old followed")
+    await _follow_articles_entity(db_session, old)
+    body = (await aclient.get("/feed?per_page=50")).json()
+    titles = [it["title"] for it in body["articles"]]
+    assert titles.index("Newest") < titles.index("Old followed")
+
+
+@pytest.mark.asyncio
+async def test_feed_on_high_affinity_crosses_to_page_1(aclient, db_session, monkeypatch):
+    """With relevance weighted high, a followed-but-old story crosses from page 2 into page 1."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    monkeypatch.setattr(s, "uer_feed_blend_ratio", 0.9)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    now = datetime.now(timezone.utc)
+    await _article(db_session, src, now, "A")
+    await _article(db_session, src, now - timedelta(days=1), "B")
+    await _article(db_session, src, now - timedelta(days=2), "C")
+    d = await _article(db_session, src, now - timedelta(days=3), "D-followed")  # oldest
+    await _follow_articles_entity(db_session, d)
+
+    page1 = [it["title"] for it in (await aclient.get("/feed?per_page=2&page=1")).json()["articles"]]
+    assert "D-followed" in page1  # relevance pulled the oldest item onto page 1
+
+    monkeypatch.setattr(s, "uer_enabled", False)
+    page1_off = [it["title"] for it in (await aclient.get("/feed?per_page=2&page=1")).json()["articles"]]
+    assert "D-followed" not in page1_off  # recency-only → oldest is on the last page
+
+
+@pytest.mark.asyncio
+async def test_feed_on_zero_uer_identical_to_off(aclient, db_session, monkeypatch):
+    """Enabled but the user has no follows/feedback → pure recency, same as off (no-op invariant)."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    now = datetime.now(timezone.utc)
+    await _article(db_session, src, now, "One")
+    await _article(db_session, src, now - timedelta(days=1), "Two")
+    await _article(db_session, src, now - timedelta(days=2), "Three")
+    body = (await aclient.get("/feed?per_page=50")).json()
+    assert [it["title"] for it in body["articles"]] == ["One", "Two", "Three"]
+
+
+@pytest.mark.asyncio
+async def test_feed_on_no_n_plus_one(aclient, db_session, engine, monkeypatch):
+    """The on-path adds only the one score aggregate — query count stays bounded (no per-article N+1)."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    now = datetime.now(timezone.utc)
+    clustered = []
+    for i in range(25):
+        a = await _article(db_session, src, now - timedelta(hours=i), f"Item {i}")
+        if i < 4:
+            clustered.append(a)
+    await _follow_articles_entity(db_session, *clustered)
+
+    counter = {"n": 0}
+
+    def _before(conn, cur, statement, params, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            counter["n"] += 1
+
+    sync_engine = engine.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", _before)
+    try:
+        resp = await aclient.get("/feed?per_page=50")
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _before)
+
+    assert resp.status_code == 200
+    assert len(resp.json()["articles"]) == 25
+    assert counter["n"] <= 13, f"feed (personalized) issued {counter['n']} SELECTs (possible N+1)"

--- a/backend/tests/integration/test_g2_all_surfaces.py
+++ b/backend/tests/integration/test_g2_all_surfaces.py
@@ -1,0 +1,113 @@
+"""G2 S9: one follow signal personalizes feed + briefing + search (one shared scorer); user-scoped."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Source, SourceType,
+    StoryCluster, User, UserEntityRelevance,
+)
+from app.services import entities as E
+
+_n = 0
+
+
+async def _ensure_users(db, *ids):
+    for uid in ids:
+        if (await db.execute(select(User).where(User.id == uid))).scalar_one_or_none() is None:
+            db.add(User(id=uid, locale="IN"))
+    await db.flush()
+
+
+async def _src(db):
+    global _n
+    _n += 1
+    s = Source(name="S", url=f"https://all/{_n}", source_type=SourceType.wire)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _cluster_article(db, src, title, *, published, created):
+    global _n
+    _n += 1
+    a = Article(title=title, url=f"https://all/{_n}/a", source_id=src.id, snippet="snip.",
+                published_at=published, embedding_status=EmbeddingStatus.complete)
+    db.add(a)
+    await db.flush()
+    cl = StoryCluster(title=title, summary=f"{title} summary.", created_at=created, coherence=0.8)
+    db.add(cl)
+    await db.flush()
+    db.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db.flush()
+    return a, cl
+
+
+async def _follow_entity(db, art, user_id):
+    global _n
+    _n += 1
+    e = Entity(canonical_name="Acme Corp", name_norm=f"acme-{_n}", kind="org")
+    db.add(e)
+    await db.flush()
+    db.add(ArticleEntity(article_id=art.id, entity_id=e.id, salience=0.5))
+    db.add(UserEntityRelevance(user_id=user_id, entity_id=e.id, source="follow",
+                               engagement_raw=1.0, last_event_at=datetime.now(timezone.utc)))
+    await db.flush()
+
+
+async def _build_world(db, *, follow_user=None):
+    """9 clusters. CF ('Acme followed') is feed-NEWEST (published now) but briefing-OLDEST (created
+    10h ago), so its climb is attributable to relevance, not recency, on every surface."""
+    src = await _src(db)
+    now = datetime.now(timezone.utc)
+    cf_art, cf_cl = await _cluster_article(db, src, "Acme followed",
+                                           published=now, created=now - timedelta(hours=10))
+    if follow_user is not None:
+        await _follow_entity(db, cf_art, follow_user)
+    await _cluster_article(db, src, "Acme plain", published=now, created=now - timedelta(hours=1))
+    for i in range(7):
+        await _cluster_article(db, src, f"Filler {i}",
+                               published=now - timedelta(hours=i + 2), created=now - timedelta(hours=i + 2))
+    return cf_art, cf_cl
+
+
+@pytest.mark.asyncio
+async def test_one_follow_lifts_all_surfaces(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_users(db_session, 1)
+    await _build_world(db_session, follow_user=1)
+
+    feed = (await aclient.get("/feed?per_page=50")).json()["articles"]
+    assert feed[0]["title"] == "Acme followed"          # recency tie broken by relevance
+    brief = (await aclient.get("/briefing")).json()["stories"]
+    assert brief[0]["title"] == "Acme followed"          # additive weight lifts the briefing-oldest
+    search = (await aclient.get("/search?q=Acme")).json()["results"]
+    assert search[0]["title"] == "Acme followed"         # within-tier boost over "Acme plain"
+
+
+@pytest.mark.asyncio
+async def test_user_scoped_isolation(db_session, monkeypatch):
+    """user1's follow must not change user2's scores — the LEFT JOIN user_id filter is the control."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_users(db_session, 1, 2)
+    _cf_art, cf_cl = await _build_world(db_session, follow_user=1)
+    s1 = await E.score_clusters_relevance(db_session, [cf_cl.id], 1)
+    s2 = await E.score_clusters_relevance(db_session, [cf_cl.id], 2)
+    assert s1.get(cf_cl.id, 0.0) > 0
+    assert s2.get(cf_cl.id, 0.0) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_toggle_off_drops_personalization(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    await _ensure_users(db_session, 1)
+    await _build_world(db_session, follow_user=1)
+    monkeypatch.setattr(s, "uer_enabled", True)
+    brief_on = (await aclient.get("/briefing")).json()["stories"]
+    monkeypatch.setattr(s, "uer_enabled", False)
+    brief_off = (await aclient.get("/briefing")).json()["stories"]
+    assert brief_on[0]["title"] == "Acme followed"
+    assert brief_off[0]["title"] != "Acme followed"  # briefing-oldest → not first once relevance is off

--- a/backend/tests/integration/test_g2_scoring.py
+++ b/backend/tests/integration/test_g2_scoring.py
@@ -1,0 +1,137 @@
+"""G2 S5: the shared per-cluster relevance scorer consumed by feed / briefing / search."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Source, SourceType,
+    StoryCluster, User, UserEntityRelevance,
+)
+from app.services import entities as E
+
+_n = 0
+
+
+async def _ensure_user1(db):
+    if (await db.execute(select(User).where(User.id == 1))).scalar_one_or_none() is None:
+        db.add(User(id=1, locale="IN"))
+        await db.flush()
+
+
+async def _cluster_with_entities(db, *salience_by_name):
+    """A cluster with one article carrying the given (entity_name, salience) pairs. Returns (cluster, {name: Entity})."""
+    global _n
+    _n += 1
+    src = Source(name="S", url=f"https://sc/{_n}", source_type=SourceType.wire)
+    db.add(src)
+    await db.flush()
+    art = Article(title="A", url=f"https://sc/{_n}/a", source_id=src.id,
+                  embedding_status=EmbeddingStatus.complete)
+    db.add(art)
+    await db.flush()
+    cl = StoryCluster(title="C")
+    db.add(cl)
+    await db.flush()
+    db.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    ents = {}
+    for name, sal in salience_by_name:
+        _n += 1
+        e = Entity(canonical_name=name, name_norm=f"{name.lower()}-{_n}", kind="org")
+        db.add(e)
+        await db.flush()
+        db.add(ArticleEntity(article_id=art.id, entity_id=e.id, salience=sal))
+        ents[name] = e
+    await db.flush()
+    return cl, ents
+
+
+def _uer(uid, entity, *, weight=1.0, when=None):
+    return UserEntityRelevance(user_id=uid, entity_id=entity.id, source="follow",
+                               engagement_raw=weight,
+                               last_event_at=when or datetime.now(timezone.utc))
+
+
+@pytest.mark.asyncio
+async def test_scorer_empty_fastpaths(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    cl, _ = await _cluster_with_entities(db_session, ("X", 0.5))
+    monkeypatch.setattr(s, "uer_enabled", False)
+    assert await E.score_clusters_relevance(db_session, [cl.id], 1) == {}  # off
+    monkeypatch.setattr(s, "uer_enabled", True)
+    assert await E.score_clusters_relevance(db_session, [cl.id], None) == {}  # no user
+    assert await E.score_clusters_relevance(db_session, [], 1) == {}  # no ids
+
+
+@pytest.mark.asyncio
+async def test_scorer_zero_uer_user_is_noop(db_session, monkeypatch):
+    """A user with no follows/feedback scores 0.0 everywhere — the surface no-op invariant
+    (salience is deliberately NOT in the surface score, so popularity can't reorder a no-signal user)."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    cl, _ = await _cluster_with_entities(db_session, ("Alpha", 0.9), ("Beta", 0.2))
+    scores = await E.score_clusters_relevance(db_session, [cl.id], 1)
+    assert scores.get(cl.id, 0.0) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_scorer_followed_entity_lifts_cluster(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    cl_followed, ents = await _cluster_with_entities(db_session, ("Followed", 0.5))
+    cl_plain, _ = await _cluster_with_entities(db_session, ("Plain", 0.5))
+    db_session.add(_uer(1, ents["Followed"]))
+    await db_session.flush()
+    scores = await E.score_clusters_relevance(db_session, [cl_followed.id, cl_plain.id], 1)
+    assert scores.get(cl_followed.id, 0.0) > scores.get(cl_plain.id, 0.0)
+    assert scores.get(cl_plain.id, 0.0) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_scorer_decay_fresh_over_stale(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    cl_fresh, ef = await _cluster_with_entities(db_session, ("Fresh", 0.5))
+    cl_stale, es = await _cluster_with_entities(db_session, ("Stale", 0.5))
+    now = datetime.now(timezone.utc)
+    db_session.add_all([
+        _uer(1, ef["Fresh"], when=now),
+        _uer(1, es["Stale"], when=now - timedelta(days=120)),
+    ])
+    await db_session.flush()
+    scores = await E.score_clusters_relevance(db_session, [cl_fresh.id, cl_stale.id], 1)
+    assert scores[cl_fresh.id] > scores[cl_stale.id] > 0
+
+
+@pytest.mark.asyncio
+async def test_scorer_future_timestamp_clamped(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    cl, e = await _cluster_with_entities(db_session, ("Future", 0.5))
+    db_session.add(_uer(1, e["Future"], when=datetime.now(timezone.utc) + timedelta(days=365)))
+    await db_session.flush()
+    score = (await E.score_clusters_relevance(db_session, [cl.id], 1))[cl.id]
+    assert 0 < score <= 1.0  # decay clamped to <= 1; without the clamp this would explode
+
+
+@pytest.mark.asyncio
+async def test_scorer_batch_ranks_by_engagement(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    cl1, e1 = await _cluster_with_entities(db_session, ("E1", 0.5))
+    cl2, e2 = await _cluster_with_entities(db_session, ("E2", 0.5))
+    cl3, _ = await _cluster_with_entities(db_session, ("E3", 0.5))  # no follow → absent/0
+    now = datetime.now(timezone.utc)
+    db_session.add_all([_uer(1, e1["E1"], weight=2.0, when=now), _uer(1, e2["E2"], weight=1.0, when=now)])
+    await db_session.flush()
+    scores = await E.score_clusters_relevance(db_session, [cl1.id, cl2.id, cl3.id], 1)
+    assert scores[cl1.id] > scores[cl2.id] > scores.get(cl3.id, 0.0)
+    # single-cluster wrapper agrees with the batch form
+    assert await E.score_cluster_relevance(db_session, cl1.id, 1) == pytest.approx(scores[cl1.id])

--- a/backend/tests/integration/test_search_personalized.py
+++ b/backend/tests/integration/test_search_personalized.py
@@ -1,0 +1,100 @@
+"""G2 S8: /search within-tier relevance boost — keyword stays above semantic; off = unchanged."""
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, EmbeddingStatus, Entity, Source, SourceType,
+    StoryCluster, User, UserEntityRelevance,
+)
+
+_n = 0
+
+
+async def _ensure_user1(db):
+    if (await db.execute(select(User).where(User.id == 1))).scalar_one_or_none() is None:
+        db.add(User(id=1, locale="IN"))
+        await db.flush()
+
+
+async def _src(db):
+    global _n
+    _n += 1
+    s = Source(name="S", url=f"https://srch/{_n}", source_type=SourceType.wire)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _kw_article(db, src, title):
+    """A keyword-matchable article in its own cluster. Returns (article, cluster)."""
+    global _n
+    _n += 1
+    a = Article(title=title, url=f"https://srch/{_n}/a", source_id=src.id,
+                embedding_status=EmbeddingStatus.complete)
+    db.add(a)
+    await db.flush()
+    cl = StoryCluster(title=title)
+    db.add(cl)
+    await db.flush()
+    db.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+    await db.flush()
+    return a, cl
+
+
+async def _follow(db, art, user_id=1):
+    global _n
+    _n += 1
+    e = Entity(canonical_name="Z", name_norm=f"z-{_n}", kind="org")
+    db.add(e)
+    await db.flush()
+    db.add(ArticleEntity(article_id=art.id, entity_id=e.id, salience=0.5))
+    db.add(UserEntityRelevance(user_id=user_id, entity_id=e.id, source="follow",
+                               engagement_raw=1.0, last_event_at=datetime.now(timezone.utc)))
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_search_on_boosts_followed_cluster(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    await _kw_article(db_session, src, "Acme alpha")        # X (inserted first)
+    ay, _ = await _kw_article(db_session, src, "Acme beta")  # Y
+    await _follow(db_session, ay)
+    res = (await aclient.get("/search?q=Acme")).json()["results"]
+    assert res[0]["id"] == ay.id  # followed cluster boosted to the top within tier
+
+
+@pytest.mark.asyncio
+async def test_search_off_ignores_follow(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    await _kw_article(db_session, src, "Acme alpha")
+    ay, _ = await _kw_article(db_session, src, "Acme beta")
+    await _follow(db_session, ay)
+
+    monkeypatch.setattr(s, "uer_enabled", True)
+    on_first = (await aclient.get("/search?q=Acme")).json()["results"][0]["id"]
+    monkeypatch.setattr(s, "uer_enabled", False)
+    off_first = (await aclient.get("/search?q=Acme")).json()["results"][0]["id"]
+    assert on_first == ay.id       # boosted when on
+    assert off_first != ay.id      # off → the follow has no effect
+
+
+@pytest.mark.asyncio
+async def test_search_zero_uer_on_equals_off(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    await _kw_article(db_session, src, "Acme alpha")
+    await _kw_article(db_session, src, "Acme beta")  # no follows anywhere
+
+    monkeypatch.setattr(s, "uer_enabled", True)
+    on = [r["id"] for r in (await aclient.get("/search?q=Acme")).json()["results"]]
+    monkeypatch.setattr(s, "uer_enabled", False)
+    off = [r["id"] for r in (await aclient.get("/search?q=Acme")).json()["results"]]
+    assert on == off  # no relevance signal → identical ordering

--- a/backend/tests/unit/test_config_g2.py
+++ b/backend/tests/unit/test_config_g2.py
@@ -12,3 +12,15 @@ def test_g2_config_defaults(monkeypatch):
     assert settings.uer_follow_weight == 1.0
     assert settings.uer_rank_alpha == 0.6
     assert settings.uer_rank_beta == 0.4
+
+
+def test_g2_surface_personalization_defaults():
+    """Surface knobs (feed/briefing/search) — conservative, ship dark behind uer_enabled."""
+    assert settings.uer_feed_pool_size == 500
+    assert settings.uer_feed_blend_ratio == 0.3
+    assert settings.uer_briefing_blend_weight == 0.2
+    assert settings.uer_search_rerank_boost == 10.0
+    assert settings.uer_search_relevance_threshold == 0.3
+    # Invariant: the search boost must stay below the keyword/semantic tier gap (100) or keyword
+    # results could be overtaken by boosted semantic ones.
+    assert settings.uer_search_rerank_boost < 100


### PR DESCRIPTION
Extends G2 personalization from the cast strip to the three main ranking surfaces, built from an adversarially-designed plan (3 approaches → synthesis). All gated behind `uer_enabled`, **byte-identical when off**, and a **no-op for users with zero relevance signal**.

## One shared primitive (S5)
`entities.score_clusters_relevance(db, cluster_ids, user_id) → {cluster_id: AVG(decayed relevance)}` — **one aggregate over the id set** (no N+1), `{}` fast-path when off / no user / no ids. Extracted `_decayed_relevance_sql()` and refactored `cluster_entities` to reuse it so the two scorers **can't drift** (its existing tests guard the refactor).

**Key decision:** the surface score is `AVG(decayed)` and deliberately **omits `alpha·salience`** (which the cast strip keeps). Global salience is the baseline each surface already encodes via recency / search rank / topic weight — re-injecting it would silently reorder a no-signal user by popularity and break the no-op invariant.

## Per surface
| Surface | Strategy | When off |
|---|---|---|
| **Feed** (S6) | Bounded recent pool (500) → blend `0.7·recency + 0.3·relevance` → sort → **then** paginate, so a high-affinity story crosses page boundaries within the horizon | Exact legacy path (count + offset/limit) — byte-identical |
| **Briefing** (S7) | Additive into `story_weights` (`+0.2·relevance`), orthogonal to topic preference; exploit/explore + fallback untouched | `+0` → identical ordering |
| **Search** (S8) | Within-tier boost (`−10·relevance`, gated at 0.3), capped well below the 100-pt keyword/semantic gap so keyword always stays on top; added `Depends(get_current_user)` for per-user scoping | No reorder |

**Feed pagination decision:** bounded-pool rerank, *not* corpus-wide SQL `ORDER BY` — the latter needs a per-page aggregate join across the whole `articles` table with no supporting index, for marginal benefit beyond a recency window. Trade-off: `total` reflects the pool when personalizing (documented).

## Tests (TDD) — backend **241 passed / 1 skipped**
Every surface: off = identical, on = reorders for a followed entity, zero-UER = no-op. Plus feed pagination-after-rerank + N+1 budget (≤13 SELECTs, only +1 aggregate), search keyword-above-semantic invariant, and a **cross-surface integration + multi-user isolation** test (user1's follow yields score>0 for user1, `0.0` for user2 — the LEFT JOIN `user_id` filter). Live-smoked all three endpoints (200) against the running server.

## Config (5 new knobs, hypothesis-grade, dark behind `uer_enabled`)
`uer_feed_pool_size=500`, `uer_feed_blend_ratio=0.3`, `uer_briefing_blend_weight=0.2`, `uer_search_rerank_boost=10.0`, `uer_search_relevance_threshold=0.3`.

## Notes
No schema change (every table already ships). Negative feedback ('less') stays out of scope (positive-signal scorer; 'less' still feeds explore_ratio). Flagged-not-fixed: an `ix_article_entities_article` index if the feed-pool aggregate ever shows hot at real scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)