### PR TITLE
fix(deploy): run migrations on deploy — fixes prod 500s on all authed endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,15 @@ GDELT_FETCH_INTERVAL_MINUTES=15
 EMBEDDING_BACKFILL_INTERVAL_MINUTES=5
 
 # Encryption (generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+# Must be a 32-byte url-safe base64 key (what Fernet.generate_key() returns) — NOT "any random string".
+# Never rotate without a re-encryption migration: a new key orphans every stored encrypted API key.
 ENCRYPTION_KEY=
 # Production: set true to refuse storing secrets without ENCRYPTION_KEY
 REQUIRE_ENCRYPTION=false
+
+# Schema bootstrap. Dev/test leave this true (init_db's create_all builds the schema without Alembic).
+# PROD must set false: prod runs `alembic upgrade head` on start (Docker CMD) and create_all can't
+# ALTER an existing table to add columns — leaving it on in prod is how the schema silently drifted.
+INIT_DB_CREATE_ALL=true
 # DB TLS is verified by default for Neon/Supabase; set true only if a cert chain can't be verified
 DB_SSL_INSECURE=false

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -31,9 +31,10 @@ Render's free Postgres does **not** include pgvector. Two options:
    - **Plan:** Free
 4. Environment variables:
    - `DATABASE_URL` — paste the Neon/Supabase connection string (the app auto-converts `postgresql://` to `postgresql+asyncpg://`)
-   - `OPENAI_API_KEY` — your OpenAI API key
-   - `ENCRYPTION_KEY` — any random 32+ char string (for Fernet key encryption)
-5. Click **Deploy**
+   - `OPENAI_API_KEY` — your OpenAI API key (**required**: with no key, embeddings never run → nothing clusters → the feed/briefing stay empty while `/health` is green)
+   - `ENCRYPTION_KEY` — a **Fernet** key: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"` (a plain "random string" is rejected by Fernet). Set it **once** and store it — rotating it orphans every stored encrypted key.
+   - `INIT_DB_CREATE_ALL=false` — prod schema is Alembic-only (see **Migrations** below)
+5. Click **Deploy**. The container runs `alembic upgrade head` on start, then serves. **If the database already exists from a pre-Alembic deploy, do the one-time [reconcile](#reconcile-an-existing-pre-alembic-database) first** or the boot-time upgrade fails.
 
 ### 4. Verify
 
@@ -104,7 +105,8 @@ fly open /health
 |----------|----------|-------------|
 | `DATABASE_URL` | Yes | PostgreSQL connection string (auto-converts to asyncpg) |
 | `OPENAI_API_KEY` | No* | OpenAI key — *required for embeddings/clustering* and the platform generation fallback |
-| `ENCRYPTION_KEY` | Yes | Fernet encryption key for per-user API key storage |
+| `ENCRYPTION_KEY` | Yes | Fernet key (`Fernet.generate_key()` — 32-byte url-safe base64) for per-user API key storage. Set once; rotating it orphans stored keys |
+| `INIT_DB_CREATE_ALL` | No | `false` in prod (schema is Alembic-only). Default `true` bootstraps dev/test via `create_all` |
 | `GENERATION_PROVIDER` | No | Default generation provider: `openai` \| `anthropic` \| `gemini` (per-user `active_provider` wins) |
 | `GEMINI_API_KEY` / `GEMINI_MODEL` | No | Google Gemini platform fallback + model |
 | `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` | No | Anthropic platform fallback + model (default `claude-haiku-4-5`) |
@@ -120,11 +122,56 @@ fly open /health
 > Tuning knobs (`UER_*` blend ratios, `GRAPH_*` extraction params, clustering thresholds) have sensible
 > defaults in `backend/app/config.py` and rarely need overriding — see that file for the full list.
 
+## Reconcile an existing (pre-Alembic) database
+
+The deploy runs `alembic upgrade head` on every start (the backend Docker start command). That is safe
+for a **fresh** database and a **no-op** once the DB is at head. But a database first built by the old
+`init_db` `create_all` path has **no `alembic_version` row** and a schema frozen at whatever code
+created it — so a plain `alembic upgrade head` tries to re-`CREATE` tables that already exist and
+**fails on boot**. Reconcile it **once**, before (or together with) the first migration-running deploy.
+
+> ⚠️ `op.add_column` is **not idempotent** — it raises `DuplicateColumn` and halts the whole upgrade
+> mid-chain if a column already exists. Know the real schema before you upgrade; do not guess.
+
+1. **Snapshot first.** Back up the DB (Render: *Backups → Create*; Neon: a branch; Supabase: a
+   snapshot). There is no automatic down-path if an upgrade halts mid-chain.
+2. **Probe the real schema** with psql against the prod DB:
+   ```sql
+   \d users
+   SELECT to_regclass('alembic_version');   -- NULL ⇒ never Alembic-managed
+   ```
+3. **Choose the path:**
+   - **At the 4-column baseline** (`users` has only `id, profession, locale, created_at`, no
+     `alembic_version`) — it matches baseline `f76aec9da324`, so stamp it there and roll forward (every
+     later migration is additive `ADD COLUMN` / `CREATE TABLE`):
+     ```bash
+     alembic stamp f76aec9da324 && alembic upgrade head
+     ```
+   - **Partially drifted** (some, not all, post-baseline columns present) — a baseline stamp + upgrade
+     would hit `DuplicateColumn`. Hand-apply only the missing delta, then mark it at head:
+     ```sql
+     ALTER TABLE users ADD COLUMN IF NOT EXISTS watchlist JSONB;
+     ALTER TABLE users ADD COLUMN IF NOT EXISTS region VARCHAR(64);
+     -- ...remaining missing columns, read off the migration files...
+     ```
+     ```bash
+     alembic stamp head
+     ```
+   - **Already at head** (full schema + an `alembic_version` row) — nothing to do; the automatic
+     upgrade is a no-op.
+4. **Verify.** Restart/redeploy and confirm a previously-failing authed route returns 200 — e.g.
+   `curl https://<app>.onrender.com/feed` or `/clusters/1` (**not** `/auth/me`: with `AUTH_REQUIRED=false`
+   it 500s on drift but never returns a clean 401, so it is a poor probe). Check the next deploy's logs
+   for the Alembic `Running upgrade` lines.
+
+Run these from a shell holding the prod `DATABASE_URL` (a Render service shell, or `docker run` the
+image with `DATABASE_URL` set). Alembic uses the sync (psycopg2) driver, derived automatically from it.
+
 ## Notes
 
 - **Free tier sleep:** Render free tier spins down after 15 min of inactivity. First request takes ~30s to cold-start.
 - **pgvector:** Required for embeddings and clustering. Neon and Supabase both offer free pgvector. Render's built-in Postgres does not.
-- **Migrations:** `alembic upgrade head` creates all tables (incl. the entity-graph + per-user tables) and installs the RLS policies. Run it once against the deployment DB.
+- **Migrations:** run **automatically** on every deploy — the backend Docker start command is `alembic upgrade head && uvicorn …`, so the schema can never drift behind the code (a failed migration blocks startup rather than serving a broken schema). The baseline migration also enables pgvector and builds the entity-graph + per-user tables + RLS policies. A database that predates Alembic must be [reconciled once first](#reconcile-an-existing-pre-alembic-database), or the boot-time upgrade fails.
 - **Multi-user auth (optional):** Set `FIREBASE_CREDENTIALS_JSON` (inline service-account JSON works well for hosted secrets) and `AUTH_REQUIRED=true`. Without it, the app runs single-user (every request is the default user).
 - **Row-level security:** RLS on per-user tables only *enforces* under a non-superuser DB role — create one with `backend/scripts/create_app_role.sql` and point `DATABASE_URL` at it for real multi-tenant isolation. A startup check logs a warning if the connection is a superuser. (The explicit per-user query filter is always on regardless.)
 - **Personalization:** Entity-relevance personalization (G2) is on by default and safe — a brand-new account with no signal sees the neutral ranking. Set `UER_ENABLED=false` to turn it off. Populating the entity graph also needs `GRAPH_EXTRACTION_ENABLED=true` + a platform LLM key.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,9 +22,20 @@
 - Per-user **OpenAI + Anthropic + Gemini** API key + model management with Fernet encryption
 
 **Still stubbed / heuristic:**
-- Cluster `coherence` is still a source-count heuristic (0.95/0.85/0.75/0.65), not a learned score —
-  the UI now labels it honestly ("Source overlap"), and a real consensus/divergence metric is Wave B
+- Cluster `coherence` now prefers the **real source-agreement ratio** (agree/total from a cached
+  consensus pass) and only falls back to the source-overlap heuristic (0.95/0.85/0.75/0.65) when no
+  consensus is cached — the UI labels it honestly ("Source overlap")
 - Tension lines on discover cards still fall back to article titles when no AI line exists
+
+**🔜 Deferred / still open (post-G2 hardening — tracked, not blocking):**
+- ⏸️ **§2b — `_source_hash` widening** — deliberately deferred until a lens becomes entity/user-dependent.
+  No lens reads graph/user data yet, so widening now would only add per-user lens-cache cost. Widen the
+  hash to include entity ids + content version + user scope the moment a personalized/graph-reading lens
+  starts caching. Breadcrumb lives in `backend/app/services/entities.py` + `docs/moat/04,07,09`.
+- 🔜 **Still open:** the deferred **G3 graph work** (embedding-NN entity resolution / reversible
+  auto-merge, multi-hop recursive-CTE lenses — correctly gated behind real-user volume + a co-typed-homonym
+  precision fixture, see `docs/moat/09`), the two unbuilt endpoints (**`GET /events`** SSE §1.3,
+  **`GET /admin/breadth`** §2.2), discover **"tension lines"** §3.1, and **native push** (Wave C2 on-device half).
 
 ---
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# Make the `app` package importable for tools that don't put CWD on sys.path — notably the Alembic
+# console script invoked by the start command (`alembic upgrade head`), whose migrations/env.py does
+# `from app.config import settings`. Belt-and-suspenders with alembic.ini's prepend_sys_path.
+ENV PYTHONPATH=/app
+
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -11,5 +16,10 @@ COPY . .
 
 EXPOSE 8000
 
-# Render sets PORT env var; fallback to 8000 for local/docker-compose
-CMD sh -c "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"
+# Render sets PORT env var; fallback to 8000 for local/docker-compose.
+# Run migrations to head BEFORE serving so the schema can never drift behind the code (a failed
+# migration intentionally blocks startup rather than serving a broken schema). Idempotent: a no-op
+# once the DB is at head. NOTE: an existing DB that predates Alembic must be reconciled ONCE first
+# (see DEPLOY.md → "Reconcile an existing (pre-Alembic) database") or this upgrade will fail on boot.
+# docker-compose overrides this command for local dev (create_all owns the dev schema).
+CMD sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,5 +1,10 @@
 [alembic]
 script_location = migrations
+# Put the project root (CWD = /app in the Docker image, where the `app` package lives) on sys.path so
+# migrations/env.py's `from app.config import settings` resolves when `alembic` runs as the container
+# start command — without it the console script omits CWD and the deploy-time `alembic upgrade head`
+# crashes with ModuleNotFoundError. Replaces the old PYTHONPATH=/app workaround.
+prepend_sys_path = .
 sqlalchemy.url = postgresql://newslens:newslens_dev@localhost:5432/newslens
 
 [loggers]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,7 +32,17 @@ def _fix_db_url(url: str, async_driver: bool = True) -> str:
 class Settings(BaseSettings):
     # Database
     database_url: str = "postgresql+asyncpg://newslens:newslens_dev@localhost:5432/newslens"
-    database_url_sync: str = "postgresql://newslens:newslens_dev@localhost:5432/newslens"
+    # Empty ⇒ DERIVED from database_url (→ psycopg2) in model_post_init. Critical: prod sets only
+    # DATABASE_URL, so a non-empty default here would win the `or` below and silently point the sync
+    # path (Alembic migrations) at localhost. Set DATABASE_URL_SYNC explicitly only to override.
+    database_url_sync: str = ""
+
+    # Schema authority. Local dev / tests bootstrap the schema with Base.metadata.create_all
+    # (init_db). PROD is migration-only: the Docker start command runs `alembic upgrade head`, and
+    # create_all is DANGEROUS there because it CREATEs missing tables but can never ALTER an existing
+    # table to add a new column — which is exactly how the prod schema silently drifted. Set
+    # INIT_DB_CREATE_ALL=false in any environment whose schema is owned by Alembic.
+    init_db_create_all: bool = True
 
     def model_post_init(self, __context):
         # Auto-fix database URLs from cloud providers

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,32 +22,41 @@ async def check_db() -> bool:
 
 
 async def init_db():
-    """Create tables, ensure pgvector extension exists, and seed default user.
+    """Ensure pgvector extension exists, optionally bootstrap tables, and seed default data.
 
-    NOTE: Alembic migrations are the authoritative source of schema for prod
-    (see backend/migrations). Base.metadata.create_all below is a convenience
-    bootstrap for local dev / tests only; the ad-hoc CREATE EXTENSION + ALTER
-    TABLE schema-evolution block was removed now that the Alembic baseline owns
-    the schema.
+    Alembic migrations are the authoritative source of schema for prod (see backend/migrations);
+    the Docker start command runs `alembic upgrade head` before the server boots. `create_all` below
+    is a convenience bootstrap for LOCAL DEV / TESTS ONLY and is gated behind ``init_db_create_all``
+    (env ``INIT_DB_CREATE_ALL``, default true). It is OFF in prod because create_all CREATEs missing
+    tables but can never ALTER an existing table to add a column — that is precisely how the prod
+    schema silently drifted and 500'd every authenticated endpoint. The seeds below stay on in every
+    environment (idempotent; the tables already exist via migrations in prod).
     """
     from app.database import Base
     import app.models  # noqa: F401 — ensure models are registered
 
-    # Create pgvector extension first (create_all needs the vector type for local dev)
+    # Ensure the pgvector extension exists (idempotent; the baseline migration also creates it).
     async with engine.begin() as conn:
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
 
-    # Create all tables (local dev bootstrap; Alembic is authoritative for prod)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    # Bootstrap tables for dev/test only. In prod (INIT_DB_CREATE_ALL=false) Alembic owns the schema.
+    if settings.init_db_create_all:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        logger.info("init_db_create_all_ran")
+    else:
+        logger.info("init_db_create_all_skipped", reason="alembic_authoritative")
 
-    # Seed default user
+    # Seed the default user via the ORM, not raw SQL: several NOT NULL users columns (locale,
+    # depth_pref, persona_version, watchlist) carry only a MODEL-side default — under a create_all
+    # schema they have no server_default, so a raw `INSERT (id)` NotNullViolation-s and aborts init_db
+    # before topics seed. Constructing User() applies every model default uniformly (and is robust to
+    # any future NOT NULL column), while created_at fills from its server_default.
+    from app.models import User
     async with async_session() as session:
-        result = await session.execute(text("SELECT id FROM users LIMIT 1"))
-        if result.scalar_one_or_none() is None:
-            await session.execute(
-                text("INSERT INTO users (id) VALUES (1)")
-            )
+        existing = await session.execute(text("SELECT id FROM users LIMIT 1"))
+        if existing.scalar_one_or_none() is None:
+            session.add(User(id=1))  # the canonical default/single-user id (auth.DEFAULT_USER_ID)
         await session.commit()
 
     # Seed default topics

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -169,6 +169,9 @@ async def backfill_embeddings():
     """Backfill embeddings for articles with pending/failed status. Called by APScheduler."""
     client = await _get_client_async()
     if not client:
+        # No OpenAI key anywhere → articles ingest but never embed → never cluster → feed/briefing
+        # stay empty while /health is green. Log it so this silent dead-stop is observable in prod.
+        logger.warning("embedding_backfill_skipped_no_openai_key")
         return
 
     async with async_session() as session:

--- a/backend/tests/integration/test_default_user_seed.py
+++ b/backend/tests/integration/test_default_user_seed.py
@@ -1,0 +1,24 @@
+"""Bug-3 regression: the default-user seed must populate every NOT NULL `users` column.
+
+`locale`, `depth_pref`, `persona_version`, `watchlist` carry only a MODEL-side default — under a
+create_all schema they have no server_default, so a raw `INSERT INTO users (id) VALUES (1)` raises
+NotNullViolation and aborts init_db before topics are seeded. init_db now seeds via the ORM
+(`User(id=1)`), which applies every model default. This guards that path against regression.
+"""
+from sqlalchemy import select
+
+from app.models import User
+
+
+async def test_orm_seed_populates_not_null_defaults(db_session):
+    """Constructing User() with only the id fills the NOT NULL columns a raw INSERT would omit —
+    exactly what init_db's default-user seed relies on (app/main.py)."""
+    db_session.add(User(id=4242))
+    await db_session.flush()
+
+    u = (await db_session.execute(select(User).where(User.id == 4242))).scalar_one()
+    assert u.locale == "IN"
+    assert u.depth_pref == "standard"
+    assert u.persona_version == 1
+    assert u.watchlist == []
+    assert u.created_at is not None

--- a/backend/tests/unit/test_config_deploy.py
+++ b/backend/tests/unit/test_config_deploy.py
@@ -1,0 +1,41 @@
+"""Deploy-schema config: init_db_create_all gates the dev-only create_all bootstrap.
+
+Prod sets INIT_DB_CREATE_ALL=false so Alembic owns the schema; create_all CREATEs missing tables but
+can never ALTER an existing one to add a column — the drift that 500'd every authed endpoint in prod.
+"""
+from app.config import Settings
+
+
+def test_init_db_create_all_defaults_true(monkeypatch):
+    """Default ON so local dev / tests keep bootstrapping the schema without running migrations."""
+    monkeypatch.delenv("INIT_DB_CREATE_ALL", raising=False)
+    assert Settings().init_db_create_all is True
+
+
+def test_init_db_create_all_env_off(monkeypatch):
+    """Prod (and any Alembic-owned DB) turns it OFF via env so create_all never runs there."""
+    monkeypatch.setenv("INIT_DB_CREATE_ALL", "false")
+    assert Settings().init_db_create_all is False
+
+
+def test_sync_url_derives_from_database_url(monkeypatch):
+    """Regression: prod sets only DATABASE_URL. database_url_sync MUST derive from it (psycopg2 driver,
+    same host) and NEVER fall back to the localhost default — else `alembic upgrade head` at deploy
+    time migrates the wrong database. Guards the empty-string default in Settings.database_url_sync."""
+    monkeypatch.delenv("DATABASE_URL_SYNC", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@db.prod.example.com:5432/newslens")
+    s = Settings()
+    assert "db.prod.example.com" in s.database_url_sync
+    assert "localhost" not in s.database_url_sync
+    assert s.database_url_sync.startswith("postgresql://")  # psycopg2 (sync) driver
+    assert "+asyncpg" not in s.database_url_sync           # not the async driver
+    # And the async URL is the asyncpg form of the same host (no cross-wiring).
+    assert s.database_url == "postgresql+asyncpg://u:p@db.prod.example.com:5432/newslens"
+
+
+def test_explicit_sync_url_overrides_derivation(monkeypatch):
+    """An explicit DATABASE_URL_SYNC still wins (docker-compose sets both)."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@async-host:5432/db")
+    monkeypatch.setenv("DATABASE_URL_SYNC", "postgresql://u:p@sync-host:5432/db")
+    s = Settings()
+    assert "sync-host" in s.database_url_sync

--- a/render.yaml
+++ b/render.yaml
@@ -17,17 +17,26 @@ services:
     dockerfilePath: ./backend/Dockerfile
     dockerContext: ./backend
     healthCheckPath: /health
+    # Schema is migration-owned: the Docker start command runs `alembic upgrade head` before serving
+    # (backend/Dockerfile), and the baseline migration enables pgvector. A pre-Alembic database must be
+    # reconciled once first — see DEPLOY.md → "Reconcile an existing (pre-Alembic) database".
     envVars:
       - key: DATABASE_URL
         fromDatabase:
           name: newslens-db
           property: connectionString
-        # Render provides postgresql:// — we need postgresql+asyncpg://
-        # Override manually after first deploy (see DEPLOY.md)
+        # config.py normalizes postgresql:// → postgresql+asyncpg:// automatically — no manual edit needed.
       - key: OPENAI_API_KEY
-        sync: false  # set manually in dashboard
+        sync: false  # set manually. REQUIRED for the content pipeline (embeddings → clustering → feed/briefing).
       - key: ENCRYPTION_KEY
-        generateValue: true
+        # sync:false (NOT generateValue): regenerating this key orphans every stored encrypted BYOM
+        # key (decrypt hard-fails). Generate ONCE with Fernet.generate_key() and set it in the
+        # dashboard; store it in a password manager. Never rotate without a re-encryption migration.
+        sync: false
+      - key: REQUIRE_ENCRYPTION
+        value: "true"  # refuse to store secrets if ENCRYPTION_KEY is missing (no silent plaintext)
+      - key: INIT_DB_CREATE_ALL
+        value: "false"  # prod schema is Alembic-only; create_all can't ALTER and is how the schema drifted
       - key: RSS_FETCH_INTERVAL_MINUTES
         value: "10"
       - key: GDELT_FETCH_INTERVAL_MINUTES


### PR DESCRIPTION
## The blocker

The live backend 500s on **every** authenticated endpoint (`/feed`, `/briefing`, `/stats`, `/auth/me`, `/discover`, `/search`) while `/health` and `/topics` work. Root cause: the Render deploy **never runs `alembic upgrade head`** — it starts `uvicorn` and relies on `init_db`'s `create_all`, which CREATEs missing tables but can never ALTER an existing one to add a column. The prod `users` table is frozen at the baseline schema, so loading the ORM `User` row references columns that don't exist → unhandled 500.

## The fix

- **Migrations run on deploy** — Dockerfile start command is `alembic upgrade head && uvicorn …`; a failed migration blocks startup rather than serving a broken schema.
- **Prod is Alembic-authoritative** — `INIT_DB_CREATE_ALL=false` gates the dev-only `create_all`.
- **`database_url_sync` derives from `DATABASE_URL`** — prod sets only `DATABASE_URL`; the sync/alembic path now follows it instead of silently defaulting to `localhost`.
- **`alembic` can import `app` at deploy time** — `prepend_sys_path` + `PYTHONPATH=/app`.
- **Default-user seed via the ORM** — applies every NOT NULL model default (a raw `INSERT` `NotNullViolation`-d on `locale` and aborted `init_db` before topics seeded on a fresh deploy).
- **Observability + blueprint hardening** — log when no OpenAI key; `REQUIRE_ENCRYPTION=true`; `ENCRYPTION_KEY` `sync:false` (regen orphans encrypted keys); `DEPLOY.md` reconcile runbook + Fernet-key fix.

## Validation (Docker, Windows-ARM)

- `alembic upgrade head` applies **empty → head** with only `DATABASE_URL` set; idempotent re-run.
- Container boots clean under **both** the migrated and `create_all` paths: `/auth/me` + `/feed` → 200, default user + 14 topics seeded, no `db_init_failed`.
- Full backend suite **252 passed / 1 skipped** (incl. 3 new regression tests); frontend build unchanged.

## ⚠️ Before deploying

The **existing drifted prod DB** must be reconciled **once** before the first migration-running deploy — otherwise `alembic upgrade head` crash-loops trying to `CREATE` tables that already exist. See `DEPLOY.md → Reconcile an existing (pre-Alembic) database` (snapshot → probe `\d users` → stamp/ALTER). After that, every deploy self-migrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)