### PR TITLE
fix(embeddings): use gemini-embedding-001 (text-embedding-004 retired)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ BACKEND_PORT=8000
 OPENAI_API_KEY=
 
 # ── LLM providers (Bring Your Own Model) ──
-# Gemini powers BOTH embeddings (text-embedding-004 -> clustering -> feed/briefing/search) AND, by
+# Gemini powers BOTH embeddings (gemini-embedding-001 -> clustering -> feed/briefing/search) AND, by
 # default, generation (summaries + all lenses), so GEMINI_API_KEY is REQUIRED. Generation can also
 # run on OpenAI or Anthropic; env keys are the PLATFORM fallback (background jobs) and each user can
 # set their own per-provider key + model in Settings (per-user active_provider wins over this default).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 NewsLens is a two-language AI news intelligence platform: Python backend (data pipeline + ML) and TypeScript frontend (UI), communicating via REST JSON. Mobile builds use Capacitor to wrap the frontend into a native Android WebView.
 
-Beyond the ingest→cluster→summarize core, the platform now layers on: **multi-provider LLM generation** (BYOM — Gemini/OpenAI/Anthropic, per-user key + model; embeddings on Gemini `text-embedding-004`), **Firebase auth + Postgres RLS** for multi-user identity (single-user dev fallback), a **knowledge graph** (G1 global entity backbone + G2 per-user entity-relevance overlay), and **on-by-default personalization** that re-ranks the cast strip, feed, briefing, and search from one shared relevance scorer (a zero-signal user is a no-op). See the Decision Log for the rationale behind each.
+Beyond the ingest→cluster→summarize core, the platform now layers on: **multi-provider LLM generation** (BYOM — Gemini/OpenAI/Anthropic, per-user key + model; embeddings on Gemini `gemini-embedding-001`), **Firebase auth + Postgres RLS** for multi-user identity (single-user dev fallback), a **knowledge graph** (G1 global entity backbone + G2 per-user entity-relevance overlay), and **on-by-default personalization** that re-ranks the cast strip, feed, briefing, and search from one shared relevance scorer (a zero-signal user is a no-op). See the Decision Log for the rationale behind each.
 
 ## System Diagram
 
@@ -26,7 +26,7 @@ graph TB
 
         subgraph "Services"
             DEDUP[Dedup Service<br/>URL + rapidfuzz]
-            EMB[Embedding Service<br/>Gemini text-embedding-004]
+            EMB[Embedding Service<br/>Gemini gemini-embedding-001]
             CLUST[Clustering Service<br/>pgvector cosine distance]
             ENC[Encryption Service<br/>Fernet]
             LLM[LLM Generation<br/>Gemini/OpenAI/Anthropic]
@@ -113,7 +113,7 @@ sequenceDiagram
 
     loop Every 5 min
         DB->>Embed: SELECT WHERE embedding_status IN (pending, failed)
-        Embed->>Embed: Gemini text-embedding-004
+        Embed->>Embed: Gemini gemini-embedding-001
         Embed->>DB: UPDATE embedding + status=complete
     end
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ NewsLens is an AI-powered news intelligence platform. Two-language stack: Python
 - `rapidfuzz` for title dedup (10-100x faster than python-Levenshtein)
 - `asyncpg` (not psycopg2) to preserve FastAPI's async benefits
 - Multi-user via Firebase Auth + Postgres RLS: `get_current_user` verifies the ID token and sets the GUC `app.user_id`; per-user tables (`user_feedback`, `user_preferences`, `user_settings`, `follows`, `user_entity_relevance`) are RLS-scoped. `AUTH_REQUIRED=false` keeps the single-user dev fallback (`user_id` FK still everywhere)
-- Multi-provider LLM generation (BYOM): Gemini / OpenAI / Anthropic, per-user encrypted key + model selection (`active_provider` + `model_prefs` JSONB), env-var platform fallback for background jobs; embeddings on Gemini (`text-embedding-004`, 768-dim)
+- Multi-provider LLM generation (BYOM): Gemini / OpenAI / Anthropic, per-user encrypted key + model selection (`active_provider` + `model_prefs` JSONB), env-var platform fallback for background jobs; embeddings on Gemini (`gemini-embedding-001`, 768-dim)
 - Knowledge graph: a global entity backbone (G1) + a per-user entity-relevance overlay (G2) personalize ranking across the cast strip, feed, briefing, and search (gated by `UER_ENABLED`, on by default; zero-signal users are a no-op)
 - Per-user API keys Fernet-encrypted in `user_settings` (+ env fallback)
 - Capacitor static export with conditional `next.config.ts` (`BUILD_TARGET=capacitor`)
@@ -78,7 +78,7 @@ news-app/
 │   │       ├── fetcher.py            # RSS feed fetcher (feedparser + httpx)
 │   │       ├── gdelt.py              # GDELT API integration (URL discovery + trafilatura)
 │   │       ├── dedup.py              # Deduplication (URL match + rapidfuzz title similarity)
-│   │       ├── embeddings.py         # Gemini embedding generation + backfill (text-embedding-004)
+│   │       ├── embeddings.py         # Gemini embedding generation + backfill (gemini-embedding-001)
 │   │       ├── clustering.py         # pgvector nearest-neighbor story clustering
 │   │       ├── encryption.py         # Fernet encryption for per-user API keys
 │   │       ├── llm.py                # Multi-provider LLM generation (OpenAI/Anthropic/Gemini)
@@ -183,7 +183,7 @@ news-app/
 
 1. **RSS Fetcher** (every 10 min) → feedparser → dedup → articles table
 2. **GDELT Fetcher** (every 15 min) → GDELT API → trafilatura extraction → dedup → articles table
-3. **Embedding Backfill** (every 5 min) → Gemini text-embedding-004 (768-dim) → pgvector
+3. **Embedding Backfill** (every 5 min) → Gemini gemini-embedding-001 (768-dim) → pgvector
 4. **Clustering** (every 10 min) → pgvector cosine distance (threshold 0.15) → story_clusters table
 5. **Entity Extraction Backfill** (every 15 min, on by default via `GRAPH_EXTRACTION_ENABLED`; needs a platform LLM key, skips gracefully without one) → LLM extraction over settled clusters → entities / entity_aliases / article_entities (G1)
 
@@ -195,7 +195,7 @@ news-app/
 - **Explore/exploit:** Feed is 70% exploit (user's topics) + 30% explore (new topics). Ratio adjusts 10-50% based on feedback.
 - **G1 entity backbone:** LLM extraction (gated by `GRAPH_EXTRACTION_ENABLED`) populates `entities` / `entity_aliases` / `article_entities`. Resolution is exact-then-alias on normalized (`*_norm`) columns with plain b-tree indexes (no functional `lower()` index — avoids autogenerate drift). No embedding NN / auto-merge in G1 (deferred). Cast strip = `GET /clusters/{id}/entities`; reverse "appears in" rail = `GET /entities/{id}/clusters`.
 - **G2 per-user overlay + personalization:** `follows.entity_id` + the RLS-scoped `user_entity_relevance` table capture per-user affinity (follow + positive feedback → `bump_relevance`), decayed at read time (half-life `exp(-ln2·age/half_life)`, age clamped ≥0). One shared scorer `entities.score_clusters_relevance` (= `AVG(decayed)`, no salience term → zero-signal users are a no-op) personalizes the cast strip, feed (recency+relevance blend over a bounded pool), briefing (additive into story_weights), and search (within-tier boost). Gated by `UER_ENABLED` (on by default); each surface is byte-identical when off.
-- **BYOM (multi-provider LLM):** `generate()` resolves the per-user `active_provider` → Gemini/OpenAI/Anthropic, model via `model_prefs` JSONB → config default (env default `gemini`). Per-provider Fernet-encrypted keys in `user_settings`; env keys are the platform fallback for background jobs. Embeddings run on Gemini (`text-embedding-004`). Anthropic uses assistant-prefill `"{"` for deterministic JSON.
+- **BYOM (multi-provider LLM):** `generate()` resolves the per-user `active_provider` → Gemini/OpenAI/Anthropic, model via `model_prefs` JSONB → config default (env default `gemini`). Per-provider Fernet-encrypted keys in `user_settings`; env keys are the platform fallback for background jobs. Embeddings run on Gemini (`gemini-embedding-001`). Anthropic uses assistant-prefill `"{"` for deterministic JSON.
 - **Auth + RLS:** `get_current_user` verifies the Firebase ID token and sets `SET LOCAL app.user_id` per request; RLS policies on per-user tables are enforce-when-set (permissive for background jobs). `AUTH_REQUIRED=false` falls back to the default user (single-user dev). RLS only bites under a non-superuser DB role (`backend/scripts/create_app_role.sql`); the explicit `current_user_id()` filter is the primary control. A startup `check_rls_posture` logs a warning when the connection is a superuser.
 - **Graceful degradation:** LLM generation degrades by provider — a user with any one valid provider key keeps working if another is down. Summaries fail soft: `get_cluster` / `get_briefing` call `summarize_cluster` on demand when a cluster lacks a cached summary (logged, no user-facing error). If embeddings lag, articles ingest without them and fall back to snippet discovery.
 - **Per-user API key:** Fernet-encrypted in `user_settings` (OpenAI/Gemini/Anthropic). Falls back to the matching `*_API_KEY` env var if no per-user key.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -106,8 +106,8 @@ fly open /health
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DATABASE_URL` | Yes | PostgreSQL connection string (auto-converts to asyncpg) |
-| `GEMINI_API_KEY` | **Yes** | Google Gemini key — powers **embeddings** (`text-embedding-004`, 768-dim → clustering) *and* the default generation provider |
-| `GEMINI_MODEL` | No | Gemini generation model (default `gemini-2.0-flash`; embedding model is fixed at `text-embedding-004`) |
+| `GEMINI_API_KEY` | **Yes** | Google Gemini key — powers **embeddings** (`gemini-embedding-001`, 768-dim → clustering) *and* the default generation provider |
+| `GEMINI_MODEL` | No | Gemini generation model (default `gemini-2.0-flash`; embedding model is fixed at `gemini-embedding-001`) |
 | `GENERATION_PROVIDER` | No | Default generation provider: `gemini` \| `openai` \| `anthropic` (per-user `active_provider` wins) |
 | `OPENAI_API_KEY` | No | *Optional* — only for the OpenAI generation provider. **Not used for embeddings.** |
 | `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` | No | Anthropic platform fallback + model (default `claude-haiku-4-5`) |
@@ -178,4 +178,4 @@ image with `DATABASE_URL` set). Alembic uses the sync (psycopg2) driver, derived
 - **Multi-user auth (optional):** Set `FIREBASE_CREDENTIALS_JSON` (inline service-account JSON works well for hosted secrets) and `AUTH_REQUIRED=true`. Without it, the app runs single-user (every request is the default user).
 - **Row-level security:** RLS on per-user tables only *enforces* under a non-superuser DB role — create one with `backend/scripts/create_app_role.sql` and point `DATABASE_URL` at it for real multi-tenant isolation. A startup check logs a warning if the connection is a superuser. (The explicit per-user query filter is always on regardless.)
 - **Personalization:** Entity-relevance personalization (G2) is on by default and safe — a brand-new account with no signal sees the neutral ranking. Set `UER_ENABLED=false` to turn it off. Populating the entity graph also needs `GRAPH_EXTRACTION_ENABLED=true` + a platform LLM key.
-- **Graceful degradation:** Generation works with any one provider key (Gemini/OpenAI/Anthropic); summaries generate on demand if a batch missed them; without embeddings, discovery falls back to snippets and keyword matching. **Embeddings require the Gemini key** (`text-embedding-004`).
+- **Graceful degradation:** Generation works with any one provider key (Gemini/OpenAI/Anthropic); summaries generate on demand if a batch missed them; without embeddings, discovery falls back to snippets and keyword matching. **Embeddings require the Gemini key** (`gemini-embedding-001`).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An AI-powered news intelligence platform. NewsLens ingests articles from RSS fee
 - **Who's in the story** — a cast strip of the people/orgs/places in each cluster, with an "appears in" rail to other stories about the same entity.
 - **Personalized ranking** — follow entities and read stories, and the entities you care about rise across the cast strip, feed, briefing, and search. On by default; a brand-new account just sees the neutral ranking.
 - **Follows + digest** — follow topics, entities, or saved searches and get a personalized digest.
-- **Bring your own model** — per-user, Fernet-encrypted keys for **Gemini, OpenAI, or Anthropic**, with model selection and an env-var platform fallback. (Embeddings use Gemini `text-embedding-004`.)
+- **Bring your own model** — per-user, Fernet-encrypted keys for **Gemini, OpenAI, or Anthropic**, with model selection and an env-var platform fallback. (Embeddings use Gemini `gemini-embedding-001`.)
 - **Accounts** — Firebase auth (Google + Email/Password); single-user dev mode when auth isn't configured.
 - **Graceful degradation** — generation degrades by provider (any one valid key keeps you working); summaries generate on demand if a batch missed them; if embeddings lag, the UI falls back to snippets.
 
@@ -24,7 +24,7 @@ An AI-powered news intelligence platform. NewsLens ingests articles from RSS fee
 | Frontend | Next.js 16 (App Router), React 19, Tailwind CSS 4, Framer Motion |
 | Backend | Python, FastAPI, APScheduler, Firebase Admin SDK (auth) |
 | Database | PostgreSQL + pgvector (+ row-level security on per-user tables) |
-| ML | Gemini `text-embedding-004` (embeddings, 768-dim) + multi-provider generation (Gemini / OpenAI / Anthropic); pgvector cosine clustering |
+| ML | Gemini `gemini-embedding-001` (embeddings, 768-dim) + multi-provider generation (Gemini / OpenAI / Anthropic); pgvector cosine clustering |
 | Mobile | Capacitor (Android) + `@capacitor/splash-screen` |
 
 ## Quick start
@@ -58,7 +58,7 @@ APScheduler jobs run inside the FastAPI process:
 
 1. **RSS fetcher** (every 10 min) → feedparser → dedup → `articles`
 2. **GDELT fetcher** (every 15 min) → trafilatura extraction → dedup → `articles`
-3. **Embedding backfill** (every 5 min) → Gemini embeddings (`text-embedding-004`) → pgvector
+3. **Embedding backfill** (every 5 min) → Gemini embeddings (`gemini-embedding-001`) → pgvector
 4. **Clustering** (every 10 min) → pgvector cosine distance (threshold 0.15) → `story_clusters`
 5. **Entity extraction** (every 15 min, off by default behind `GRAPH_EXTRACTION_ENABLED`) → LLM extraction over settled clusters → `entities` / `article_entities`
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -119,11 +119,13 @@ class Settings(BaseSettings):
     # GDELT query (parametrized for region/language; default India + English)
     gdelt_query: str = "sourcecountry:IN"
 
-    # Embedding config — Gemini text-embedding-004 (native 768-dim, task-typed asymmetric retrieval).
-    # Changing the model/dim requires a migration on the pgvector column + a full re-embed (old vectors
-    # live in a different space); see migration a2b3c4d5e6f7. Kept config-driven so models.py's
-    # Vector(embedding_dimensions) and the tests follow automatically.
-    embedding_model: str = "models/text-embedding-004"
+    # Embedding config — Gemini gemini-embedding-001 (current GA model; text-embedding-004 is retired).
+    # It is natively 3072-dim but supports Matryoshka truncation via output_dimensionality, so we
+    # request 768 to match the pgvector column (migration a2b3c4d5e6f7). Truncation needs no L2
+    # normalization here because clustering/search use cosine distance (scale-invariant). Config-driven
+    # so models.py's Vector(embedding_dimensions) and the tests follow automatically; overridable via
+    # EMBEDDING_MODEL if Google rotates the model name again.
+    embedding_model: str = "models/gemini-embedding-001"
     embedding_dimensions: int = 768
     embedding_task_document: str = "retrieval_document"  # stored article/topic vectors
     embedding_task_query: str = "retrieval_query"        # search-query vectors (asymmetric retrieval)

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -94,11 +94,14 @@ async def _resolve_embedding_key() -> str | None:
     return await _resolve_gemini_key()
 
 
-def _embed_sync(key: str, model: str, content: str, task_type: str) -> list[float]:
+def _embed_sync(key: str, model: str, content: str, task_type: str, output_dim: int) -> list[float]:
     import google.generativeai as genai  # lazy — only on the embedding path
 
     genai.configure(api_key=key)
-    result = genai.embed_content(model=model, content=content, task_type=task_type)
+    # output_dimensionality truncates gemini-embedding-001's native 3072 to the pgvector column size.
+    result = genai.embed_content(
+        model=model, content=content, task_type=task_type, output_dimensionality=output_dim
+    )
     return result["embedding"]
 
 
@@ -120,6 +123,7 @@ async def generate_embedding(text: str, *, task_type: str | None = None) -> list
             settings.embedding_model,
             text,
             task_type or settings.embedding_task_document,
+            settings.embedding_dimensions,
         )
     except Exception as e:
         logger.error("embedding_generation_failed", error=str(e))

--- a/backend/tests/unit/test_embeddings_gemini.py
+++ b/backend/tests/unit/test_embeddings_gemini.py
@@ -4,7 +4,7 @@ from app.services import embeddings
 
 
 def test_embedding_config_is_gemini():
-    assert settings.embedding_model == "models/text-embedding-004"
+    assert settings.embedding_model == "models/gemini-embedding-001"
     assert settings.embedding_dimensions == 768
     assert settings.embedding_task_document == "retrieval_document"
     assert settings.embedding_task_query == "retrieval_query"
@@ -16,8 +16,10 @@ def _patch_gemini(monkeypatch, captured):
     def _configure(api_key=None):
         captured["key"] = api_key
 
-    def _embed(model=None, content=None, task_type=None):
-        captured.update(model=model, content=content, task_type=task_type)
+    def _embed(model=None, content=None, task_type=None, output_dimensionality=None):
+        captured.update(
+            model=model, content=content, task_type=task_type, output_dim=output_dimensionality
+        )
         return {"embedding": [0.1, 0.2, 0.3]}
 
     monkeypatch.setattr(genai, "configure", _configure)
@@ -37,9 +39,10 @@ async def test_generate_embedding_calls_gemini_document(monkeypatch):
 
     assert out == [0.1, 0.2, 0.3]
     assert cap["key"] == "test-gemini-key"
-    assert cap["model"] == "models/text-embedding-004"
+    assert cap["model"] == "models/gemini-embedding-001"
     assert cap["content"] == "hello world"
     assert cap["task_type"] == "retrieval_document"  # stored-document default
+    assert cap["output_dim"] == 768                  # truncated to the pgvector column size
 
 
 async def test_query_embedding_uses_query_task_type(monkeypatch):

--- a/render.yaml
+++ b/render.yaml
@@ -27,7 +27,7 @@ services:
           property: connectionString
         # config.py normalizes postgresql:// → postgresql+asyncpg:// automatically — no manual edit needed.
       - key: GEMINI_API_KEY
-        sync: false  # set manually. REQUIRED — powers BOTH embeddings (text-embedding-004 → clustering →
+        sync: false  # set manually. REQUIRED — powers BOTH embeddings (gemini-embedding-001 → clustering →
                      # feed/briefing/search) and generation (summaries + all lenses).
       - key: GENERATION_PROVIDER
         value: gemini  # summaries + lenses run on Gemini (per-user active_provider still wins)


### PR DESCRIPTION
Prod deploy is live and the API is healthy, but the embedding backfill logged:

```
404 models/text-embedding-004 is not found for API version v1beta, or is not supported for embedContent
```

`text-embedding-004` has been retired for current Gemini keys. Fix: switch to the GA model **`gemini-embedding-001`** and pass `output_dimensionality=768` (Matryoshka truncation) so it fits the existing `pgvector(768)` column — **no new migration**. Clustering/search use cosine distance (scale-invariant), so the truncated vectors need no L2 normalization. The model stays overridable via `EMBEDDING_MODEL`.

Verified in Docker: SDK `google-generativeai==0.8.3` `embed_content` accepts `output_dimensionality`; full suite **256 passed / 1 skipped**. (The live Gemini call is still mocked in CI — this will confirm on the next backfill.)

**After merge:** redeploy on Render. The already-`failed` articles get retried by the backfill automatically — no DB change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)