### PR TITLE
Personalization on by default + full docs refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,31 @@ DB_PORT=5432
 BACKEND_PORT=8000
 OPENAI_API_KEY=sk-your-key-here
 
+# ── LLM providers (Bring Your Own Model) ──
+# Generation can run on OpenAI, Google Gemini, or Anthropic. Embeddings ALWAYS use OpenAI.
+# These env keys are the PLATFORM fallback (background jobs); each user can also set their own
+# per-provider key + model in Settings, and the per-user active_provider wins over this default.
+GENERATION_PROVIDER=openai            # openai | gemini | anthropic
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.0-flash
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-haiku-4-5
+
+# ── Auth (Firebase) ──
+# Supply ONE to verify Firebase ID tokens (Google + Email/Password). If NEITHER is set, token
+# verification is disabled and requests fall back to the default user (single-user dev path).
+FIREBASE_CREDENTIALS_JSON=            # inline service-account JSON (best for hosted secrets)
+GOOGLE_APPLICATION_CREDENTIALS=       # path to a mounted service-account .json
+# Set true for real multi-user production: reject unauthenticated requests with 401.
+AUTH_REQUIRED=false
+
+# ── Knowledge graph + personalization ──
+# Entity extraction (G1) ships dark; enable after watching the skip rate. Needs a platform LLM key.
+GRAPH_EXTRACTION_ENABLED=false
+# Per-user entity-relevance personalization (G2): cast strip + feed/briefing/search. ON by default;
+# a user with no follows/feedback is a no-op everywhere. Set false to disable.
+UER_ENABLED=true
+
 # Fetch intervals (minutes)
 RSS_FETCH_INTERVAL_MINUTES=10
 GDELT_FETCH_INTERVAL_MINUTES=15

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,8 @@
 
 NewsLens is a two-language AI news intelligence platform: Python backend (data pipeline + ML) and TypeScript frontend (UI), communicating via REST JSON. Mobile builds use Capacitor to wrap the frontend into a native Android WebView.
 
+Beyond the ingest→cluster→summarize core, the platform now layers on: **multi-provider LLM generation** (BYOM — OpenAI/Anthropic/Gemini, per-user key + model; embeddings stay OpenAI), **Firebase auth + Postgres RLS** for multi-user identity (single-user dev fallback), a **knowledge graph** (G1 global entity backbone + G2 per-user entity-relevance overlay), and **on-by-default personalization** that re-ranks the cast strip, feed, briefing, and search from one shared relevance scorer (a zero-signal user is a no-op). See the Decision Log for the rationale behind each.
+
 ## System Diagram
 
 ```mermaid
@@ -19,6 +21,7 @@ graph TB
             GF[GDELT Fetcher<br/>every 15min]
             EB[Embedding Backfill<br/>every 5min]
             CL[Clustering<br/>every 10min]
+            EE[Entity Extraction<br/>every 15min · gated]
         end
 
         subgraph "Services"
@@ -26,10 +29,13 @@ graph TB
             EMB[Embedding Service<br/>OpenAI text-embedding-3-small]
             CLUST[Clustering Service<br/>pgvector cosine distance]
             ENC[Encryption Service<br/>Fernet]
+            LLM[LLM Generation<br/>OpenAI/Anthropic/Gemini]
+            AUTH[Auth + RLS<br/>Firebase / app.user_id]
+            REL[Relevance Scorer<br/>G2 personalization]
         end
 
         subgraph "API Layer"
-            ROUTES[FastAPI Routes<br/>12 endpoints]
+            ROUTES[FastAPI Routes<br/>~40 endpoints]
         end
     end
 
@@ -66,6 +72,9 @@ graph TB
     GF --> DEDUP
     EB --> EMB --> PG
     CL --> CLUST --> PG
+    EE --> LLM --> PG
+    AUTH --> ROUTES
+    REL --> ROUTES
     PG --> ROUTES
     ROUTES --> API_CLIENT
     API_CLIENT --> BRIEF & DISC & DEEP & SETT
@@ -119,6 +128,8 @@ sequenceDiagram
     DB->>API: Results
     API->>UI: JSON response
 ```
+
+> **Not shown:** a 5th, gated job (`GRAPH_EXTRACTION_ENABLED`) extracts entities from settled clusters via the provider-aware LLM into `entities` / `article_entities`. On reads, `get_current_user` sets the RLS GUC `app.user_id`, and the personalized surfaces (cast strip, feed, briefing, search) call the shared relevance scorer (`entities.score_clusters_relevance`) before responding.
 
 ## Database Schema
 
@@ -201,7 +212,59 @@ erDiagram
         text openai_api_key_encrypted
         bool openai_key_verified
         timestamp openai_key_verified_at
+        text gemini_api_key_encrypted
+        text anthropic_api_key_encrypted
+        string active_provider "openai|anthropic|gemini"
+        json model_prefs "per-provider model overrides"
         timestamp updated_at
+    }
+
+    follows {
+        int id PK
+        int user_id FK
+        string kind "topic|entity|saved_search"
+        string value
+        int entity_id FK "G2: resolved entity (nullable)"
+        timestamp created_at
+    }
+
+    cluster_edges {
+        int id PK
+        int src_cluster_id FK
+        int dst_cluster_id FK
+        string kind "successor|background|duplicate"
+        float score
+    }
+
+    entities {
+        int id PK
+        string canonical_name
+        string name_norm
+        string kind "person|org|place|other"
+    }
+
+    entity_aliases {
+        int id PK
+        int entity_id FK
+        string alias_norm
+        string source
+    }
+
+    article_entities {
+        int id PK
+        int article_id FK
+        int entity_id FK
+        float salience
+        float confidence
+    }
+
+    user_entity_relevance {
+        int user_id PK
+        int entity_id PK
+        string source "follow|feedback"
+        float engagement_raw
+        timestamp last_event_at
+        float score
     }
 
     users ||--o{ user_feedback : has
@@ -215,9 +278,23 @@ erDiagram
     story_clusters ||--o{ cluster_articles : contains
     articles ||--o{ user_feedback : receives
     topics ||--o{ user_preferences : weighted
+    users ||--o{ follows : has
+    users ||--o{ user_entity_relevance : has
+    entities ||--o{ entity_aliases : aliased
+    articles ||--o{ article_entities : mentions
+    entities ||--o{ article_entities : mentioned_in
+    entities ||--o{ user_entity_relevance : scored
+    entities ||--o{ follows : followed
+    story_clusters ||--o{ cluster_edges : links
 ```
 
 **pgvector columns:** `articles.embedding` and `topics.embedding` are `Vector(1536)` for OpenAI text-embedding-3-small. Clustering uses cosine distance with threshold 0.15.
+
+**Knowledge-graph tables (Wave D Phase 3):** `entities` / `entity_aliases` / `article_entities` are the global G1 backbone (populated by the gated extraction job). `user_entity_relevance` (composite PK `user_id,entity_id`) is the G2 per-user overlay that drives personalization; `follows.entity_id` links an entity-follow to its graph node. `cluster_edges` (Wave D2) is the directed temporal "how we got here" graph between clusters.
+
+**Row-level security:** `user_feedback`, `user_preferences`, `user_settings`, `follows`, and `user_entity_relevance` carry RLS policies (enforce-when-set on the GUC `app.user_id`; permissive for background jobs). They enforce only under a non-superuser DB role — the explicit `current_user_id()` query filter is the primary control. See `backend/scripts/create_app_role.sql`.
+
+**BYOM columns:** `user_settings` now stores per-provider encrypted keys (OpenAI/Gemini/Anthropic) plus `active_provider` and a `model_prefs` JSONB of per-provider model overrides.
 
 ## Capacitor Build Pipeline
 
@@ -246,6 +323,12 @@ Web builds use `rewrites()` to proxy `/api/*` to the backend. Capacitor builds u
 | Mobile | Capacitor static export | React Native rewrite | Zero code duplication; wraps existing web app; 4.75 MB APK |
 | API proxy | Next.js rewrites | CORS headers | No CORS configuration needed; single origin in dev |
 | Encryption | Fernet (symmetric) | RSA / AES-GCM | Simple, battle-tested; good for per-user key storage |
+| Auth | Firebase Admin SDK + Postgres RLS | Custom JWT / sessions | Offloads identity (Google + Email/Password); `app.user_id` GUC + RLS gives defense-in-depth; `AUTH_REQUIRED=false` keeps single-user dev |
+| Per-user isolation | Explicit `current_user_id()` filter + RLS | RLS alone | RLS is inert under a superuser role, so the explicit filter is the primary control; RLS (non-superuser role) is defense-in-depth |
+| LLM generation | Multi-provider (OpenAI/Anthropic/Gemini), per-user key + model | OpenAI-only | BYOM avoids lock-in + cost sensitivity; per-user `active_provider` + `model_prefs`; embeddings stay OpenAI for vector consistency |
+| Entity graph | Exact + alias resolution on normalized columns (G1); per-user relevance overlay (G2) | Embedding NN dedup / auto-merge | Precision-biased + cheap at MVP scale; embedding-NN merge deferred until it's justified by data |
+| Personalization | One shared `AVG(decayed)` cluster scorer across all surfaces, on by default | Per-surface bespoke ranking / off by default | DRY + consistent; salience omitted so a zero-signal user is a guaranteed no-op (safe to default on) |
+| Decay | Read-time half-life (`exp(-ln2·age/hl)`, age clamped ≥0) | Cron/materialized scores | No background job; always-fresh; clock-skew-safe |
 | CSS | Tailwind CSS 4 | CSS Modules / styled-components | Utility-first; design token integration; small bundle |
 | Motion | Framer Motion | CSS animations | Complex gesture physics (swipe cards); declarative API |
 | Brand assets | Single source of truth (official NewsLens brand kit) | Ad-hoc per-surface art | One canonical mark/lockup; icons + splash regenerate from it, no drift |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ cd frontend && npm run apk:debug               # Build debug APK via Gradle
 
 NewsLens is an AI-powered news intelligence platform. Two-language stack: Python backend (data pipeline + ML) and TypeScript frontend (UI). They communicate via REST JSON — no shared types needed. Mobile builds use Capacitor to wrap the Next.js static export into a native Android WebView app.
 
-**Stack:** Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Python FastAPI, PostgreSQL + pgvector, OpenAI API, APScheduler, Capacitor (Android) + `@capacitor/splash-screen`
+**Stack:** Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Python FastAPI, PostgreSQL + pgvector, multi-provider LLM (OpenAI embeddings + OpenAI/Anthropic/Gemini generation), Firebase Admin SDK (auth), APScheduler, Capacitor (Android) + `@capacitor/splash-screen`
 
 **Key architectural decisions:**
 - pgvector nearest-neighbor SQL for clustering (not Python pairwise — O(n) vs O(n²))
@@ -49,8 +49,11 @@ NewsLens is an AI-powered news intelligence platform. Two-language stack: Python
 - Next.js `rewrites` in `next.config.ts` proxying `/api/*` → `localhost:8000` (no CORS needed in web mode)
 - `rapidfuzz` for title dedup (10-100x faster than python-Levenshtein)
 - `asyncpg` (not psycopg2) to preserve FastAPI's async benefits
-- Single-user MVP with `user_id` FK for forward-compatibility
-- Per-user OpenAI API key with Fernet encryption + env var fallback
+- Multi-user via Firebase Auth + Postgres RLS: `get_current_user` verifies the ID token and sets the GUC `app.user_id`; per-user tables (`user_feedback`, `user_preferences`, `user_settings`, `follows`, `user_entity_relevance`) are RLS-scoped. `AUTH_REQUIRED=false` keeps the single-user dev fallback (`user_id` FK still everywhere)
+- Multi-provider LLM generation (BYOM): OpenAI / Anthropic / Gemini, per-user encrypted key + model selection (`active_provider` + `model_prefs` JSONB), env-var platform fallback for background jobs; embeddings always OpenAI
+- Knowledge graph: a global entity backbone (G1) + a per-user entity-relevance overlay (G2) personalize ranking across the cast strip, feed, briefing, and search (gated by `UER_ENABLED`, on by default; zero-signal users are a no-op)
+- Per-user API keys Fernet-encrypted in `user_settings` (+ env fallback)
+- Capacitor static export with conditional `next.config.ts` (`BUILD_TARGET=capacitor`)
 - Capacitor static export with conditional `next.config.ts` (`BUILD_TARGET=capacitor`)
 - Dual story routes: `/story/[clusterId]` (web dynamic) + `/story?id=X` (Capacitor static export)
 - Brand assets (adaptive launcher icon, native splash, favicons) regenerate from one official brand kit via deterministic `System.Drawing` resize — `@capacitor/assets`/`sharp` are broken on Windows ARM (see Windows ARM Notes)
@@ -65,7 +68,9 @@ news-app/
 │   │   ├── main.py                   # FastAPI app, lifespan, scheduler setup
 │   │   ├── config.py                 # Pydantic settings (env vars)
 │   │   ├── database.py               # SQLAlchemy async engine + session
-│   │   ├── models.py                 # SQLAlchemy ORM models (9 tables)
+│   │   ├── models.py                 # SQLAlchemy ORM models (16 tables) + RLS DDL events
+│   │   │                             #   incl. entities, entity_aliases, article_entities (G1),
+│   │   │                             #   user_entity_relevance (G2), follows (C), cluster_edges (D2)
 │   │   ├── schemas.py                # Pydantic request/response schemas
 │   │   ├── api/
 │   │   │   └── routes.py             # All REST endpoints
@@ -73,9 +78,12 @@ news-app/
 │   │       ├── fetcher.py            # RSS feed fetcher (feedparser + httpx)
 │   │       ├── gdelt.py              # GDELT API integration (URL discovery + trafilatura)
 │   │       ├── dedup.py              # Deduplication (URL match + rapidfuzz title similarity)
-│   │       ├── embeddings.py         # OpenAI embedding generation + backfill
+│   │       ├── embeddings.py         # OpenAI embedding generation + backfill (always OpenAI)
 │   │       ├── clustering.py         # pgvector nearest-neighbor story clustering
-│   │       └── encryption.py         # Fernet encryption for per-user API keys
+│   │       ├── encryption.py         # Fernet encryption for per-user API keys
+│   │       ├── llm.py                # Multi-provider LLM generation (OpenAI/Anthropic/Gemini)
+│   │       ├── auth.py               # Firebase ID-token verify + get_current_user (sets GUC app.user_id)
+│   │       └── entities.py           # G1/G2 entity backbone: extraction, resolution, relevance scorer
 │   ├── tests/
 │   │   ├── conftest.py               # Pytest fixtures + test DB setup
 │   │   ├── test_api.py               # API endpoint tests
@@ -93,7 +101,7 @@ news-app/
 │   │   │   ├── discover/
 │   │   │   │   └── page.tsx          # Swipe deck discover screen
 │   │   │   ├── settings/
-│   │   │   │   └── page.tsx          # OpenAI API key management
+│   │   │   │   └── page.tsx          # API keys + provider selection (OpenAI/Anthropic/Gemini)
 │   │   │   └── story/
 │   │   │       ├── [clusterId]/
 │   │   │       │   ├── page.tsx      # Deep dive (web — dynamic route)
@@ -150,13 +158,24 @@ news-app/
 | GET/PUT | /profile | Persona: profession, locale, interests, watchlist, depth_pref, region |
 | PUT | /settings/gemini-key | Save/remove per-user Gemini key (Fernet) |
 | POST | /settings/test-gemini-key | Validate Gemini key |
+| PUT | /settings/anthropic-key | Save/remove per-user Anthropic key (Fernet) |
+| POST | /settings/test-anthropic-key | Validate Anthropic key |
 | GET | /clusters/{id}/analysis | Key Facts / 5Ws / profession lens |
 | GET | /clusters/{id}/impact | Per-persona "what's in it for me" (Impact engine v2, `?refresh=1`) |
+| POST | /clusters/{id}/ask | Ask a free-text question about a story (Wave B) |
+| GET | /clusters/{id}/frameworks | Analytical frameworks for a story (Wave B) |
+| GET | /clusters/{id}/consensus | Consensus / divergence across sources (Wave B) |
+| GET | /clusters/{id}/timeline | "How we got here" — temporal cluster edges (Wave D2) |
+| GET | /clusters/{id}/entities | Entities in a story — cast strip, personalized ranking (G1/G2) |
+| GET | /entities/{id}/clusters | Other stories featuring an entity — "appears in" rail (G1) |
 | GET | /clusters/{id}/strategic | Game-theory lens (geopolitics-gated) |
 | GET | /clusters/{id}/trivia | Story quiz (easy/medium/hard) |
 | GET | /trivia/daily | Daily quiz by topic |
+| GET/POST/DELETE | /follows[ /{id}] | List / add / remove a follow (topic, entity, or saved search) (Wave C) |
+| GET | /digest | Personalized digest of followed topics/entities (Wave C) |
 | GET/POST | /admin/sources | List / upsert sources |
-| GET | /search | Hybrid semantic + keyword search |
+| GET | /search | Hybrid semantic + keyword search (G2 within-tier relevance boost) |
+| GET | /auth/me | Current authenticated user (Firebase) |
 
 **Not yet implemented:** `GET /events` (SSE stream), `GET /admin/breadth`
 
@@ -166,6 +185,7 @@ news-app/
 2. **GDELT Fetcher** (every 15 min) → GDELT API → trafilatura extraction → dedup → articles table
 3. **Embedding Backfill** (every 5 min) → OpenAI text-embedding-3-small → pgvector
 4. **Clustering** (every 10 min) → pgvector cosine distance (threshold 0.15) → story_clusters table
+5. **Entity Extraction Backfill** (every 15 min, gated by `GRAPH_EXTRACTION_ENABLED`, dark by default) → LLM extraction over settled clusters → entities / entity_aliases / article_entities (G1)
 
 ## Key Patterns
 
@@ -173,8 +193,12 @@ news-app/
 - **Embedding status:** Articles have `embedding_status` enum (pending/complete/failed). Backfill job retries pending/failed.
 - **Free-first sorting:** Source cards in deep-dive sorted by `is_paywalled` (free first, paywalled last).
 - **Explore/exploit:** Feed is 70% exploit (user's topics) + 30% explore (new topics). Ratio adjusts 10-50% based on feedback.
-- **Graceful degradation:** If OpenAI is down, articles ingested without embeddings; UI shows snippet instead of AI summary.
-- **Per-user API key:** Fernet-encrypted in `user_settings` table. Falls back to `OPENAI_API_KEY` env var if no per-user key.
+- **G1 entity backbone:** LLM extraction (gated by `GRAPH_EXTRACTION_ENABLED`) populates `entities` / `entity_aliases` / `article_entities`. Resolution is exact-then-alias on normalized (`*_norm`) columns with plain b-tree indexes (no functional `lower()` index — avoids autogenerate drift). No embedding NN / auto-merge in G1 (deferred). Cast strip = `GET /clusters/{id}/entities`; reverse "appears in" rail = `GET /entities/{id}/clusters`.
+- **G2 per-user overlay + personalization:** `follows.entity_id` + the RLS-scoped `user_entity_relevance` table capture per-user affinity (follow + positive feedback → `bump_relevance`), decayed at read time (half-life `exp(-ln2·age/half_life)`, age clamped ≥0). One shared scorer `entities.score_clusters_relevance` (= `AVG(decayed)`, no salience term → zero-signal users are a no-op) personalizes the cast strip, feed (recency+relevance blend over a bounded pool), briefing (additive into story_weights), and search (within-tier boost). Gated by `UER_ENABLED` (on by default); each surface is byte-identical when off.
+- **BYOM (multi-provider LLM):** `generate()` resolves the per-user `active_provider` → OpenAI/Anthropic/Gemini, model via `model_prefs` JSONB → config default. Per-provider Fernet-encrypted keys in `user_settings`; env keys are the platform fallback for background jobs. Embeddings stay on OpenAI. Anthropic uses assistant-prefill `"{"` for deterministic JSON.
+- **Auth + RLS:** `get_current_user` verifies the Firebase ID token and sets `SET LOCAL app.user_id` per request; RLS policies on per-user tables are enforce-when-set (permissive for background jobs). `AUTH_REQUIRED=false` falls back to the default user (single-user dev). RLS only bites under a non-superuser DB role (`backend/scripts/create_app_role.sql`); the explicit `current_user_id()` filter is the primary control. A startup `check_rls_posture` logs a warning when the connection is a superuser.
+- **Graceful degradation:** LLM generation degrades by provider — a user with any one valid provider key keeps working if another is down. Summaries fail soft: `get_cluster` / `get_briefing` call `summarize_cluster` on demand when a cluster lacks a cached summary (logged, no user-facing error). If embeddings lag, articles ingest without them and fall back to snippet discovery.
+- **Per-user API key:** Fernet-encrypted in `user_settings` (OpenAI/Gemini/Anthropic). Falls back to the matching `*_API_KEY` env var if no per-user key.
 - **Capacitor static export:** `BUILD_TARGET=capacitor` triggers `output: "export"` in next.config.ts. Dynamic routes like `[clusterId]` don't work in static export, so Capacitor uses `/story?id=X` query-param routing instead.
 - **Dual story routes:** `/story/[clusterId]` for web (dynamic route with rewrites), `/story?id=X` for Capacitor (static export with `useSearchParams` + Suspense boundary).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,25 @@ Copy `.env.example` and fill in:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `POSTGRES_PASSWORD` | Yes | Database password |
-| `OPENAI_API_KEY` | No | Global fallback API key (users can set their own in Settings) |
-| `ENCRYPTION_KEY` | Yes | Fernet key for encrypting per-user API keys |
+| `OPENAI_API_KEY` | No | Platform fallback key — also the only provider used for embeddings (users can set their own in Settings) |
+| `ENCRYPTION_KEY` | Prod | Fernet key for encrypting the per-user API keys stored in `user_settings` |
+| `GENERATION_PROVIDER` | No | Default LLM provider for generation: `openai` \| `anthropic` \| `gemini` (per-user `active_provider` wins) |
+| `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` | No | Platform fallback keys for the other providers (background jobs) |
+| `FIREBASE_CREDENTIALS_JSON` *or* `GOOGLE_APPLICATION_CREDENTIALS` | No | Service account to verify Firebase ID tokens. Omit both → auth disabled, requests use the default user (single-user dev) |
+| `AUTH_REQUIRED` | No | `true` rejects unauthenticated requests with 401 (multi-user prod). Default `false` |
+| `GRAPH_EXTRACTION_ENABLED` | No | Turns on the entity-extraction backfill job (G1). Off by default; needs a platform LLM key |
+| `UER_ENABLED` | No | Per-user entity-relevance personalization (G2). **On by default**; `false` disables it everywhere |
 
 Generate an encryption key:
 ```bash
 python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ```
+
+> **Migrations note:** `alembic upgrade head` also creates the entity-graph tables
+> (`entities`, `entity_aliases`, `article_entities`, `user_entity_relevance`, `follows`,
+> `cluster_edges`) and installs the row-level-security policies on the per-user tables. RLS only
+> *enforces* under a non-superuser DB role (`backend/scripts/create_app_role.sql`); the dev/superuser
+> role bypasses it, so the explicit `current_user_id()` filter is the primary isolation control.
 
 ## Running Tests
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -103,14 +103,29 @@ fly open /health
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DATABASE_URL` | Yes | PostgreSQL connection string (auto-converts to asyncpg) |
-| `OPENAI_API_KEY` | No | OpenAI API key (summaries/embeddings degrade gracefully without it) |
+| `OPENAI_API_KEY` | No* | OpenAI key — *required for embeddings/clustering* and the platform generation fallback |
 | `ENCRYPTION_KEY` | Yes | Fernet encryption key for per-user API key storage |
+| `GENERATION_PROVIDER` | No | Default generation provider: `openai` \| `anthropic` \| `gemini` (per-user `active_provider` wins) |
+| `GEMINI_API_KEY` / `GEMINI_MODEL` | No | Google Gemini platform fallback + model |
+| `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` | No | Anthropic platform fallback + model (default `claude-haiku-4-5`) |
+| `FIREBASE_CREDENTIALS_JSON` *or* `GOOGLE_APPLICATION_CREDENTIALS` | No | Service account to verify Firebase ID tokens. Omit both → auth disabled (default user) |
+| `AUTH_REQUIRED` | No | `true` rejects unauthenticated requests (multi-user prod). Default `false` |
+| `GRAPH_EXTRACTION_ENABLED` | No | Entity-extraction backfill job (G1). Off by default; needs a platform LLM key |
+| `UER_ENABLED` | No | Per-user entity-relevance personalization (G2). **On by default**; `false` disables it |
+| `REQUIRE_ENCRYPTION` | No | `true` refuses to store secrets without `ENCRYPTION_KEY` (recommended in prod) |
 | `RSS_FETCH_INTERVAL_MINUTES` | No | RSS fetch interval (default: 10) |
 | `GDELT_FETCH_INTERVAL_MINUTES` | No | GDELT fetch interval (default: 15) |
 | `EMBEDDING_BACKFILL_INTERVAL_MINUTES` | No | Embedding backfill interval (default: 5) |
+
+> Tuning knobs (`UER_*` blend ratios, `GRAPH_*` extraction params, clustering thresholds) have sensible
+> defaults in `backend/app/config.py` and rarely need overriding — see that file for the full list.
 
 ## Notes
 
 - **Free tier sleep:** Render free tier spins down after 15 min of inactivity. First request takes ~30s to cold-start.
 - **pgvector:** Required for embeddings and clustering. Neon and Supabase both offer free pgvector. Render's built-in Postgres does not.
-- **Graceful degradation:** The app works without OpenAI — summaries fall back to snippets, topic assignment falls back to keyword matching.
+- **Migrations:** `alembic upgrade head` creates all tables (incl. the entity-graph + per-user tables) and installs the RLS policies. Run it once against the deployment DB.
+- **Multi-user auth (optional):** Set `FIREBASE_CREDENTIALS_JSON` (inline service-account JSON works well for hosted secrets) and `AUTH_REQUIRED=true`. Without it, the app runs single-user (every request is the default user).
+- **Row-level security:** RLS on per-user tables only *enforces* under a non-superuser DB role — create one with `backend/scripts/create_app_role.sql` and point `DATABASE_URL` at it for real multi-tenant isolation. A startup check logs a warning if the connection is a superuser. (The explicit per-user query filter is always on regardless.)
+- **Personalization:** Entity-relevance personalization (G2) is on by default and safe — a brand-new account with no signal sees the neutral ranking. Set `UER_ENABLED=false` to turn it off. Populating the entity graph also needs `GRAPH_EXTRACTION_ENABLED=true` + a platform LLM key.
+- **Graceful degradation:** Generation works with any one provider key (OpenAI/Anthropic/Gemini); summaries generate on demand if a batch missed them; without embeddings, discovery falls back to snippets and keyword matching. **Embeddings always require OpenAI.**

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -2,6 +2,14 @@
 
 > Generated using PM Skills: `roadmap-planning` + `prioritization-advisor` (RICE framework)
 
+> **⚠️ Historical record.** This RICE-scored plan captures the original MVP→v2 sprint. Much of it has
+> since shipped — the scores/sequencing below are not current. **Shipped since:** E1 Real AI Summaries,
+> E2 Embedding Topics, E3 Read State, E4 Explore/Exploit, E5 Backend Deploy, **E6 User Auth (Firebase,
+> Google + Email/Password + RLS)**, **E7 Search** (hybrid keyword+semantic). **Beyond this roadmap:**
+> per-persona Impact engine + story lenses (Wave A/B), follows + digest (Wave C), the cluster timeline
+> (Wave D2), the G1/G2 knowledge graph + on-by-default personalization across feed/briefing/search, and
+> multi-provider BYOM (OpenAI/Anthropic/Gemini). See [ROADMAP.md](ROADMAP.md) and `docs/moat/` for current state.
+
 ## Strategy Context
 
 **Business Goal:** Transform NewsLens from an RSS-reader demo into a real AI-powered news intelligence product that delivers its core promise — multi-source story clustering with AI summaries.
@@ -15,8 +23,8 @@
 
 **Constraints:**
 - Solo developer on Windows ARM (Turbopack broken, backend in Docker)
-- Single-user MVP (no auth yet)
-- OpenAI API cost sensitivity (per-user keys, batched calls)
+- ~~Single-user MVP (no auth yet)~~ → **multi-user via Firebase auth + Postgres RLS shipped** (E6); `AUTH_REQUIRED=false` keeps single-user dev
+- LLM API cost sensitivity (per-user keys, batched calls) — now multi-provider (OpenAI/Anthropic/Gemini)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,22 @@ An AI-powered news intelligence platform. NewsLens ingests articles from RSS fee
 - **Daily briefing** — top story clusters with AI-generated summaries, free sources surfaced first.
 - **Discover deck** — swipe through randomized cards; swipes adjust your topic weights.
 - **Deep dive** — every cluster expands to all its source articles with a confidence score (`src:N · coh:0.XX`).
-- **Explore/exploit feed** — 70% your topics, 30% new ones; the ratio adapts to your feedback.
-- **Bring your own key** — per-user OpenAI API key, Fernet-encrypted, with an env-var fallback.
-- **Graceful degradation** — if OpenAI is down, articles still ingest and the UI shows snippets instead of AI summaries.
+- **Story lenses** — Key Facts / 5Ws, a profession-aware "what's in it for me" impact, ask-a-question, analytical frameworks, consensus/divergence, a "how we got here" timeline, and a per-story quiz.
+- **Who's in the story** — a cast strip of the people/orgs/places in each cluster, with an "appears in" rail to other stories about the same entity.
+- **Personalized ranking** — follow entities and read stories, and the entities you care about rise across the cast strip, feed, briefing, and search. On by default; a brand-new account just sees the neutral ranking.
+- **Follows + digest** — follow topics, entities, or saved searches and get a personalized digest.
+- **Bring your own model** — per-user, Fernet-encrypted keys for **OpenAI, Anthropic, or Gemini**, with model selection and an env-var platform fallback. (Embeddings always use OpenAI.)
+- **Accounts** — Firebase auth (Google + Email/Password); single-user dev mode when auth isn't configured.
+- **Graceful degradation** — generation degrades by provider (any one valid key keeps you working); summaries generate on demand if a batch missed them; if embeddings lag, the UI falls back to snippets.
 
 ## Stack
 
 | Layer | Tech |
 |-------|------|
 | Frontend | Next.js 16 (App Router), React 19, Tailwind CSS 4, Framer Motion |
-| Backend | Python, FastAPI, APScheduler |
-| Database | PostgreSQL + pgvector |
-| ML | OpenAI `text-embedding-3-small`, pgvector cosine clustering |
+| Backend | Python, FastAPI, APScheduler, Firebase Admin SDK (auth) |
+| Database | PostgreSQL + pgvector (+ row-level security on per-user tables) |
+| ML | OpenAI `text-embedding-3-small` (embeddings) + multi-provider generation (OpenAI / Anthropic / Gemini); pgvector cosine clustering |
 | Mobile | Capacitor (Android) + `@capacitor/splash-screen` |
 
 ## Quick start
@@ -29,7 +33,10 @@ Requires Docker (recommended for the DB + backend) and Node.js for the frontend.
 
 ```bash
 # 1. Configure environment
-cp .env.example .env        # then fill in DATABASE_URL, OPENAI_API_KEY, ENCRYPTION_KEY
+cp .env.example .env        # fill in OPENAI_API_KEY (+ ENCRYPTION_KEY for production).
+                            # Optional: GEMINI_API_KEY / ANTHROPIC_API_KEY (other providers),
+                            # FIREBASE_CREDENTIALS_JSON + AUTH_REQUIRED (multi-user auth),
+                            # GRAPH_EXTRACTION_ENABLED / UER_ENABLED (entity graph + personalization)
 
 # 2. Start the database + backend
 docker-compose up -d db      # PostgreSQL + pgvector
@@ -47,12 +54,13 @@ Open http://localhost:3000 and the briefing should load. The frontend proxies `/
 
 ## Data pipeline
 
-Four APScheduler jobs run inside the FastAPI process:
+APScheduler jobs run inside the FastAPI process:
 
 1. **RSS fetcher** (every 10 min) → feedparser → dedup → `articles`
 2. **GDELT fetcher** (every 15 min) → trafilatura extraction → dedup → `articles`
 3. **Embedding backfill** (every 5 min) → OpenAI embeddings → pgvector
 4. **Clustering** (every 10 min) → pgvector cosine distance (threshold 0.15) → `story_clusters`
+5. **Entity extraction** (every 15 min, off by default behind `GRAPH_EXTRACTION_ENABLED`) → LLM extraction over settled clusters → `entities` / `article_entities`
 
 ## Mobile (Android)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,17 +7,19 @@
 ## Current Status
 
 **Working:**
-- Data pipeline: RSS + GDELT fetching, dedup, embedding, clustering (all on APScheduler)
-- API: ~27 endpoints (feed, briefing, discover, cluster lenses, profile, settings, search, admin, stats)
-- Frontend: Briefing, Discover, Deep Dive, Search, Saved, Settings, Onboarding
-- Real LLM features shipped (E1–E8): provider abstraction (OpenAI + Gemini), real AI summaries,
+- Data pipeline: RSS + GDELT fetching, dedup, embedding, clustering, **entity extraction** (G1, gated) — all on APScheduler
+- API: ~40 endpoints (feed, briefing, discover, cluster lenses, **entities + appears-in**, **follows + digest**, ask/frameworks/consensus/timeline, profile, settings, search, admin, stats, auth)
+- Frontend: Briefing, Discover, Deep Dive, Search, Saved, Settings, Onboarding, **entity cast strip**
+- Real LLM features shipped (E1–E8): provider abstraction (**OpenAI + Anthropic + Gemini**, Wave E BYOM), real AI summaries,
   analysis/5Ws/profession lenses, **per-persona Impact engine v2 (structured + guarded, Wave A)**,
   strategic lens, trivia/daily quiz
+- **Knowledge graph (Wave D Phase 3):** G1 global entity backbone (entities/aliases/article links + cast strip) and G2 per-user entity-relevance overlay; **personalized ranking across cast strip + feed + briefing + search, ON by default (`UER_ENABLED`)** — zero-signal users are a no-op
+- **Auth (Wave D Phase A):** Firebase (Google + Email/Password), `get_current_user` + Postgres RLS on per-user tables; `AUTH_REQUIRED=false` keeps single-user dev
 - Feedback-driven explore/exploit (0.3 is now only a cold-start fallback; swipes move weights)
 - Design system: Full spec + CSS token implementation
 - Mobile: Capacitor Android APK builds
 - Brand: authentic NewsLens launcher icon (adaptive) + native splash (mark + Fraunces wordmark on #0C0C0E) + web/PWA favicons, all from the official brand kit; `@capacitor/splash-screen` controlled splash → WebView fade
-- Per-user OpenAI + Gemini API key management with Fernet encryption
+- Per-user **OpenAI + Anthropic + Gemini** API key + model management with Fernet encryption
 
 **Still stubbed / heuristic:**
 - Cluster `coherence` is still a source-count heuristic (0.95/0.85/0.75/0.65), not a learned score —

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -78,8 +78,10 @@ class Settings(BaseSettings):
     graph_extract_interval_minutes: int = 15   # backfill cadence
 
     # G2 per-user entity overlay (Wave D Phase 3). Decay/weight constants are HYPOTHESES — no
-    # single-user data can tune them; treat as knobs, not validated values. Ships off by default.
-    uer_enabled: bool = False
+    # single-user data can tune them; treat as knobs, not validated values.
+    # ON by default (cast strip + feed/briefing/search). Safe with no signal: a user with zero
+    # relevance rows is a no-op on every surface. Set UER_ENABLED=false to disable.
+    uer_enabled: bool = True
     uer_half_life_days: float = 21.0
     uer_follow_weight: float = 1.0
     uer_rank_alpha: float = 0.6   # weight on global salience (cast strip only)

--- a/backend/tests/unit/test_config_g2.py
+++ b/backend/tests/unit/test_config_g2.py
@@ -3,10 +3,10 @@ from app.config import Settings, settings
 
 
 def test_g2_config_defaults(monkeypatch):
-    # Assert the SHIPPED default (the code literal), independent of any ambient UER_ENABLED that a
-    # local docker-compose.override.yml may set for dev — construct a fresh Settings with it unset.
+    # Assert the SHIPPED default (the code literal), independent of any ambient UER_ENABLED override —
+    # construct a fresh Settings with it unset.
     monkeypatch.delenv("UER_ENABLED", raising=False)
-    assert Settings().uer_enabled is False  # overlay ships dark
+    assert Settings().uer_enabled is True  # personalization is ON by default (no-op without signal)
     # The numeric knobs have no env override in any environment, so the singleton is representative.
     assert settings.uer_half_life_days == 21.0
     assert settings.uer_follow_weight == 1.0
@@ -15,7 +15,7 @@ def test_g2_config_defaults(monkeypatch):
 
 
 def test_g2_surface_personalization_defaults():
-    """Surface knobs (feed/briefing/search) — conservative, ship dark behind uer_enabled."""
+    """Surface knobs (feed/briefing/search) — conservative defaults, active when uer_enabled."""
     assert settings.uer_feed_pool_size == 500
     assert settings.uer_feed_blend_ratio == 0.3
     assert settings.uer_briefing_blend_weight == 0.2

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,11 +13,17 @@ Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Capacitor (Andro
 | Route | File | Purpose |
 |-------|------|---------|
 | `/` | `app/page.tsx` | Briefing screen — daily AI news briefing |
+| `/welcome` | `app/welcome/page.tsx` | First-run 3-page intro (before onboarding) |
+| `/onboarding` | `app/onboarding/page.tsx` | Persona/interest picker (E3) |
+| `/login` | `app/login/page.tsx` | Firebase sign-in (Google + Email/Password) |
 | `/discover` | `app/discover/page.tsx` | Discover screen — swipable card deck |
+| `/search` | `app/search/page.tsx` | Hybrid keyword + semantic search |
+| `/following` | `app/following/page.tsx` | Followed topics / entities + digest |
 | `/story/[clusterId]` | `app/story/[clusterId]/page.tsx` | Deep dive — web (dynamic route) |
 | `/story?id=X` | `app/story/page.tsx` + `StoryContent.tsx` | Deep dive — Capacitor (query param) |
 | `/saved` | `app/saved/page.tsx` | Saved articles list with unsave |
-| `/settings` | `app/settings/page.tsx` | Profile, topics, theme, API key management |
+| `/settings` | `app/settings/page.tsx` | Profile, topics, theme, multi-provider API keys + model selection |
+| `/admin/sources` | `app/admin/sources/page.tsx` | Source management (list / upsert) |
 
 ### Why two story routes?
 
@@ -29,16 +35,26 @@ Next.js static export (`output: "export"`) cannot handle dynamic route segments 
 layout.tsx (NavBar)
 ├── page.tsx → StoryCard[]
 ├── discover/page.tsx → DiscoverCard[] (Framer Motion swipe)
-├── story/[clusterId]/page.tsx → DeepDiveView → SourceCard[], AISummaryBox
+├── story/[clusterId]/page.tsx → DeepDiveView → SourceCard[], AISummaryBox,
+│                                  EntityChips (cast strip), ImpactCard, AskBox,
+│                                  FrameworksCard, ConsensusRow, FollowButton
 ├── story/page.tsx → StoryContent → DeepDiveView
-└── settings/page.tsx
+├── following/page.tsx → FollowButton[]
+└── settings/page.tsx (multi-provider key + model UI)
 ```
+
+Most story lenses (impact / ask / frameworks / consensus) and the entity cast strip self-fetch their
+own endpoint and are gated/skeleton-guarded, so the deep-dive renders progressively.
 
 ## API Client
 
 `src/lib/api.ts` — Environment-aware base URL:
 - Web: `/api` (proxied to backend via Next.js rewrites in `next.config.ts`)
 - Capacitor: `NEXT_PUBLIC_API_BASE_URL` env var (e.g., `http://10.0.2.2:8000`)
+
+**Auth:** when Firebase is configured, the client attaches the user's ID token as a Bearer header; the
+backend `get_current_user` verifies it and scopes per-user data. With `AUTH_REQUIRED=false` (default
+dev) the backend falls back to the default user, so the app works unauthenticated.
 
 ## Design System
 


### PR DESCRIPTION
Two coherent changes: flip the personalization default on, and bring **every living doc** in sync with the system as it now stands.

## 1. Personalization on by default
`uer_enabled: False → True`, so the G2 entity-relevance personalization (cast strip + feed / briefing / search) is on in every environment, not just behind the local override. Safe by construction — the surface scorer is `AVG(decayed relevance)` with no salience term, so a zero-signal user collapses to the exact baseline (the no-op invariant, regression-guarded per surface). `test_g2_config_defaults` now asserts the `True` default (still hermetic). **Set `UER_ENABLED=false` to disable.**

Validated **backend 241 passed / 1 skipped** both with the default ON and with `UER_ENABLED=false` forced.

## 2. Docs refresh (audited against the code)
One reader per doc cross-checked against `routes.py` / `config.py` / `models.py`, then applied:

- **`.env.example`** — BYOM provider keys, Firebase auth flags, `GRAPH_EXTRACTION_ENABLED`, `UER_ENABLED`.
- **`CLAUDE.md`** — +11 missing endpoints, 9→16 tables, +`llm`/`auth`/`entities` services, multi-provider + multi-user/RLS decisions, 5th pipeline job, G1/G2/BYOM/Auth/personalization patterns.
- **`README.md`** — features, ML stack, quick-start env, 5th job.
- **`ARCHITECTURE.md`** — ER diagram +6 tables + BYOM columns + relationships, system diagram (entity job / LLM / auth / relevance, ~40 endpoints), +7 decision-log rows.
- **`CONTRIBUTING.md` / `DEPLOY.md`** — full env-var reference + multi-user / RLS-role / personalization production notes.
- **`ROADMAP.md` / `PRODUCT_ROADMAP.md`** — marked shipped (auth, search, lenses, graph, BYOM); fixed the "single-user, no auth" constraint.
- **`frontend/CLAUDE.md`** — +6 routes, lens + cast-strip components, Firebase auth note.

Historical plan/PRD records (`docs/moat/*`, `docs/enhancement/*`) left as point-in-time records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)