### PR TITLE
fix(llm): current Gemini generation model + root route + HTML-entity hygiene

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ OPENAI_API_KEY=
 # set their own per-provider key + model in Settings (per-user active_provider wins over this default).
 GEMINI_API_KEY=                       # REQUIRED (embeddings + default generation)
 GENERATION_PROVIDER=gemini            # gemini | openai | anthropic
-GEMINI_MODEL=gemini-2.0-flash
+GEMINI_MODEL=gemini-2.5-flash
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-haiku-4-5
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -107,7 +107,7 @@ fly open /health
 |----------|----------|-------------|
 | `DATABASE_URL` | Yes | PostgreSQL connection string (auto-converts to asyncpg) |
 | `GEMINI_API_KEY` | **Yes** | Google Gemini key — powers **embeddings** (`gemini-embedding-001`, 768-dim → clustering) *and* the default generation provider |
-| `GEMINI_MODEL` | No | Gemini generation model (default `gemini-2.0-flash`; embedding model is fixed at `gemini-embedding-001`) |
+| `GEMINI_MODEL` | No | Gemini generation model (default `gemini-2.5-flash` — `gemini-2.0-flash` is retired/404s; embedding model is fixed at `gemini-embedding-001`) |
 | `GENERATION_PROVIDER` | No | Default generation provider: `gemini` \| `openai` \| `anthropic` (per-user `active_provider` wins) |
 | `OPENAI_API_KEY` | No | *Optional* — only for the OpenAI generation provider. **Not used for embeddings.** |
 | `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` | No | Anthropic platform fallback + model (default `claude-haiku-4-5`) |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -57,6 +57,19 @@ logger = structlog.get_logger()
 router = APIRouter()
 
 
+@router.get("/", include_in_schema=False)
+async def root():
+    """Landing for the bare API host (Render's platform probe + humans hitting the base URL).
+    Without this, GET / 404s and pollutes the logs even though the service is healthy."""
+    return {
+        "service": "NewsLens API",
+        "version": "0.1.0",
+        "status": "ok",
+        "health": "/health",
+        "docs": "/docs",
+    }
+
+
 @router.get("/health", response_model=HealthResponse)
 async def health_check():
     db_ok = False
@@ -1524,7 +1537,10 @@ async def trivia_daily(
         return await llm.generate(prompt, schema={"questions": []})
     except llm.LLMUnavailable:
         return {"unavailable": True, "reason": "no_llm_key"}
-    except Exception:  # noqa: BLE001 — graceful degradation, never 500
+    except Exception as e:  # noqa: BLE001 — graceful degradation, never 500
+        # Log the provider error — a silent swallow here hid the retired-model 404 in prod
+        # (the response said only "llm_error" and the root cause had to be inferred).
+        logger.warning("trivia_daily_llm_failed", error=str(e))
         return {"unavailable": True, "reason": "llm_error"}
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -57,7 +57,10 @@ class Settings(BaseSettings):
     # LLM generation provider. Default gemini (BYOM; env default, per-user active_provider wins).
     generation_provider: str = "gemini"  # "openai" | "gemini" | "anthropic"
     gemini_api_key: str = ""
-    gemini_model: str = "gemini-2.0-flash"
+    # gemini-2.0-flash was retired for current keys (404 NotFound, same failure vector as
+    # text-embedding-004 → see embedding_model below). 2.5-flash is the current GA workhorse;
+    # override via GEMINI_MODEL if Google rotates names again.
+    gemini_model: str = "gemini-2.5-flash"
     # Wave E (BYOM): Anthropic provider. Env key = platform fallback for background jobs.
     anthropic_api_key: str = ""
     anthropic_model: str = "claude-haiku-4-5"  # cheap/fast default; env or per-user override wins

--- a/backend/app/services/fetcher.py
+++ b/backend/app/services/fetcher.py
@@ -1,5 +1,6 @@
 """RSS feed fetcher service with retry and structured logging."""
 
+import html
 import json
 import structlog
 import feedparser
@@ -238,7 +239,9 @@ async def fetch_single_feed(source: Source, client: httpx.AsyncClient) -> int:
     new_count = 0
     async with async_session() as session:
         for entry in feed.entries:
-            title = getattr(entry, "title", "").strip()
+            # RSS titles/summaries carry HTML entities (&nbsp; &#8377; &amp;) — decode at
+            # ingestion so every downstream consumer (cards, summaries, embeddings) sees clean text.
+            title = html.unescape(getattr(entry, "title", "").strip())
             link = getattr(entry, "link", "").strip()
 
             if not title or not link:
@@ -256,7 +259,9 @@ async def fetch_single_feed(source: Source, client: httpx.AsyncClient) -> int:
                 raw = entry.summary
             elif hasattr(entry, "content") and entry.content:
                 raw = entry.content[0].get("value", "")
-            raw = re.sub(r"<[^>]+>", "", raw).strip()
+            # Strip tags FIRST, then unescape — so an encoded "&lt;script&gt;" never becomes a
+            # live tag that the strip would have removed.
+            raw = html.unescape(re.sub(r"<[^>]+>", "", raw)).strip()
             snippet = raw[:300]
             body = raw[:16000] if raw else None
 

--- a/backend/app/services/gdelt.py
+++ b/backend/app/services/gdelt.py
@@ -4,6 +4,7 @@ GDELT provides event metadata with links to source articles.
 We use it to discover article URLs, then extract title + snippet via trafilatura.
 """
 
+import html
 import re
 import structlog
 import httpx
@@ -61,7 +62,9 @@ async def fetch_gdelt():
         new_count = 0
         for item in articles:
             url = item.get("url", "").strip()
-            title = item.get("title", "").strip()
+            # GDELT titles arrive raw; decode entities at ingestion (snippet/body come from
+            # trafilatura, which already decodes — don't double-process those).
+            title = html.unescape(item.get("title", "").strip())
             domain = item.get("domain", "").strip()
             seendate = item.get("seendate", "")
 

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -35,8 +35,10 @@ async def generate_cluster_summary(
     Returns (summary_text, coherence_score). Coherence is estimated from the number of
     corroborating sources. Falls back to the first snippet if generation is unavailable.
     """
-    # Fallback: first available snippet, trimmed to ~2 sentences.
-    fallback_text = next((s for s in snippets if s), "No summary available.")
+    # Fallback: first available snippet, trimmed to ~2 sentences. Unescape defensively — rows
+    # ingested before the fetcher decoded entities still carry &nbsp;/&#8377; in the DB.
+    import html as _html
+    fallback_text = _html.unescape(next((s for s in snippets if s), "No summary available."))
     sentences = fallback_text.split(". ")
     fallback_summary = ". ".join(sentences[:2]) + "." if len(sentences) > 1 else fallback_text
 

--- a/backend/scripts/unescape_articles.py
+++ b/backend/scripts/unescape_articles.py
@@ -1,0 +1,61 @@
+"""One-time backfill: decode HTML entities in already-ingested rows.
+
+The fetcher now html.unescape()s titles/snippets at ingestion, but rows ingested before that fix
+still carry raw entities (&nbsp; &#8377; &amp;) in the DB — visible on cards and in fallback
+summaries. This decodes them in place. Idempotent: unescaping already-clean text is a no-op, and
+the WHERE prefilter skips rows without an entity-looking pattern.
+
+Run inside the backend container/image with DATABASE_URL set (same env as the app):
+
+    python scripts/unescape_articles.py
+"""
+import asyncio
+import html
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # make `app` importable
+
+from sqlalchemy import text  # noqa: E402
+
+from app.database import async_session  # noqa: E402
+
+# (table, [columns]) — only text the UI/summaries surface. Prefilter keeps churn minimal.
+TARGETS = [
+    ("articles", ["title", "snippet", "extracted_text"]),
+    ("story_clusters", ["title", "summary"]),
+]
+# Matches &word; / &#123; style sequences cheaply in SQL to prefilter candidate rows.
+ENTITY_LIKE = "'%&%;%'"
+
+
+async def main() -> None:
+    total = 0
+    async with async_session() as session:
+        for table, columns in TARGETS:
+            for col in columns:
+                rows = (
+                    await session.execute(
+                        text(
+                            f"SELECT id, {col} FROM {table} "
+                            f"WHERE {col} IS NOT NULL AND {col} LIKE {ENTITY_LIKE}"
+                        )
+                    )
+                ).all()
+                changed = 0
+                for row_id, value in rows:
+                    decoded = html.unescape(value)
+                    if decoded != value:
+                        await session.execute(
+                            text(f"UPDATE {table} SET {col} = :v WHERE id = :id"),
+                            {"v": decoded, "id": row_id},
+                        )
+                        changed += 1
+                total += changed
+                print(f"{table}.{col}: {len(rows)} candidates, {changed} updated")
+        await session.commit()
+    print(f"done — {total} values decoded")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_root_and_entities.py
+++ b/backend/tests/test_root_and_entities.py
@@ -1,0 +1,68 @@
+"""Root route + HTML-entity hygiene + current Gemini generation model.
+
+Covers the three prod issues found after the Gemini cutover: GET / 404-noise, raw HTML entities
+(&nbsp; &#8377;) surfacing in snippets/summaries, and the retired gemini-2.0-flash model default.
+"""
+import html
+
+import pytest
+
+from app.config import Settings
+
+
+# ── GET / ──
+
+@pytest.mark.asyncio
+async def test_root_route_returns_service_info(client):
+    r = await client.get("/")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["service"] == "NewsLens API"
+    assert body["health"] == "/health"
+    assert body["docs"] == "/docs"
+
+
+# ── generation model default ──
+
+def test_gemini_generation_model_is_current(monkeypatch):
+    """gemini-2.0-flash was retired (404 NotFound in prod — same vector as text-embedding-004).
+    Guard the shipped default so a revert reintroducing the dead model fails loudly."""
+    monkeypatch.delenv("GEMINI_MODEL", raising=False)
+    assert Settings().gemini_model == "gemini-2.5-flash"
+
+
+# ── entity decoding at ingestion (the exact transform the fetcher applies) ──
+
+def test_strip_tags_then_unescape_never_yields_live_tags():
+    """Order matters: strip tags FIRST, then unescape — otherwise encoded '&lt;script&gt;'
+    would decode into a live tag after the strip already ran."""
+    import re
+
+    raw = "&lt;script&gt;alert(1)&lt;/script&gt; RBI auction &nbsp;&#8377;34,000 crore &amp; more"
+    out = html.unescape(re.sub(r"<[^>]+>", "", raw)).strip()
+    assert "₹34,000" in out          # &#8377; → ₹
+    assert "&nbsp;" not in out and "&amp;" not in out
+    assert "<script>" in out              # decoded but INERT text — strip already ran, never executed
+    # and a real tag in the source is removed before decoding
+    raw2 = "<p>Sensex up &nbsp;500 points</p>"
+    out2 = html.unescape(re.sub(r"<[^>]+>", "", raw2)).strip()
+    assert "<p>" not in out2 and "500 points" in out2 and "&nbsp;" not in out2
+
+
+@pytest.mark.asyncio
+async def test_summarizer_fallback_unescapes_entities(monkeypatch):
+    """Rows ingested before the fetcher fix still hold raw entities — the summary fallback
+    must decode them so degraded cards render clean."""
+    from app.services import llm, summarizer
+
+    async def _unavailable(*a, **k):
+        raise llm.LLMUnavailable("no key")
+
+    monkeypatch.setattr(llm, "generate", _unavailable)
+
+    summary, coherence = await summarizer.generate_cluster_summary(
+        ["RBI auction"], ["&nbsp;Cut-off yield &#8377;34,000 crore. Second sentence here."],
+    )
+    assert coherence == 0.70
+    assert "&#8377;" not in summary and "&nbsp;" not in summary
+    assert "₹" in summary


### PR DESCRIPTION
Live diagnosis (4-agent workflow, prod probes + code traces) after the Gemini cutover found three issues:

## 1. Generation was silently BROKEN in prod
`/trivia/daily` → `{"unavailable":true,"reason":"llm_error"}` — that reason code fires **only when a Gemini key IS resolved but the model call throws**. Root cause: **`gemini-2.0-flash` is retired for current keys (404 NotFound)** — the exact same failure vector as `text-embedding-004`.
- Default → **`gemini-2.5-flash`** (env-overridable via `GEMINI_MODEL`), guarded by a test so a revert fails loudly.
- The trivia catch-all now **logs the provider error** (`trivia_daily_llm_failed`) — the silent swallow is why the 404 had to be inferred instead of read.

## 2. `GET /` 404-noise
Render's platform probe + browsers hit the bare host; no route existed. Added a minimal root handler (service info + `/health` + `/docs` links), `include_in_schema=False`.

## 3. HTML entities stored raw in the DB
`&nbsp;` / `&#8377;` visible on cards and fallback summaries — the RSS fetcher stripped tags but never decoded entities (confirmed stored raw via `/clusters/926`).
- Fetcher: strip tags **first**, then `html.unescape` (so an encoded `<script>` can never decode into a live tag) — RSS titles/snippets/bodies + GDELT titles. trafilatura output is already decoded — not double-processed.
- Summarizer fallback unescapes defensively (pre-fix rows).
- **One-time cleanup for existing rows:** `backend/scripts/unescape_articles.py` (idempotent, `LIKE '%&%;%'`-prefiltered; covers `articles` + `story_clusters`).

## Validation
- Full suite **260 passed / 1 skipped** (4 new tests: root route, strip-then-unescape order, fallback decode, current-model guard) on a fresh Docker DB.
- ⚠️ `gemini-2.5-flash` itself is not live-testable from CI — instant pre-merge confirm: set `GEMINI_MODEL=gemini-2.5-flash` on Render and re-curl `/trivia/daily`.

## After merge
1. Redeploy on Render → `curl /trivia/daily` returns a real quiz; `GET /` returns 200 JSON.
2. Optionally run the entity cleanup once: `python scripts/unescape_articles.py` (backend env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)