### PR TITLE
feat(llm): move embeddings + generation to Gemini (text-embedding-004)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,14 +4,16 @@ DB_PORT=5432
 
 # Backend
 BACKEND_PORT=8000
-OPENAI_API_KEY=sk-your-key-here
+# OPTIONAL now — only needed if you select the OpenAI *generation* provider. Embeddings use Gemini.
+OPENAI_API_KEY=
 
 # ── LLM providers (Bring Your Own Model) ──
-# Generation can run on OpenAI, Google Gemini, or Anthropic. Embeddings ALWAYS use OpenAI.
-# These env keys are the PLATFORM fallback (background jobs); each user can also set their own
-# per-provider key + model in Settings, and the per-user active_provider wins over this default.
-GENERATION_PROVIDER=openai            # openai | gemini | anthropic
-GEMINI_API_KEY=
+# Gemini powers BOTH embeddings (text-embedding-004 -> clustering -> feed/briefing/search) AND, by
+# default, generation (summaries + all lenses), so GEMINI_API_KEY is REQUIRED. Generation can also
+# run on OpenAI or Anthropic; env keys are the PLATFORM fallback (background jobs) and each user can
+# set their own per-provider key + model in Settings (per-user active_provider wins over this default).
+GEMINI_API_KEY=                       # REQUIRED (embeddings + default generation)
+GENERATION_PROVIDER=gemini            # gemini | openai | anthropic
 GEMINI_MODEL=gemini-2.0-flash
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-haiku-4-5

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 NewsLens is a two-language AI news intelligence platform: Python backend (data pipeline + ML) and TypeScript frontend (UI), communicating via REST JSON. Mobile builds use Capacitor to wrap the frontend into a native Android WebView.
 
-Beyond the ingest→cluster→summarize core, the platform now layers on: **multi-provider LLM generation** (BYOM — OpenAI/Anthropic/Gemini, per-user key + model; embeddings stay OpenAI), **Firebase auth + Postgres RLS** for multi-user identity (single-user dev fallback), a **knowledge graph** (G1 global entity backbone + G2 per-user entity-relevance overlay), and **on-by-default personalization** that re-ranks the cast strip, feed, briefing, and search from one shared relevance scorer (a zero-signal user is a no-op). See the Decision Log for the rationale behind each.
+Beyond the ingest→cluster→summarize core, the platform now layers on: **multi-provider LLM generation** (BYOM — Gemini/OpenAI/Anthropic, per-user key + model; embeddings on Gemini `text-embedding-004`), **Firebase auth + Postgres RLS** for multi-user identity (single-user dev fallback), a **knowledge graph** (G1 global entity backbone + G2 per-user entity-relevance overlay), and **on-by-default personalization** that re-ranks the cast strip, feed, briefing, and search from one shared relevance scorer (a zero-signal user is a no-op). See the Decision Log for the rationale behind each.
 
 ## System Diagram
 
@@ -26,10 +26,10 @@ graph TB
 
         subgraph "Services"
             DEDUP[Dedup Service<br/>URL + rapidfuzz]
-            EMB[Embedding Service<br/>OpenAI text-embedding-3-small]
+            EMB[Embedding Service<br/>Gemini text-embedding-004]
             CLUST[Clustering Service<br/>pgvector cosine distance]
             ENC[Encryption Service<br/>Fernet]
-            LLM[LLM Generation<br/>OpenAI/Anthropic/Gemini]
+            LLM[LLM Generation<br/>Gemini/OpenAI/Anthropic]
             AUTH[Auth + RLS<br/>Firebase / app.user_id]
             REL[Relevance Scorer<br/>G2 personalization]
         end
@@ -113,7 +113,7 @@ sequenceDiagram
 
     loop Every 5 min
         DB->>Embed: SELECT WHERE embedding_status IN (pending, failed)
-        Embed->>Embed: OpenAI text-embedding-3-small
+        Embed->>Embed: Gemini text-embedding-004
         Embed->>DB: UPDATE embedding + status=complete
     end
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ cd frontend && npm run apk:debug               # Build debug APK via Gradle
 
 NewsLens is an AI-powered news intelligence platform. Two-language stack: Python backend (data pipeline + ML) and TypeScript frontend (UI). They communicate via REST JSON — no shared types needed. Mobile builds use Capacitor to wrap the Next.js static export into a native Android WebView app.
 
-**Stack:** Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Python FastAPI, PostgreSQL + pgvector, multi-provider LLM (OpenAI embeddings + OpenAI/Anthropic/Gemini generation), Firebase Admin SDK (auth), APScheduler, Capacitor (Android) + `@capacitor/splash-screen`
+**Stack:** Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Python FastAPI, PostgreSQL + pgvector, multi-provider LLM (Gemini embeddings + Gemini/OpenAI/Anthropic generation), Firebase Admin SDK (auth), APScheduler, Capacitor (Android) + `@capacitor/splash-screen`
 
 **Key architectural decisions:**
 - pgvector nearest-neighbor SQL for clustering (not Python pairwise — O(n) vs O(n²))
@@ -50,7 +50,7 @@ NewsLens is an AI-powered news intelligence platform. Two-language stack: Python
 - `rapidfuzz` for title dedup (10-100x faster than python-Levenshtein)
 - `asyncpg` (not psycopg2) to preserve FastAPI's async benefits
 - Multi-user via Firebase Auth + Postgres RLS: `get_current_user` verifies the ID token and sets the GUC `app.user_id`; per-user tables (`user_feedback`, `user_preferences`, `user_settings`, `follows`, `user_entity_relevance`) are RLS-scoped. `AUTH_REQUIRED=false` keeps the single-user dev fallback (`user_id` FK still everywhere)
-- Multi-provider LLM generation (BYOM): OpenAI / Anthropic / Gemini, per-user encrypted key + model selection (`active_provider` + `model_prefs` JSONB), env-var platform fallback for background jobs; embeddings always OpenAI
+- Multi-provider LLM generation (BYOM): Gemini / OpenAI / Anthropic, per-user encrypted key + model selection (`active_provider` + `model_prefs` JSONB), env-var platform fallback for background jobs; embeddings on Gemini (`text-embedding-004`, 768-dim)
 - Knowledge graph: a global entity backbone (G1) + a per-user entity-relevance overlay (G2) personalize ranking across the cast strip, feed, briefing, and search (gated by `UER_ENABLED`, on by default; zero-signal users are a no-op)
 - Per-user API keys Fernet-encrypted in `user_settings` (+ env fallback)
 - Capacitor static export with conditional `next.config.ts` (`BUILD_TARGET=capacitor`)
@@ -78,7 +78,7 @@ news-app/
 │   │       ├── fetcher.py            # RSS feed fetcher (feedparser + httpx)
 │   │       ├── gdelt.py              # GDELT API integration (URL discovery + trafilatura)
 │   │       ├── dedup.py              # Deduplication (URL match + rapidfuzz title similarity)
-│   │       ├── embeddings.py         # OpenAI embedding generation + backfill (always OpenAI)
+│   │       ├── embeddings.py         # Gemini embedding generation + backfill (text-embedding-004)
 │   │       ├── clustering.py         # pgvector nearest-neighbor story clustering
 │   │       ├── encryption.py         # Fernet encryption for per-user API keys
 │   │       ├── llm.py                # Multi-provider LLM generation (OpenAI/Anthropic/Gemini)
@@ -183,7 +183,7 @@ news-app/
 
 1. **RSS Fetcher** (every 10 min) → feedparser → dedup → articles table
 2. **GDELT Fetcher** (every 15 min) → GDELT API → trafilatura extraction → dedup → articles table
-3. **Embedding Backfill** (every 5 min) → OpenAI text-embedding-3-small → pgvector
+3. **Embedding Backfill** (every 5 min) → Gemini text-embedding-004 (768-dim) → pgvector
 4. **Clustering** (every 10 min) → pgvector cosine distance (threshold 0.15) → story_clusters table
 5. **Entity Extraction Backfill** (every 15 min, on by default via `GRAPH_EXTRACTION_ENABLED`; needs a platform LLM key, skips gracefully without one) → LLM extraction over settled clusters → entities / entity_aliases / article_entities (G1)
 
@@ -195,7 +195,7 @@ news-app/
 - **Explore/exploit:** Feed is 70% exploit (user's topics) + 30% explore (new topics). Ratio adjusts 10-50% based on feedback.
 - **G1 entity backbone:** LLM extraction (gated by `GRAPH_EXTRACTION_ENABLED`) populates `entities` / `entity_aliases` / `article_entities`. Resolution is exact-then-alias on normalized (`*_norm`) columns with plain b-tree indexes (no functional `lower()` index — avoids autogenerate drift). No embedding NN / auto-merge in G1 (deferred). Cast strip = `GET /clusters/{id}/entities`; reverse "appears in" rail = `GET /entities/{id}/clusters`.
 - **G2 per-user overlay + personalization:** `follows.entity_id` + the RLS-scoped `user_entity_relevance` table capture per-user affinity (follow + positive feedback → `bump_relevance`), decayed at read time (half-life `exp(-ln2·age/half_life)`, age clamped ≥0). One shared scorer `entities.score_clusters_relevance` (= `AVG(decayed)`, no salience term → zero-signal users are a no-op) personalizes the cast strip, feed (recency+relevance blend over a bounded pool), briefing (additive into story_weights), and search (within-tier boost). Gated by `UER_ENABLED` (on by default); each surface is byte-identical when off.
-- **BYOM (multi-provider LLM):** `generate()` resolves the per-user `active_provider` → OpenAI/Anthropic/Gemini, model via `model_prefs` JSONB → config default. Per-provider Fernet-encrypted keys in `user_settings`; env keys are the platform fallback for background jobs. Embeddings stay on OpenAI. Anthropic uses assistant-prefill `"{"` for deterministic JSON.
+- **BYOM (multi-provider LLM):** `generate()` resolves the per-user `active_provider` → Gemini/OpenAI/Anthropic, model via `model_prefs` JSONB → config default (env default `gemini`). Per-provider Fernet-encrypted keys in `user_settings`; env keys are the platform fallback for background jobs. Embeddings run on Gemini (`text-embedding-004`). Anthropic uses assistant-prefill `"{"` for deterministic JSON.
 - **Auth + RLS:** `get_current_user` verifies the Firebase ID token and sets `SET LOCAL app.user_id` per request; RLS policies on per-user tables are enforce-when-set (permissive for background jobs). `AUTH_REQUIRED=false` falls back to the default user (single-user dev). RLS only bites under a non-superuser DB role (`backend/scripts/create_app_role.sql`); the explicit `current_user_id()` filter is the primary control. A startup `check_rls_posture` logs a warning when the connection is a superuser.
 - **Graceful degradation:** LLM generation degrades by provider — a user with any one valid provider key keeps working if another is down. Summaries fail soft: `get_cluster` / `get_briefing` call `summarize_cluster` on demand when a cluster lacks a cached summary (logged, no user-facing error). If embeddings lag, articles ingest without them and fall back to snippet discovery.
 - **Per-user API key:** Fernet-encrypted in `user_settings` (OpenAI/Gemini/Anthropic). Falls back to the matching `*_API_KEY` env var if no per-user key.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -31,7 +31,9 @@ Render's free Postgres does **not** include pgvector. Two options:
    - **Plan:** Free
 4. Environment variables:
    - `DATABASE_URL` — paste the Neon/Supabase connection string (the app auto-converts `postgresql://` to `postgresql+asyncpg://`)
-   - `OPENAI_API_KEY` — your OpenAI API key (**required**: with no key, embeddings never run → nothing clusters → the feed/briefing stay empty while `/health` is green)
+   - `GEMINI_API_KEY` — your Google Gemini key (**required**: powers embeddings *and* generation — with no key, embeddings never run → nothing clusters → the feed/briefing stay empty while `/health` is green)
+   - `GENERATION_PROVIDER=gemini` — run summaries + lenses on Gemini (default; per-user `active_provider` still wins)
+   - `OPENAI_API_KEY` — *optional*, only if you select the OpenAI generation provider (not used for embeddings)
    - `ENCRYPTION_KEY` — a **Fernet** key: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"` (a plain "random string" is rejected by Fernet). Set it **once** and store it — rotating it orphans every stored encrypted key.
    - `INIT_DB_CREATE_ALL=false` — prod schema is Alembic-only (see **Migrations** below)
 5. Click **Deploy**. The container runs `alembic upgrade head` on start, then serves. **If the database already exists from a pre-Alembic deploy, do the one-time [reconcile](#reconcile-an-existing-pre-alembic-database) first** or the boot-time upgrade fails.
@@ -104,12 +106,13 @@ fly open /health
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DATABASE_URL` | Yes | PostgreSQL connection string (auto-converts to asyncpg) |
-| `OPENAI_API_KEY` | No* | OpenAI key — *required for embeddings/clustering* and the platform generation fallback |
+| `GEMINI_API_KEY` | **Yes** | Google Gemini key — powers **embeddings** (`text-embedding-004`, 768-dim → clustering) *and* the default generation provider |
+| `GEMINI_MODEL` | No | Gemini generation model (default `gemini-2.0-flash`; embedding model is fixed at `text-embedding-004`) |
+| `GENERATION_PROVIDER` | No | Default generation provider: `gemini` \| `openai` \| `anthropic` (per-user `active_provider` wins) |
+| `OPENAI_API_KEY` | No | *Optional* — only for the OpenAI generation provider. **Not used for embeddings.** |
+| `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` | No | Anthropic platform fallback + model (default `claude-haiku-4-5`) |
 | `ENCRYPTION_KEY` | Yes | Fernet key (`Fernet.generate_key()` — 32-byte url-safe base64) for per-user API key storage. Set once; rotating it orphans stored keys |
 | `INIT_DB_CREATE_ALL` | No | `false` in prod (schema is Alembic-only). Default `true` bootstraps dev/test via `create_all` |
-| `GENERATION_PROVIDER` | No | Default generation provider: `openai` \| `anthropic` \| `gemini` (per-user `active_provider` wins) |
-| `GEMINI_API_KEY` / `GEMINI_MODEL` | No | Google Gemini platform fallback + model |
-| `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` | No | Anthropic platform fallback + model (default `claude-haiku-4-5`) |
 | `FIREBASE_CREDENTIALS_JSON` *or* `GOOGLE_APPLICATION_CREDENTIALS` | No | Service account to verify Firebase ID tokens. Omit both → auth disabled (default user) |
 | `AUTH_REQUIRED` | No | `true` rejects unauthenticated requests (multi-user prod). Default `false` |
 | `GRAPH_EXTRACTION_ENABLED` | No | Entity-extraction backfill job (G1). **On by default**; needs a platform LLM key, skips without one. Set `false` to avoid the extraction LLM cost |
@@ -175,4 +178,4 @@ image with `DATABASE_URL` set). Alembic uses the sync (psycopg2) driver, derived
 - **Multi-user auth (optional):** Set `FIREBASE_CREDENTIALS_JSON` (inline service-account JSON works well for hosted secrets) and `AUTH_REQUIRED=true`. Without it, the app runs single-user (every request is the default user).
 - **Row-level security:** RLS on per-user tables only *enforces* under a non-superuser DB role — create one with `backend/scripts/create_app_role.sql` and point `DATABASE_URL` at it for real multi-tenant isolation. A startup check logs a warning if the connection is a superuser. (The explicit per-user query filter is always on regardless.)
 - **Personalization:** Entity-relevance personalization (G2) is on by default and safe — a brand-new account with no signal sees the neutral ranking. Set `UER_ENABLED=false` to turn it off. Populating the entity graph also needs `GRAPH_EXTRACTION_ENABLED=true` + a platform LLM key.
-- **Graceful degradation:** Generation works with any one provider key (OpenAI/Anthropic/Gemini); summaries generate on demand if a batch missed them; without embeddings, discovery falls back to snippets and keyword matching. **Embeddings always require OpenAI.**
+- **Graceful degradation:** Generation works with any one provider key (Gemini/OpenAI/Anthropic); summaries generate on demand if a batch missed them; without embeddings, discovery falls back to snippets and keyword matching. **Embeddings require the Gemini key** (`text-embedding-004`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NewsLens
 
-An AI-powered news intelligence platform. NewsLens ingests articles from RSS feeds and the GDELT API, deduplicates them, embeds them with OpenAI, and clusters related coverage into single **stories** — so you read one multi-source briefing instead of ten near-identical headlines.
+An AI-powered news intelligence platform. NewsLens ingests articles from RSS feeds and the GDELT API, deduplicates them, embeds them with Gemini, and clusters related coverage into single **stories** — so you read one multi-source briefing instead of ten near-identical headlines.
 
 > Two-language stack: a Python **FastAPI** backend (data pipeline + ML) and a TypeScript **Next.js** frontend (UI), talking over REST JSON. Mobile ships as a native Android app via **Capacitor** wrapping the Next.js static export.
 
@@ -13,7 +13,7 @@ An AI-powered news intelligence platform. NewsLens ingests articles from RSS fee
 - **Who's in the story** — a cast strip of the people/orgs/places in each cluster, with an "appears in" rail to other stories about the same entity.
 - **Personalized ranking** — follow entities and read stories, and the entities you care about rise across the cast strip, feed, briefing, and search. On by default; a brand-new account just sees the neutral ranking.
 - **Follows + digest** — follow topics, entities, or saved searches and get a personalized digest.
-- **Bring your own model** — per-user, Fernet-encrypted keys for **OpenAI, Anthropic, or Gemini**, with model selection and an env-var platform fallback. (Embeddings always use OpenAI.)
+- **Bring your own model** — per-user, Fernet-encrypted keys for **Gemini, OpenAI, or Anthropic**, with model selection and an env-var platform fallback. (Embeddings use Gemini `text-embedding-004`.)
 - **Accounts** — Firebase auth (Google + Email/Password); single-user dev mode when auth isn't configured.
 - **Graceful degradation** — generation degrades by provider (any one valid key keeps you working); summaries generate on demand if a batch missed them; if embeddings lag, the UI falls back to snippets.
 
@@ -24,7 +24,7 @@ An AI-powered news intelligence platform. NewsLens ingests articles from RSS fee
 | Frontend | Next.js 16 (App Router), React 19, Tailwind CSS 4, Framer Motion |
 | Backend | Python, FastAPI, APScheduler, Firebase Admin SDK (auth) |
 | Database | PostgreSQL + pgvector (+ row-level security on per-user tables) |
-| ML | OpenAI `text-embedding-3-small` (embeddings) + multi-provider generation (OpenAI / Anthropic / Gemini); pgvector cosine clustering |
+| ML | Gemini `text-embedding-004` (embeddings, 768-dim) + multi-provider generation (Gemini / OpenAI / Anthropic); pgvector cosine clustering |
 | Mobile | Capacitor (Android) + `@capacitor/splash-screen` |
 
 ## Quick start
@@ -33,8 +33,8 @@ Requires Docker (recommended for the DB + backend) and Node.js for the frontend.
 
 ```bash
 # 1. Configure environment
-cp .env.example .env        # fill in OPENAI_API_KEY (+ ENCRYPTION_KEY for production).
-                            # Optional: GEMINI_API_KEY / ANTHROPIC_API_KEY (other providers),
+cp .env.example .env        # fill in GEMINI_API_KEY (embeddings + generation) (+ ENCRYPTION_KEY for production).
+                            # Optional: OPENAI_API_KEY / ANTHROPIC_API_KEY (other generation providers),
                             # FIREBASE_CREDENTIALS_JSON + AUTH_REQUIRED (multi-user auth),
                             # GRAPH_EXTRACTION_ENABLED / UER_ENABLED (entity graph + personalization)
 
@@ -58,7 +58,7 @@ APScheduler jobs run inside the FastAPI process:
 
 1. **RSS fetcher** (every 10 min) → feedparser → dedup → `articles`
 2. **GDELT fetcher** (every 15 min) → trafilatura extraction → dedup → `articles`
-3. **Embedding backfill** (every 5 min) → OpenAI embeddings → pgvector
+3. **Embedding backfill** (every 5 min) → Gemini embeddings (`text-embedding-004`) → pgvector
 4. **Clustering** (every 10 min) → pgvector cosine distance (threshold 0.15) → `story_clusters`
 5. **Entity extraction** (every 15 min, off by default behind `GRAPH_EXTRACTION_ENABLED`) → LLM extraction over settled clusters → `entities` / `article_entities`
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -54,8 +54,8 @@ class Settings(BaseSettings):
     # OpenAI
     openai_api_key: str = ""
 
-    # LLM generation provider (embeddings stay on OpenAI — see embeddings.py)
-    generation_provider: str = "openai"  # "openai" | "gemini" | "anthropic" (env default; per-user active_provider wins)
+    # LLM generation provider. Default gemini (BYOM; env default, per-user active_provider wins).
+    generation_provider: str = "gemini"  # "openai" | "gemini" | "anthropic"
     gemini_api_key: str = ""
     gemini_model: str = "gemini-2.0-flash"
     # Wave E (BYOM): Anthropic provider. Env key = platform fallback for background jobs.
@@ -119,9 +119,14 @@ class Settings(BaseSettings):
     # GDELT query (parametrized for region/language; default India + English)
     gdelt_query: str = "sourcecountry:IN"
 
-    # Embedding config
-    embedding_model: str = "text-embedding-3-small"
-    embedding_dimensions: int = 1536
+    # Embedding config — Gemini text-embedding-004 (native 768-dim, task-typed asymmetric retrieval).
+    # Changing the model/dim requires a migration on the pgvector column + a full re-embed (old vectors
+    # live in a different space); see migration a2b3c4d5e6f7. Kept config-driven so models.py's
+    # Vector(embedding_dimensions) and the tests follow automatically.
+    embedding_model: str = "models/text-embedding-004"
+    embedding_dimensions: int = 768
+    embedding_task_document: str = "retrieval_document"  # stored article/topic vectors
+    embedding_task_query: str = "retrieval_query"        # search-query vectors (asymmetric retrieval)
 
     # Summary config
     summary_model: str = "gpt-4o-mini"

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -1,8 +1,11 @@
-"""Embedding generation service using OpenAI text-embedding-3-small.
+"""Embedding generation service — Gemini text-embedding-004 (768-dim, task-typed).
 
-Generates embeddings for article title + snippet.
-Includes backfill job for articles that failed or were ingested when OpenAI was down.
+Generates embeddings for article title + snippet and for search queries; backfill re-embeds
+pending/failed articles. The OpenAI client helpers below are retained ONLY for the OpenAI
+*generation* provider (llm._generate_openai / summarizer) — the embeddings themselves are Gemini.
 """
+
+import asyncio
 
 import structlog
 from openai import AsyncOpenAI
@@ -83,19 +86,41 @@ async def _get_client_async() -> AsyncOpenAI | None:
     return None
 
 
-async def generate_embedding(text: str) -> list[float] | None:
-    """Generate embedding for a text string. Returns None on failure."""
-    client = await _get_client_async()
-    if not client:
-        logger.warning("openai_no_api_key")
+async def _resolve_embedding_key() -> str | None:
+    """Gemini key for embeddings: the owner's verified per-user key, else the platform env key.
+    Reuses the generation-side resolver (lazy import avoids a circular import with llm)."""
+    from app.services.llm import _resolve_gemini_key
+
+    return await _resolve_gemini_key()
+
+
+def _embed_sync(key: str, model: str, content: str, task_type: str) -> list[float]:
+    import google.generativeai as genai  # lazy — only on the embedding path
+
+    genai.configure(api_key=key)
+    result = genai.embed_content(model=model, content=content, task_type=task_type)
+    return result["embedding"]
+
+
+async def generate_embedding(text: str, *, task_type: str | None = None) -> list[float] | None:
+    """Generate a Gemini embedding for a text string. Returns None on failure (never raises).
+
+    task_type defaults to the stored-document type; search passes the query type for asymmetric
+    retrieval. Runs the synchronous SDK call in a thread so it never blocks the event loop.
+    """
+    key = await _resolve_embedding_key()
+    if not key:
+        logger.warning("embedding_no_gemini_key")
         return None
 
     try:
-        response = await client.embeddings.create(
-            model=settings.embedding_model,
-            input=text,
+        return await asyncio.to_thread(
+            _embed_sync,
+            key,
+            settings.embedding_model,
+            text,
+            task_type or settings.embedding_task_document,
         )
-        return response.data[0].embedding
     except Exception as e:
         logger.error("embedding_generation_failed", error=str(e))
         return None
@@ -121,7 +146,7 @@ async def embed_query_cached(text: str) -> list[float] | None:
     if cached is not None:
         return cached
 
-    embedding = await generate_embedding(key)
+    embedding = await generate_embedding(key, task_type=settings.embedding_task_query)
     if embedding is not None:
         if len(_query_embedding_cache) >= _QUERY_CACHE_MAX:
             # Simple bound: drop the oldest inserted entry.
@@ -167,11 +192,10 @@ async def embed_article(article_id: int):
 
 async def backfill_embeddings():
     """Backfill embeddings for articles with pending/failed status. Called by APScheduler."""
-    client = await _get_client_async()
-    if not client:
-        # No OpenAI key anywhere → articles ingest but never embed → never cluster → feed/briefing
+    if not await _resolve_embedding_key():
+        # No Gemini key anywhere → articles ingest but never embed → never cluster → feed/briefing
         # stay empty while /health is green. Log it so this silent dead-stop is observable in prod.
-        logger.warning("embedding_backfill_skipped_no_openai_key")
+        logger.warning("embedding_backfill_skipped_no_gemini_key")
         return
 
     async with async_session() as session:

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -1,6 +1,7 @@
-"""AI summary generation service using GPT-4o-mini.
+"""AI summary generation service via the active LLM provider (llm.generate).
 
-Generates cluster summaries from article titles and snippets.
+Generates cluster summaries from article titles and snippets through the provider abstraction
+(OpenAI / Gemini / Anthropic), so summaries follow the configured provider like every other lens.
 Hybrid strategy: batch job pre-generates + on-demand fallback.
 """
 
@@ -25,78 +26,56 @@ def _staleness_cutoff(now: datetime | None = None) -> datetime:
     return now - timedelta(hours=4)
 
 
-async def _get_client():
-    """Get OpenAI client — reuses embeddings.py pattern."""
-    from app.services.embeddings import _get_client_async
-    return await _get_client_async()
-
-
 async def generate_cluster_summary(
     titles: list[str],
     snippets: list[str],
 ) -> tuple[str, float]:
-    """Generate a summary for a story cluster using GPT-4o-mini.
+    """Generate a summary for a story cluster via the active LLM provider (llm.generate).
 
-    Returns (summary_text, coherence_score).
-    Coherence is estimated from the number of corroborating sources.
-    Falls back to first snippet if OpenAI is unavailable.
+    Returns (summary_text, coherence_score). Coherence is estimated from the number of
+    corroborating sources. Falls back to the first snippet if generation is unavailable.
     """
-    client = await _get_client()
-
-    # Fallback: return first available snippet
+    # Fallback: first available snippet, trimmed to ~2 sentences.
     fallback_text = next((s for s in snippets if s), "No summary available.")
     sentences = fallback_text.split(". ")
     fallback_summary = ". ".join(sentences[:2]) + "." if len(sentences) > 1 else fallback_text
 
-    if not client:
-        return fallback_summary, 0.70
+    # Coherence heuristic (source-count fallback; the real ratio is computed in lenses.cluster_coherence).
+    source_count = len(titles)
+    if source_count >= 5:
+        coherence = 0.95
+    elif source_count >= 3:
+        coherence = 0.85
+    elif source_count >= 2:
+        coherence = 0.75
+    else:
+        coherence = 0.65
 
-    # Build prompt from article data
     articles_text = ""
     for i, (title, snippet) in enumerate(zip(titles, snippets), 1):
         articles_text += f"\n{i}. {title}"
         if snippet:
             articles_text += f"\n   {snippet[:300]}"
 
+    from app.services import llm
     try:
-        response = await client.chat.completions.create(
-            model=settings.summary_model,
-            messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "You are a news analyst. Summarize the following related news articles "
-                        "in 2-3 concise sentences. Focus on key facts, implications, and what "
-                        "makes this story significant. Be neutral and factual."
-                    ),
-                },
-                {
-                    "role": "user",
-                    "content": f"Summarize these {len(titles)} related articles:\n{articles_text}",
-                },
-            ],
+        summary = await llm.generate(
+            f"Summarize these {len(titles)} related articles:\n{articles_text}",
+            system=(
+                "You are a news analyst. Summarize the following related news articles in 2-3 "
+                "concise sentences. Focus on key facts, implications, and what makes this story "
+                "significant. Be neutral and factual."
+            ),
             max_tokens=200,
-            temperature=0.3,
         )
-
-        summary = response.choices[0].message.content.strip()
-
-        # Estimate coherence from source count (more sources = higher confidence)
-        source_count = len(titles)
-        if source_count >= 5:
-            coherence = 0.95
-        elif source_count >= 3:
-            coherence = 0.85
-        elif source_count >= 2:
-            coherence = 0.75
-        else:
-            coherence = 0.65
-
-        return summary, coherence
-
-    except Exception as e:
+    except llm.LLMUnavailable:
+        return fallback_summary, 0.70
+    except Exception as e:  # noqa: BLE001 — never let a summary failure crash the caller
         logger.error("summary_generation_failed", error=str(e))
         return fallback_summary, 0.70
+
+    summary = (summary or "").strip()
+    return (summary, coherence) if summary else (fallback_summary, 0.70)
 
 
 async def summarize_cluster(cluster_id: int) -> tuple[str, float] | None:

--- a/backend/migrations/versions/a2b3c4d5e6f7_gemini_embeddings_768.py
+++ b/backend/migrations/versions/a2b3c4d5e6f7_gemini_embeddings_768.py
@@ -1,0 +1,47 @@
+"""Move embeddings to Gemini text-embedding-004: pgvector column 1536 -> 768 + re-embed.
+
+Old OpenAI 1536-dim vectors live in a different embedding space and cannot be reused, so this clears
+all stored embeddings (articles reset to 'pending' so the backfill re-embeds them with Gemini; topic
+embeddings re-seed on next startup) and resizes the pgvector columns. The HNSW index is dropped and
+recreated because it is bound to the column dimension.
+
+Revision ID: a2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-06-27 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a2b3c4d5e6f7"
+down_revision: Union[str, None] = "f1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_HNSW = "ix_articles_embedding_hnsw"
+
+
+def _resize(dim: int) -> None:
+    # 1) Drop the dimension-bound HNSW index before altering the column type.
+    op.execute(f"DROP INDEX IF EXISTS {_HNSW}")
+    # 2) Clear vectors from the old space (only possible to resize once every value is NULL).
+    #    Articles go back to 'pending' so the embedding backfill re-embeds; topics re-seed on startup.
+    op.execute(
+        "UPDATE articles SET embedding = NULL, embedding_status = 'pending' "
+        "WHERE embedding IS NOT NULL"
+    )
+    op.execute("UPDATE topics SET embedding = NULL WHERE embedding IS NOT NULL")
+    # 3) Resize the pgvector columns.
+    op.execute(f"ALTER TABLE articles ALTER COLUMN embedding TYPE vector({dim})")
+    op.execute(f"ALTER TABLE topics   ALTER COLUMN embedding TYPE vector({dim})")
+    # 4) Recreate the cosine HNSW index at the new dimension.
+    op.execute(f"CREATE INDEX {_HNSW} ON articles USING hnsw (embedding vector_cosine_ops)")
+
+
+def upgrade() -> None:
+    _resize(768)   # Gemini text-embedding-004
+
+
+def downgrade() -> None:
+    _resize(1536)  # OpenAI text-embedding-3-small (vectors are cleared, not restored)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -208,7 +208,7 @@ def fake_llm(monkeypatch):
             return "STUB SUMMARY"
         return _schema_shape(prompt)
 
-    async def _embed(_text):
+    async def _embed(_text, *, task_type=None):
         calls["embed"] += 1
         from app.config import settings as _s
         v = [0.0] * _s.embedding_dimensions

--- a/backend/tests/integration/test_search.py
+++ b/backend/tests/integration/test_search.py
@@ -112,7 +112,7 @@ async def test_query_embedding_cached(aclient, db_session, monkeypatch):
 
     calls = {"n": 0}
 
-    async def _spy_embed(_text):
+    async def _spy_embed(_text, *, task_type=None):
         calls["n"] += 1
         v = [0.0] * settings.embedding_dimensions
         v[0] = 1.0

--- a/backend/tests/unit/test_embeddings_gemini.py
+++ b/backend/tests/unit/test_embeddings_gemini.py
@@ -1,0 +1,62 @@
+"""Embeddings run on Gemini (text-embedding-004, 768-dim, task-typed) — not OpenAI."""
+from app.config import settings
+from app.services import embeddings
+
+
+def test_embedding_config_is_gemini():
+    assert settings.embedding_model == "models/text-embedding-004"
+    assert settings.embedding_dimensions == 768
+    assert settings.embedding_task_document == "retrieval_document"
+    assert settings.embedding_task_query == "retrieval_query"
+
+
+def _patch_gemini(monkeypatch, captured):
+    import google.generativeai as genai
+
+    def _configure(api_key=None):
+        captured["key"] = api_key
+
+    def _embed(model=None, content=None, task_type=None):
+        captured.update(model=model, content=content, task_type=task_type)
+        return {"embedding": [0.1, 0.2, 0.3]}
+
+    monkeypatch.setattr(genai, "configure", _configure)
+    monkeypatch.setattr(genai, "embed_content", _embed)
+
+
+async def _fake_key():
+    return "test-gemini-key"
+
+
+async def test_generate_embedding_calls_gemini_document(monkeypatch):
+    cap = {}
+    _patch_gemini(monkeypatch, cap)
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _fake_key)
+
+    out = await embeddings.generate_embedding("hello world")
+
+    assert out == [0.1, 0.2, 0.3]
+    assert cap["key"] == "test-gemini-key"
+    assert cap["model"] == "models/text-embedding-004"
+    assert cap["content"] == "hello world"
+    assert cap["task_type"] == "retrieval_document"  # stored-document default
+
+
+async def test_query_embedding_uses_query_task_type(monkeypatch):
+    cap = {}
+    _patch_gemini(monkeypatch, cap)
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _fake_key)
+    embeddings._query_embedding_cache.clear()
+
+    out = await embeddings.embed_query_cached("budget news")
+
+    assert out == [0.1, 0.2, 0.3]
+    assert cap["task_type"] == "retrieval_query"  # asymmetric retrieval for search queries
+
+
+async def test_generate_embedding_no_key_returns_none(monkeypatch):
+    async def _no_key():
+        return None
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _no_key)
+    assert await embeddings.generate_embedding("x") is None

--- a/render.yaml
+++ b/render.yaml
@@ -26,8 +26,13 @@ services:
           name: newslens-db
           property: connectionString
         # config.py normalizes postgresql:// → postgresql+asyncpg:// automatically — no manual edit needed.
+      - key: GEMINI_API_KEY
+        sync: false  # set manually. REQUIRED — powers BOTH embeddings (text-embedding-004 → clustering →
+                     # feed/briefing/search) and generation (summaries + all lenses).
+      - key: GENERATION_PROVIDER
+        value: gemini  # summaries + lenses run on Gemini (per-user active_provider still wins)
       - key: OPENAI_API_KEY
-        sync: false  # set manually. REQUIRED for the content pipeline (embeddings → clustering → feed/briefing).
+        sync: false  # OPTIONAL now — only used if a user/env selects the OpenAI generation provider.
       - key: ENCRYPTION_KEY
         # sync:false (NOT generateValue): regenerating this key orphans every stored encrypted BYOM
         # key (decrypt hard-fails). Generate ONCE with Fernet.generate_key() and set it in the


### PR DESCRIPTION
Fully migrate off OpenAI. **Embeddings** now run on **Gemini `text-embedding-004`** (768-dim, task-typed asymmetric retrieval) and **generation** (summaries + all lenses) defaults to Gemini. OpenAI remains an *optional* generation provider only.

## Changes
- **embeddings.py** — `generate_embedding` → Gemini `embed_content` (thread-wrapped so it never blocks the loop), `retrieval_document`/`retrieval_query` task types, per-user-then-env Gemini key. OpenAI client helpers kept for the OpenAI *generation* provider.
- **summarizer.py** — was a **direct OpenAI chat call**; routed through `llm.generate()` so summaries follow the active provider like every other lens.
- **config.py** — `embedding_model=models/text-embedding-004`, `embedding_dimensions=768`, task-type knobs, `generation_provider` default → `gemini`.
- **migration `a2b3c4d5e6f7`** — resize the pgvector column `1536 → 768` on `articles` + `topics`, clear the incompatible OpenAI vectors (articles reset to `pending` for re-embed; topics re-seed), rebuild the cosine HNSW index.
- **render.yaml / .env.example** — `GEMINI_API_KEY` now **required** (embeddings + default generation); `OPENAI_API_KEY` optional.
- **docs** (CLAUDE / DEPLOY / README / ARCHITECTURE) — drop the "embeddings always OpenAI" invariant.
- **tests** — Gemini embedding unit tests (mocked SDK) + fixture signature updates.

## Validation (Docker)
- Migration applies **empty → head**; `articles`/`topics.embedding` = `vector(768)`, HNSW index rebuilt.
- Full suite **256 passed / 1 skipped** on the fresh 768-dim schema; `py_compile` clean.
- ⚠️ The live Gemini `embed_content` call is **mocked** in tests (no key in CI) — confirm on the first backfill once `GEMINI_API_KEY` is set (watch for `embedding_backfill_complete`).

## Operational notes
1. **Requires `GEMINI_API_KEY`** — with no key nothing embeds → empty feed (logged `embedding_backfill_skipped_no_gemini_key`).
2. **Re-embeds the whole corpus** — the migration clears all embeddings and resets articles to `pending`; the backfill re-embeds with Gemini over the following cycles. Expect a re-embed window after deploy where clustering is thin until it catches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)