### PR TITLE
Turn on entity extraction by default + relevance/index hardening + coherence swap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,9 @@ GOOGLE_APPLICATION_CREDENTIALS=       # path to a mounted service-account .json
 AUTH_REQUIRED=false
 
 # ── Knowledge graph + personalization ──
-# Entity extraction (G1) ships dark; enable after watching the skip rate. Needs a platform LLM key.
-GRAPH_EXTRACTION_ENABLED=false
+# Entity extraction (G1) is ON by default. It needs a platform LLM key to run and skips gracefully
+# without one. Set to false to disable (e.g. to avoid the extraction LLM cost).
+GRAPH_EXTRACTION_ENABLED=true
 # Per-user entity-relevance personalization (G2): cast strip + feed/briefing/search. ON by default;
 # a user with no follows/feedback is a no-op everywhere. Set false to disable.
 UER_ENABLED=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ news-app/
 2. **GDELT Fetcher** (every 15 min) → GDELT API → trafilatura extraction → dedup → articles table
 3. **Embedding Backfill** (every 5 min) → OpenAI text-embedding-3-small → pgvector
 4. **Clustering** (every 10 min) → pgvector cosine distance (threshold 0.15) → story_clusters table
-5. **Entity Extraction Backfill** (every 15 min, gated by `GRAPH_EXTRACTION_ENABLED`, dark by default) → LLM extraction over settled clusters → entities / entity_aliases / article_entities (G1)
+5. **Entity Extraction Backfill** (every 15 min, on by default via `GRAPH_EXTRACTION_ENABLED`; needs a platform LLM key, skips gracefully without one) → LLM extraction over settled clusters → entities / entity_aliases / article_entities (G1)
 
 ## Key Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Copy `.env.example` and fill in:
 | `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` | No | Platform fallback keys for the other providers (background jobs) |
 | `FIREBASE_CREDENTIALS_JSON` *or* `GOOGLE_APPLICATION_CREDENTIALS` | No | Service account to verify Firebase ID tokens. Omit both → auth disabled, requests use the default user (single-user dev) |
 | `AUTH_REQUIRED` | No | `true` rejects unauthenticated requests with 401 (multi-user prod). Default `false` |
-| `GRAPH_EXTRACTION_ENABLED` | No | Turns on the entity-extraction backfill job (G1). Off by default; needs a platform LLM key |
+| `GRAPH_EXTRACTION_ENABLED` | No | Entity-extraction backfill job (G1). **On by default**; needs a platform LLM key (skips without one). Set `false` to disable |
 | `UER_ENABLED` | No | Per-user entity-relevance personalization (G2). **On by default**; `false` disables it everywhere |
 
 Generate an encryption key:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -110,7 +110,7 @@ fly open /health
 | `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` | No | Anthropic platform fallback + model (default `claude-haiku-4-5`) |
 | `FIREBASE_CREDENTIALS_JSON` *or* `GOOGLE_APPLICATION_CREDENTIALS` | No | Service account to verify Firebase ID tokens. Omit both → auth disabled (default user) |
 | `AUTH_REQUIRED` | No | `true` rejects unauthenticated requests (multi-user prod). Default `false` |
-| `GRAPH_EXTRACTION_ENABLED` | No | Entity-extraction backfill job (G1). Off by default; needs a platform LLM key |
+| `GRAPH_EXTRACTION_ENABLED` | No | Entity-extraction backfill job (G1). **On by default**; needs a platform LLM key, skips without one. Set `false` to avoid the extraction LLM cost |
 | `UER_ENABLED` | No | Per-user entity-relevance personalization (G2). **On by default**; `false` disables it |
 | `REQUIRE_ENCRYPTION` | No | `true` refuses to store secrets without `ENCRYPTION_KEY` (recommended in prod) |
 | `RSS_FETCH_INTERVAL_MINUTES` | No | RSS fetch interval (default: 10) |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -340,12 +340,15 @@ async def get_cluster(cluster_id: int, db: AsyncSession = Depends(get_db)):
     # Free first, then paywalled
     source_cards.sort(key=lambda x: (not x.is_free, x.article.title))
 
+    from app.services import lenses
+
     return ClusterDetailOut(
         id=cluster.id,
         title=cluster.title,
         summary=cluster.summary,
         created_at=cluster.created_at,
-        coherence=getattr(cluster, "coherence", None),  # real coherence; None when not yet computed
+        # Real source-agreement ratio when a consensus pass is cached; else stored value / heuristic.
+        coherence=lenses.cluster_coherence(cluster, [ca.article for ca in cluster.articles]),
         sources=source_cards,
     )
 
@@ -473,7 +476,7 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
     clusters = result.scalars().all()
 
     # G2: per-cluster entity relevance for this user (one aggregate; {} when off / zero-signal).
-    from app.services import entities
+    from app.services import entities, lenses
 
     cluster_scores = await entities.score_clusters_relevance(
         db, [c.id for c in clusters], current_user_id()
@@ -520,17 +523,9 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
             if len(sentences) > 2:
                 summary = ". ".join(sentences[:2]) + "."
 
-        # Dynamic coherence from source count if not set
-        if coherence is None:
-            sc = len(source_names)
-            if sc >= 5:
-                coherence = 0.95
-            elif sc >= 3:
-                coherence = 0.85
-            elif sc >= 2:
-                coherence = 0.75
-            else:
-                coherence = 0.65
+        # Coherence: the real source-agreement ratio when a consensus pass is cached for this cluster,
+        # else the stored value, else the honest source-overlap heuristic (all in cluster_coherence).
+        coherence = lenses.cluster_coherence(cluster, [ca.article for ca in cluster.articles])
 
         # Check if any article in this cluster has been read
         is_read = any(aid in read_article_ids for aid in cluster_article_ids)
@@ -1406,8 +1401,15 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
             )
             await db.commit()
         else:
-            # String path: resolve_existing is kind-blind, so stays log-only (no UER write).
+            # String/typed path: resolve_existing is kind-blind (best-effort) — but a typed entity
+            # follow is still an explicit signal, so seed relevance when it resolves to a node. The
+            # follow row keeps entity_id NULL (only the chip path persists the trustworthy id).
             eid = await entities.resolve_existing(db, value)
+            if eid is not None:
+                await entities.bump_relevance(
+                    db, current_user_id(), eid, source="follow", weight=settings.uer_follow_weight
+                )
+                await db.commit()
             logger.info("entity_follow_resolved", value=value, entity_id=eid)
     return FollowOut.model_validate(f)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -67,8 +67,9 @@ class Settings(BaseSettings):
     # default false keeps single-user dev + the rollout window working.
     auth_required: bool = False
 
-    # G1 entity backbone (Wave D Phase 3). Extraction ships DARK (enable after monitoring skip rate).
-    graph_extraction_enabled: bool = False
+    # G1 entity backbone (Wave D Phase 3). Extraction is ON by default — it needs a platform LLM key to
+    # run and skips gracefully (LLMUnavailable) without one. Set GRAPH_EXTRACTION_ENABLED=false to disable.
+    graph_extraction_enabled: bool = True
     graph_extraction_model: str = "gpt-4o-mini"
     graph_max_entities_per_cluster: int = 12   # cast-strip cap + extraction salience cap
     graph_salience_floor: float = 0.3          # drop entities below this salience at extraction

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -381,6 +381,7 @@ class ArticleEntity(Base):
     __table_args__ = (
         UniqueConstraint("article_id", "entity_id", name="uq_article_entity"),  # idempotent re-extract
         Index("ix_article_entities_entity", "entity_id"),  # reverse "appears in" lookup
+        Index("ix_article_entities_article", "article_id"),  # feed-pool + relevance-scorer join (hot path)
     )
 
 
@@ -400,9 +401,10 @@ class UserEntityRelevance(Base):
     last_event_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     score: Mapped[float | None] = mapped_column(Float)  # optional write-time cache (not the ranking key)
 
-    __table_args__ = (
-        Index("ix_uer_user_score", "user_id", "score"),  # serves the WHERE user_id= filter
-    )
+    # No extra index: the (user_id, entity_id) PK already serves the personalization join's
+    # `WHERE user_id =` (leftmost column). The old ix_uer_user_score on (user_id, score) was dead
+    # weight — `score` is never written, so it indexed all-NULL and only cost writes. Re-add a
+    # (user_id, score) index if/when score is materialized for a global-ranking query.
 
 
 # ── Row-Level Security (Wave D Phase A) ──────────────────────────────────────────────

--- a/backend/app/services/lenses.py
+++ b/backend/app/services/lenses.py
@@ -250,6 +250,36 @@ async def _cache_write(db: AsyncSession, cluster: StoryCluster, column: str, sub
     db.expire(cluster, [column])
 
 
+def coherence_heuristic(source_count: int) -> float:
+    """Source-overlap (breadth) fallback when no real agreement metric exists — a coverage proxy,
+    not a learned score. The UI labels it honestly as 'source overlap', never 'agreement'."""
+    if source_count >= 5:
+        return 0.95
+    if source_count >= 3:
+        return 0.85
+    if source_count >= 2:
+        return 0.75
+    return 0.65
+
+
+def cluster_coherence(cluster: StoryCluster, articles: list[Article]) -> float:
+    """Honest coherence for a cluster. Prefers the REAL source-agreement ratio (agree_count / total)
+    from a cached consensus pass for the current sources — so a contested story can score below the
+    heuristic floor — then the stored value, then the source-overlap heuristic. Pure read (no LLM, no
+    extra query): it only inspects the already-loaded cluster + the consensus cache."""
+    try:
+        cons = _cache_read(cluster, "extra_json", "consensus", _source_hash(articles))
+    except AttributeError:
+        cons = None  # cluster-like object without the JSONB column → fall through (never crash a read)
+    if isinstance(cons, dict):
+        total = cons.get("total") or 0
+        if total > 0:
+            return max(0.0, min(1.0, (cons.get("agree_count") or 0) / total))
+    if getattr(cluster, "coherence", None) is not None:
+        return cluster.coherence
+    return coherence_heuristic(len({a.source_id for a in articles}) or len(articles))
+
+
 async def get_lens(
     db: AsyncSession,
     cluster_id: int,

--- a/backend/migrations/versions/f1a2b3c4d5e6_index_cleanup.py
+++ b/backend/migrations/versions/f1a2b3c4d5e6_index_cleanup.py
@@ -1,0 +1,29 @@
+"""index cleanup: drop dead ix_uer_user_score, add ix_article_entities_article
+
+Revision ID: f1a2b3c4d5e6
+Revises: d1e2f3a4b5c6
+Create Date: 2026-06-27 10:00:00.000000
+
+- ix_uer_user_score (user_id, score) was dead weight: `score` is never written, so it indexed
+  all-NULL; the (user_id, entity_id) PK already serves the personalization join's WHERE user_id=.
+- ix_article_entities_article (article_id) backs the now-hot feed-pool + relevance-scorer join
+  (article_entities ON ca.article_id) that runs on every personalized feed/briefing/search read.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, None] = "d1e2f3a4b5c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_uer_user_score", table_name="user_entity_relevance")
+    op.create_index("ix_article_entities_article", "article_entities", ["article_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_article_entities_article", table_name="article_entities")
+    op.create_index("ix_uer_user_score", "user_entity_relevance", ["user_id", "score"])

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -78,6 +78,8 @@ class FakeCluster:
         self.title = title
         self.summary = summary
         self.created_at = datetime.now(timezone.utc)
+        self.coherence = None
+        self.extra_json = None  # lens cache column (consensus etc.) — None until populated
         self.articles = cluster_articles or []
 
 

--- a/backend/tests/integration/test_coherence.py
+++ b/backend/tests/integration/test_coherence.py
@@ -1,0 +1,73 @@
+"""S4: cluster_coherence — real consensus agreement ratio when cached, else honest fallback."""
+import pytest
+from sqlalchemy import select  # noqa: F401 (kept for parity with sibling test modules)
+
+from app.models import (
+    Article, ClusterArticle, EmbeddingStatus, Source, SourceType, StoryCluster,
+)
+from app.services import lenses
+
+_n = 0
+
+
+async def _cluster(db, n_sources, *, stored_coherence=None):
+    """A cluster of n_sources distinct-source articles (summary set → no on-demand LLM call)."""
+    global _n
+    cl = StoryCluster(title="C", summary="s", coherence=stored_coherence)
+    db.add(cl)
+    await db.flush()
+    arts = []
+    for _i in range(n_sources):
+        _n += 1
+        s = Source(name=f"S{_n}", url=f"https://coh/{_n}", source_type=SourceType.wire)
+        db.add(s)
+        await db.flush()
+        a = Article(title=f"A{_n}", url=f"https://coh/{_n}/a", source_id=s.id,
+                    embedding_status=EmbeddingStatus.complete)
+        db.add(a)
+        await db.flush()
+        db.add(ClusterArticle(cluster_id=cl.id, article_id=a.id))
+        arts.append(a)
+    await db.flush()
+    return cl, arts
+
+
+async def _cache_consensus(db, cl, arts, agree, total):
+    sh = lenses._source_hash(arts)
+    await lenses._cache_write(db, cl, "extra_json", "consensus", sh,
+                              {"agree_count": agree, "total": total, "dissent": [], "summary": "x"})
+    await db.refresh(cl, ["extra_json"])
+
+
+@pytest.mark.asyncio
+async def test_coherence_uses_cached_consensus(db_session):
+    cl, arts = await _cluster(db_session, 4)  # source-overlap heuristic would be 0.85
+    await _cache_consensus(db_session, cl, arts, agree=1, total=4)
+    assert lenses.cluster_coherence(cl, arts) == pytest.approx(0.25)  # real 1/4, not the 0.85 heuristic
+
+
+@pytest.mark.asyncio
+async def test_coherence_contested_scores_below_heuristic_floor(db_session):
+    cl, arts = await _cluster(db_session, 5)  # heuristic would be 0.95
+    await _cache_consensus(db_session, cl, arts, agree=2, total=5)
+    assert lenses.cluster_coherence(cl, arts) == pytest.approx(0.4)  # honest: contested → below floor
+
+
+@pytest.mark.asyncio
+async def test_coherence_falls_back_to_heuristic(db_session):
+    cl, arts = await _cluster(db_session, 4)  # no consensus, no stored value
+    assert lenses.cluster_coherence(cl, arts) == pytest.approx(0.85)  # >=3 distinct sources
+
+
+@pytest.mark.asyncio
+async def test_coherence_prefers_stored_when_no_consensus(db_session):
+    cl, arts = await _cluster(db_session, 2, stored_coherence=0.5)
+    assert lenses.cluster_coherence(cl, arts) == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_surfaces_consensus_coherence(aclient, db_session):
+    cl, arts = await _cluster(db_session, 4)
+    await _cache_consensus(db_session, cl, arts, agree=3, total=4)
+    body = (await aclient.get(f"/clusters/{cl.id}")).json()
+    assert body["coherence"] == pytest.approx(0.75)  # 3/4 from the real consensus, end-to-end

--- a/backend/tests/integration/test_g2_overlay.py
+++ b/backend/tests/integration/test_g2_overlay.py
@@ -73,6 +73,19 @@ async def test_entity_follow_persists_entity_id_and_seeds_relevance(aclient, db_
     assert uer2.engagement_raw == 1.0
 
 
+@pytest.mark.asyncio
+async def test_typed_entity_follow_seeds_relevance(aclient, db_session):
+    """A typed entity-follow (no chip id) that resolves to a node still seeds relevance (§2a)."""
+    e = await _entity(db_session, "Globex")  # name_norm "globex"
+    r = await aclient.post("/follows", json={"kind": "entity", "value": "Globex"})  # no entity_id
+    assert r.status_code == 201
+    follow = (await db_session.execute(select(Follow).where(Follow.value == "Globex"))).scalar_one()
+    assert follow.entity_id is None  # string path leaves the link NULL (resolution is best-effort)
+    uer = (await db_session.execute(
+        select(UserEntityRelevance).where(UserEntityRelevance.entity_id == e.id))).scalar_one()
+    assert uer.source == "follow" and uer.engagement_raw == 1.0
+
+
 # ── S3 ──
 @pytest.mark.asyncio
 async def test_cluster_entities_personalized_ranks_followed_first(aclient, db_session, monkeypatch):


### PR DESCRIPTION
Lights up the knowledge graph and lands the §2 hardening + the coherence-metric swap.

## S1 — Entity extraction on by default
`GRAPH_EXTRACTION_ENABLED: False → True`. The extraction backfill now runs by default; it needs a platform LLM key and **skips gracefully** (`LLMUnavailable`) without one. This is what gives the cast strip + personalization real signal to act on. Docs synced (`.env.example`, `CLAUDE.md`, `DEPLOY.md`, `CONTRIBUTING.md`). *Cost note: where a platform key exists, extraction now makes LLM calls by default — set `GRAPH_EXTRACTION_ENABLED=false` to opt out.*

## S2 (§2a) — typed-follow seeds relevance
The string/typed entity-follow path now seeds `user_entity_relevance` when `resolve_existing` finds a node (was log-only). The follow row still keeps `entity_id` NULL — only the chip path persists the trustworthy id. → `test_typed_entity_follow_seeds_relevance`.

## S3 (§2c) — index cleanup (migration `f1a2b3c4d5e6`)
- **Drop** `ix_uer_user_score` — `score` is never written, so it indexed all-NULL; the `(user_id, entity_id)` PK already serves the personalization join's `WHERE user_id=`.
- **Add** `ix_article_entities_article(article_id)` — backs the now-hot feed-pool + relevance-scorer join that runs on every personalized read. Parity + upgrade tests green.

## S4 — coherence-metric swap
`lenses.cluster_coherence` prefers the **real source-agreement ratio** (`agree_count/total`) from a cached consensus pass for the current sources — so a contested story can honestly score *below* the old 0.65 heuristic floor — then the stored value, then the deduped source-overlap heuristic. Wired into `/briefing` + `/clusters/{id}` (pure read: no extra query, no LLM). Hardened to never crash a read; the `FakeCluster` test mock gained the `extra_json`/`coherence` columns it was missing. → `test_coherence.py`.

## Deliberately NOT done
**§2b — widening `lenses._source_hash` with entity ids + user scope.** Premature: no lens reads graph or user-dependent data yet (personalized surfaces are uncached pure-SQL), and adding user scope would make lens caches per-user → real cost for zero current benefit. Do it the moment a lens actually becomes entity- or user-dependent.

## Validation
**Backend 247 passed / 1 skipped** (+6 new), schema reset for the index migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)