### PR TITLE
fix(qa): all 11 device-QA items — navigation, brand fidelity, UI polish, AI content

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -366,6 +366,47 @@ async def get_cluster(cluster_id: int, db: AsyncSession = Depends(get_db)):
     )
 
 
+@router.get("/articles/{article_id}", dependencies=[Depends(get_current_user)])
+async def get_article(article_id: int, db: AsyncSession = Depends(get_db)):
+    """Single-article detail for briefing-fallback stories (article not clustered yet).
+
+    Resolves the article's cluster id when one exists so the client can upgrade to the
+    full deep dive instead of the single-article view.
+    """
+    from fastapi import HTTPException
+
+    from app.schemas import ArticleDetail
+
+    article = (
+        await db.execute(
+            select(Article)
+            .options(selectinload(Article.source))
+            .where(Article.id == article_id)
+        )
+    ).scalar_one_or_none()
+    if article is None:
+        raise HTTPException(status_code=404, detail="article not found")
+
+    cluster_id = (
+        await db.execute(
+            select(ClusterArticle.cluster_id)
+            .where(ClusterArticle.article_id == article_id)
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    return ArticleDetail(
+        id=article.id,
+        title=article.title,
+        snippet=article.snippet,
+        url=article.url,
+        source_name=article.source.name if article.source else "Unknown",
+        is_paywalled=bool(article.source.is_paywalled) if article.source else False,
+        published_at=article.published_at,
+        cluster_id=cluster_id,
+    )
+
+
 @router.get("/topics", response_model=TopicListResponse)
 async def get_topics(db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Topic).order_by(Topic.name))
@@ -459,6 +500,19 @@ def _extract_impact_headline(impact_json: dict | None) -> str | None:
     return None
 
 
+# Source-taxonomy categories → reader-facing chip names (used when an article has no topic
+# row yet — the source's own category beats a blanket "General").
+SOURCE_CATEGORY_DISPLAY = {
+    "world": "World",
+    "technology": "Technology",
+    "science": "Science",
+    "business": "Business",
+    "national": "India",
+    "policy": "Policy",
+    "startup": "Start-up",
+}
+
+
 @router.get("/briefing", response_model=BriefingResponse, dependencies=[Depends(get_current_user)])
 async def get_briefing(db: AsyncSession = Depends(get_db)):
     """
@@ -517,18 +571,27 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
         first_snippet = None
         category = "General"
         topic_id = None
+        region = None
         cluster_article_ids = []
         for ca in cluster.articles:
             source_names.add(ca.article.source.name)
             cluster_article_ids.append(ca.article.id)
             if first_snippet is None and ca.article.snippet:
                 first_snippet = ca.article.snippet
+            if region is None and ca.article.source and ca.article.source.region == "in":
+                region = "India"
             if category == "General" and ca.article.topics:
                 for at in ca.article.topics:
                     if at.topic:
                         category = at.topic.name
                         topic_id = at.topic_id
                         break
+            # No topic row yet → classify by the source's own category (every seeded source
+            # carries one) instead of defaulting everything to "General" (device-QA #3b).
+            if category == "General" and ca.article.source and ca.article.source.category:
+                category = SOURCE_CATEGORY_DISPLAY.get(
+                    ca.article.source.category, category
+                )
 
         # Use real summary or on-demand generate
         summary = cluster.summary
@@ -572,6 +635,7 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
                 summary=summary,
                 cluster_id=cluster.id,
                 category=category,
+                region=region,
                 source_count=len(source_names),
                 coherence=coherence,
                 is_read=is_read,
@@ -594,7 +658,10 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
     if not stories:
         article_result = await db.execute(
             select(Article)
-            .options(selectinload(Article.source))
+            .options(
+                selectinload(Article.source),
+                selectinload(Article.topics).selectinload(ArticleTopic.topic),
+            )
             .where(Article.snippet.isnot(None))
             .order_by(Article.published_at.desc().nullslast())
             .limit(8)
@@ -613,24 +680,21 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
         ).all()
         article_cluster = {aid: cid for aid, cid in ca_rows}
 
-        source_categories = {
-            "BBC News": "World",
-            "Al Jazeera": "World",
-            "NPR News": "World",
-            "Reuters - World": "World",
-            "TechCrunch": "Tech",
-            "Ars Technica": "Tech",
-            "The Verge": "Tech",
-            "Hacker News": "Tech",
-            "Nature News": "Science",
-            "Wall Street Journal": "Business",
-        }
-
         for a in articles:
             snippet = a.snippet or ""
             sentences = snippet.split(". ")
             summary = ". ".join(sentences[:2]) + "." if len(sentences) > 1 else snippet
-            category = source_categories.get(a.source.name, "General")
+            # Classify: article topic → source's own category → General. (The old version
+            # mapped 10 hardcoded Western outlet names, so every Indian source fell to
+            # "General" — device-QA #3b.)
+            category = "General"
+            for at in a.topics:
+                if at.topic:
+                    category = at.topic.name
+                    break
+            if category == "General" and a.source and a.source.category:
+                category = SOURCE_CATEGORY_DISPLAY.get(a.source.category, "General")
+            region = "India" if (a.source and a.source.region == "in") else None
             is_read = a.id in read_article_ids
 
             stories.append(
@@ -638,7 +702,9 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
                     title=a.title,
                     summary=summary,
                     cluster_id=article_cluster.get(a.id),
+                    article_id=a.id,  # unclustered fallback cards open /story?aid=N
                     category=category,
+                    region=region,
                     source_count=1,
                     coherence=0.70,
                     is_read=is_read,
@@ -1314,7 +1380,12 @@ async def cluster_analysis(
     if lens not in ("key_facts", "5ws", "profession"):
         raise HTTPException(status_code=400, detail="invalid lens")
     profession, _ = await _user_profession_locale(db)
-    return await lenses.analysis(db, cluster_id, lens, profession=profession)
+    # Depth toggle (Brief/Standard/Expert) genuinely changes retrieval budget + answer style.
+    u = (
+        await db.execute(select(User).where(User.id == current_user_id()))
+    ).scalar_one_or_none()
+    depth = (u.depth_pref if u and u.depth_pref else "standard")
+    return await lenses.analysis(db, cluster_id, lens, profession=profession, depth_pref=depth)
 
 
 @router.get("/clusters/{cluster_id}/impact", dependencies=[Depends(get_current_user)])

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -127,12 +127,30 @@ class BriefingStory(BaseModel):
     # article id: cluster and article ids are separate sequences, so a masqueraded id points the
     # deep-dive/lenses at a nonexistent or WRONG cluster as the sequences race past each other.
     cluster_id: int | None
+    # Set on the article-fallback path so unclustered stories still open a detail view
+    # (/story?aid=N) instead of rendering as dead cards.
+    article_id: int | None = None
     category: str
+    # Reader-facing region tag ("India" when any source is region=in) — device-QA #3b.
+    region: str | None = None
     source_count: int
     coherence: float
     is_read: bool = False
     # E6: best-effort WIIFM headline from already-cached impact_json (no new LLM calls)
     impact_headline: str | None = None
+
+
+class ArticleDetail(BaseModel):
+    """Single-article detail for briefing-fallback stories (no cluster yet)."""
+    id: int
+    title: str
+    snippet: str | None
+    url: str
+    source_name: str
+    is_paywalled: bool
+    published_at: datetime | None
+    # Resolved so the client can upgrade to the full deep dive when the article has a cluster.
+    cluster_id: int | None
 
 
 class BriefingResponse(BaseModel):

--- a/backend/app/services/lenses.py
+++ b/backend/app/services/lenses.py
@@ -64,9 +64,27 @@ def _source_hash(articles: list[Article]) -> str:
     return hashlib.sha1(",".join(map(str, ids)).encode()).hexdigest()[:16]
 
 
-def _cluster_text(cluster: StoryCluster, articles: list[Article]) -> str:
+def _cluster_text(
+    cluster: StoryCluster, articles: list[Article], depth_pref: str = "standard"
+) -> str:
     # Wave D1: route through the retrieval seam so lenses see full bodies, not snippet[:400].
-    return retrieval.cluster_text(cluster, articles)
+    # depth_pref drives the retrieval budget ladder (brief/standard/expert).
+    return retrieval.cluster_text(cluster, articles, depth_pref=depth_pref)
+
+
+_DEPTH_STYLE = {
+    "brief": "Answer for a general reader in a hurry: plainest language, shortest form, no jargon.",
+    "expert": (
+        "Answer for a domain-expert reader: precise terminology, concrete figures, mechanisms and "
+        "second-order implications — skip basic explanations."
+    ),
+}
+
+
+def _depth_suffix(depth_pref: str | None) -> str:
+    """Depth instruction appended to lens prompts so brief/standard/expert visibly differ."""
+    style = _DEPTH_STYLE.get(depth_pref or "standard")
+    return f"\n\n{style}" if style else ""
 
 
 # ── analysis / strategic / trivia prompt builders (unchanged) ──
@@ -318,21 +336,28 @@ async def get_lens(
 
 
 # ── public API (used by routes) ──
-async def analysis(db, cluster_id, lens: str, profession: str | None = None):
+async def analysis(
+    db, cluster_id, lens: str, profession: str | None = None,
+    depth_pref: str = "standard",
+):
     cluster, articles = await _load(db, cluster_id)
     if cluster is None:
         return {"error": "cluster_not_found"}
-    text_ = _cluster_text(cluster, articles) if articles else ""
+    text_ = _cluster_text(cluster, articles, depth_pref=depth_pref) if articles else ""
+    # Depth-scoped cache subkeys ONLY for non-standard depths: existing standard caches stay
+    # valid, and brief/expert answers can never cross-serve (the 04-plan cache trap).
+    dp = "" if depth_pref in (None, "", "standard") else f":{depth_pref}"
+    ds = _depth_suffix(depth_pref)
     if lens == "key_facts":
-        return await get_lens(db, cluster_id, column="analysis_json", subkey="key_facts",
-                              prompt=_prompt_key_facts(text_), schema={"facts": []})
+        return await get_lens(db, cluster_id, column="analysis_json", subkey=f"key_facts{dp}",
+                              prompt=_prompt_key_facts(text_) + ds, schema={"facts": []})
     if lens == "5ws":
-        return await get_lens(db, cluster_id, column="analysis_json", subkey="5ws",
-                              prompt=_prompt_5ws(text_), schema={"who": ""})
+        return await get_lens(db, cluster_id, column="analysis_json", subkey=f"5ws{dp}",
+                              prompt=_prompt_5ws(text_) + ds, schema={"who": ""})
     if lens == "profession":
         return await get_lens(db, cluster_id, column="analysis_json",
-                              subkey=f"prof:{profession_hash(profession)}",
-                              prompt=_prompt_profession(text_, profession),
+                              subkey=f"prof:{profession_hash(profession)}{dp}",
+                              prompt=_prompt_profession(text_, profession) + ds,
                               schema={"headline": ""})
     return {"error": "unknown_lens"}
 

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -29,11 +29,14 @@ def _staleness_cutoff(now: datetime | None = None) -> datetime:
 async def generate_cluster_summary(
     titles: list[str],
     snippets: list[str],
-) -> tuple[str, float]:
-    """Generate a summary for a story cluster via the active LLM provider (llm.generate).
+) -> tuple[str | None, str, float]:
+    """Generate an editorial headline + summary for a story cluster via llm.generate.
 
-    Returns (summary_text, coherence_score). Coherence is estimated from the number of
-    corroborating sources. Falls back to the first snippet if generation is unavailable.
+    Returns (headline | None, summary_text, coherence_score). The headline is a punchy,
+    fully fact-supported rewrite (device-QA #2 — raw feed titles like "Government Stock -
+    Full Auction Results" don't tell a reader why they should care). None on any failure
+    or guard trip → callers keep the existing title. Coherence is estimated from the
+    number of corroborating sources.
     """
     # Fallback: first available snippet, trimmed to ~2 sentences. Unescape defensively — rows
     # ingested before the fetcher decoded entities still carry &nbsp;/&#8377; in the DB.
@@ -61,23 +64,34 @@ async def generate_cluster_summary(
 
     from app.services import llm
     try:
-        summary = await llm.generate(
-            f"Summarize these {len(titles)} related articles:\n{articles_text}",
+        data = await llm.generate(
+            f"Rewrite the headline and summarize these {len(titles)} related articles:\n{articles_text}",
             system=(
-                "You are a news analyst. Summarize the following related news articles in 2-3 "
-                "concise sentences. Focus on key facts, implications, and what makes this story "
-                "significant. Be neutral and factual."
+                "You are a sharp news editor. Respond ONLY as JSON: "
+                '{"headline": "...", "summary": "..."}. '
+                "headline: one line, UNDER 90 characters, plain language, spark curiosity or "
+                "surprise — but every word must be fully supported by the articles; no clickbait "
+                "that overpromises, no invented numbers or names. "
+                "summary: 2-3 concise, neutral, factual sentences on what happened, why it "
+                "matters, and what to watch."
             ),
-            max_tokens=200,
+            schema={"headline": "", "summary": ""},
+            max_tokens=260,
         )
     except llm.LLMUnavailable:
-        return fallback_summary, 0.70
+        return None, fallback_summary, 0.70
     except Exception as e:  # noqa: BLE001 — never let a summary failure crash the caller
         logger.error("summary_generation_failed", error=str(e))
-        return fallback_summary, 0.70
+        return None, fallback_summary, 0.70
 
-    summary = (summary or "").strip()
-    return (summary, coherence) if summary else (fallback_summary, 0.70)
+    if not isinstance(data, dict):
+        return None, fallback_summary, 0.70
+    headline = (data.get("headline") or "").strip()
+    summary = (data.get("summary") or "").strip()
+    # Guard: an over-long/empty headline is worse than the original title.
+    if not headline or len(headline) > 90:
+        headline = None
+    return (headline, summary, coherence) if summary else (headline, fallback_summary, 0.70)
 
 
 async def summarize_cluster(cluster_id: int) -> tuple[str, float] | None:
@@ -105,9 +119,9 @@ async def summarize_cluster(cluster_id: int) -> tuple[str, float] | None:
         titles = [a.title for a in articles]
         snippets = [a.snippet or "" for a in articles]
 
-    summary, coherence = await generate_cluster_summary(titles, snippets)
+    headline, summary, coherence = await generate_cluster_summary(titles, snippets)
 
-    # Store on cluster
+    # Store on cluster; the AI headline replaces the raw first-article title when present.
     async with async_session() as session:
         await session.execute(
             update(StoryCluster)
@@ -116,6 +130,7 @@ async def summarize_cluster(cluster_id: int) -> tuple[str, float] | None:
                 summary=summary,
                 coherence=coherence,
                 summary_generated_at=datetime.now(timezone.utc),
+                **({"title": headline} if headline else {}),
             )
         )
         await session.commit()
@@ -125,6 +140,7 @@ async def summarize_cluster(cluster_id: int) -> tuple[str, float] | None:
         cluster_id=cluster_id,
         coherence=coherence,
         source_count=len(titles),
+        headline=bool(headline),
     )
 
     return summary, coherence

--- a/backend/tests/test_root_and_entities.py
+++ b/backend/tests/test_root_and_entities.py
@@ -60,9 +60,10 @@ async def test_summarizer_fallback_unescapes_entities(monkeypatch):
 
     monkeypatch.setattr(llm, "generate", _unavailable)
 
-    summary, coherence = await summarizer.generate_cluster_summary(
+    headline, summary, coherence = await summarizer.generate_cluster_summary(
         ["RBI auction"], ["&nbsp;Cut-off yield &#8377;34,000 crore. Second sentence here."],
     )
+    assert headline is None  # LLM unavailable → keep the existing cluster title
     assert coherence == 0.70
     assert "&#8377;" not in summary and "&nbsp;" not in summary
     assert "₹" in summary

--- a/frontend/android/app/capacitor.build.gradle
+++ b/frontend/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-firebase-authentication')
+    implementation project(':capacitor-app')
     implementation project(':capacitor-splash-screen')
 
 }

--- a/frontend/android/capacitor.settings.gradle
+++ b/frontend/android/capacitor.settings.gradle
@@ -5,5 +5,8 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-firebase-authentication'
 project(':capacitor-firebase-authentication').projectDir = new File('../node_modules/@capacitor-firebase/authentication/android')
 
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@capacitor-firebase/authentication": "^8.3.0",
         "@capacitor/android": "^8.3.0",
+        "@capacitor/app": "^8.1.0",
         "@capacitor/cli": "^8.3.0",
         "@capacitor/core": "^8.3.0",
         "@capacitor/splash-screen": "^8.0.1",
@@ -404,6 +405,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@capacitor-firebase/authentication": "^8.3.0",
     "@capacitor/android": "^8.3.0",
+    "@capacitor/app": "^8.1.0",
     "@capacitor/cli": "^8.3.0",
     "@capacitor/core": "^8.3.0",
     "@capacitor/splash-screen": "^8.0.1",

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -20,6 +20,7 @@ export default function DiscoverPage() {
   const [state, setState] = useState<PageState>("loading");
   const [deck, setDeck] = useState<DiscoverCardType[]>([]);
   const [totalSwiped, setTotalSwiped] = useState(0);
+  const [batchTotal, setBatchTotal] = useState(0); // frozen per batch — counter never inflates on prefetch
   const [history, setHistory] = useState<DiscoverCardType[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isFetching, setIsFetching] = useState(false);
@@ -36,6 +37,7 @@ export default function DiscoverPage() {
       }
 
       setDeck(cards);
+      setBatchTotal(cards.length); // freeze the counter denominator for this batch
       setTotalSwiped(0);
       setState("swiping");
     } catch (err) {
@@ -101,12 +103,15 @@ export default function DiscoverPage() {
         }
       }
 
-      if (deck.length <= 1) {
-        setState("empty");
-      }
     },
     [deck]
   );
+
+  // Deck exhausted → "caught up". An effect (not a stale-closure check inside handleSwipe)
+  // so async topic-card refills are respected and there's no premature empty-state flash.
+  useEffect(() => {
+    if (state === "swiping" && deck.length === 0) setState("empty");
+  }, [deck.length, state]);
 
   const handleUndo = useCallback(() => {
     setHistory((h) => {
@@ -197,17 +202,21 @@ export default function DiscoverPage() {
       {state === "swiping" && (
         <div className="flex flex-col items-center pt-2">
           {/* Header */}
-          <div className="w-full mb-3">
-            <h1 className="text-hero text-[var(--text-primary)]">Discover</h1>
-            <p className="text-mono text-[var(--text-muted)] mt-1">
-              SWIPE TO TRIAGE &middot; {totalSwiped + 1} OF {deck.length + totalSwiped}
+          <div className="w-full mb-3 flex items-end justify-between">
+            <div>
+              <h1 className="text-hero text-[var(--text-primary)]">Discover</h1>
+              <p className="text-mono text-[var(--text-muted)] mt-1">SWIPE TO TRIAGE</p>
+            </div>
+            <p className="text-mono text-[var(--text-ghost)]">
+              {Math.min(totalSwiped + 1, batchTotal)} / {batchTotal}
             </p>
           </div>
 
-          {/* Card stack */}
+          {/* Card stack — the container is the single source of height truth; cards fill it
+              (inset-0). 344 ≈ page chrome (top 48 + header 84 + gap 24 + buttons 92 + bottom 72 + slack). */}
           <div
             className="relative w-full"
-            style={{ height: "min(360px, calc(100dvh - 240px))" }}
+            style={{ height: "clamp(360px, calc(100dvh - 344px), 560px)" }}
             role="group"
             aria-label="Discover card deck"
           >

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { BottomTabBar } from "@/components/layout/BottomTabBar";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { AuthProvider } from "@/components/AuthProvider";
 import { SplashScreen } from "@/components/SplashScreen";
+import { BackButtonHandler } from "@/components/BackButtonHandler";
 import "./globals.css";
 
 // Inline script to prevent flash of wrong theme (runs before React hydration)
@@ -64,6 +65,7 @@ export default function RootLayout({
       <body className="min-h-[100dvh] flex flex-col overflow-x-hidden">
         <ThemeProvider>
           <AuthProvider>
+            <BackButtonHandler />
             <SplashScreen />
             <NavBar />
             <main className="flex-1 pt-[var(--page-top)] pb-[var(--page-bottom)]">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,6 +13,7 @@ import { DailyTriviaCard } from "@/components/ui/DailyTriviaCard";
 import { PersonalizeBanner } from "@/components/ui/PersonalizeBanner";
 import { WhileAwayCard } from "@/components/ui/WhileAwayCard";
 import { LaunchScreen } from "@/components/LaunchScreen";
+import { AnimatedMark } from "@/components/SplashScreen";
 import { getBriefing, getTopics, type Briefing, type BriefingStory, type Topic } from "@/lib/api";
 import { isStale } from "@/lib/utils";
 import { cn } from "@/lib/utils";
@@ -176,7 +177,7 @@ export default function BriefingPage() {
       {/* Topic chips */}
       {(state === "success" || state === "refreshing") &&
         categories.length > 2 && (
-          <div className="flex gap-2 overflow-x-auto no-scrollbar py-3 -mx-4 px-4">
+          <div className="flex flex-nowrap gap-2 overflow-x-auto no-scrollbar overscroll-x-contain py-3 -mx-4 px-4">
             {categories.map((cat) => (
               <Chip
                 key={cat}
@@ -202,16 +203,26 @@ export default function BriefingPage() {
           </div>
         )}
 
-      {/* Loading state */}
-      {state === "loading" && (
-        <div className="pt-4">
-          <div className="h-8 w-48 skeleton mb-4" />
-          <div className="h-5 w-32 skeleton mb-6" />
-          {[1, 2, 3, 4, 5].map((i) => (
-            <StoryCardSkeleton key={i} />
-          ))}
-        </div>
-      )}
+      {/* Loading state — FIRST load (no content yet) gets the branded animated-mark loader
+          (device-QA #11: "I see news loading instead of the loader screen"); skeletons only
+          when we already have content on screen (refresh / topic switch). */}
+      {state === "loading" &&
+        (!briefing || briefing.stories.length === 0 ? (
+          <div className="flex flex-col items-center justify-center text-center min-h-[60vh]">
+            <AnimatedMark size={120} loop />
+            <p className="text-mono uppercase text-[var(--text-secondary)] mt-6">
+              Assembling your briefing
+            </p>
+          </div>
+        ) : (
+          <div className="pt-4">
+            <div className="h-8 w-48 skeleton mb-4" />
+            <div className="h-5 w-32 skeleton mb-6" />
+            {[1, 2, 3, 4, 5].map((i) => (
+              <StoryCardSkeleton key={i} />
+            ))}
+          </div>
+        ))}
 
       {/* Empty / first-run state — cold-start launch experience */}
       {state === "empty" && (

--- a/frontend/src/app/story/StoryContent.tsx
+++ b/frontend/src/app/story/StoryContent.tsx
@@ -2,18 +2,19 @@
 
 import { useSearchParams } from "next/navigation";
 import DeepDiveView from "@/components/DeepDiveView";
+import { ArticleView } from "@/components/ArticleView";
 
 export default function StoryContent() {
   const searchParams = useSearchParams();
   const id = searchParams.get("id");
+  const aid = searchParams.get("aid"); // unclustered fallback article (/story?aid=N)
 
-  if (!id) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <p className="text-body text-[var(--text-muted)]">No story selected</p>
-      </div>
-    );
-  }
+  if (id) return <DeepDiveView clusterIdOverride={Number(id)} />;
+  if (aid) return <ArticleView articleId={Number(aid)} />;
 
-  return <DeepDiveView clusterIdOverride={Number(id)} />;
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <p className="text-body text-[var(--text-muted)]">No story selected</p>
+    </div>
+  );
 }

--- a/frontend/src/app/welcome/page.tsx
+++ b/frontend/src/app/welcome/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { AnimatedMark } from "@/components/SplashScreen";
 
 /**
  * Welcome — first-run intro carousel (official "Splash & Onboarding" design,
@@ -52,6 +53,7 @@ function Slide({ children, className }: { children: React.ReactNode; className?:
 export default function WelcomePage() {
   const router = useRouter();
   const [page, setPage] = useState(0);
+  const [paused, setPaused] = useState(false);
 
   // Returning users skip the intro.
   useEffect(() => {
@@ -60,23 +62,40 @@ export default function WelcomePage() {
     }
   }, [router]);
 
+  // Auto-advance every 4s until the last page; any deliberate interaction (Back, dot tap,
+  // press-and-hold on the track) pauses it — the reader has taken control.
+  useEffect(() => {
+    if (paused || page >= 2) return;
+    const t = setTimeout(() => setPage((p) => Math.min(2, p + 1)), 4000);
+    return () => clearTimeout(t);
+  }, [page, paused]);
+
   const next = () => setPage((p) => Math.min(2, p + 1));
-  const back = () => setPage((p) => Math.max(0, p - 1));
+  const back = () => {
+    setPaused(true); // going back = reading at their own pace
+    setPage((p) => Math.max(0, p - 1));
+  };
   const toPicker = () => router.push("/onboarding");
 
   return (
     <div className="relative mt-[calc(var(--page-top)*-1)] mb-[calc(var(--page-bottom)*-1)] min-h-[100dvh] bg-[#0C0C0E] flex flex-col overflow-hidden">
-      {/* Top controls */}
-      <div className="h-12 flex items-center justify-between px-4 pt-[var(--safe-top)] shrink-0 z-10">
+      {/* Top controls — ≥44px tap targets (Android minimum) */}
+      <div className="h-14 flex items-center justify-between px-4 pt-[var(--safe-top)] shrink-0 z-10">
         {page > 0 ? (
-          <button onClick={back} className="text-mono uppercase tracking-[0.1em] text-[var(--text-muted)]">
+          <button
+            onClick={back}
+            className="min-h-12 min-w-12 -ml-3 px-3 flex items-center gap-1 text-[12px] font-[family-name:var(--font-jetbrains-mono)] uppercase tracking-[0.1em] text-[var(--text-secondary)] active:opacity-60 transition-opacity"
+          >
             &larr; Back
           </button>
         ) : (
           <span />
         )}
         {page < 2 ? (
-          <button onClick={toPicker} className="text-mono uppercase tracking-[0.1em] text-[var(--text-muted)]">
+          <button
+            onClick={toPicker}
+            className="min-h-12 min-w-12 -mr-3 px-3 flex items-center gap-1 text-[12px] font-[family-name:var(--font-jetbrains-mono)] uppercase tracking-[0.1em] text-[var(--text-secondary)] active:opacity-60 transition-opacity"
+          >
             Skip
           </button>
         ) : (
@@ -84,8 +103,13 @@ export default function WelcomePage() {
         )}
       </div>
 
-      {/* Track */}
-      <div className="flex-1 relative overflow-hidden">
+      {/* Track — press-and-hold pauses the auto-advance */}
+      <div
+        className="flex-1 relative overflow-hidden"
+        onPointerDown={() => setPaused(true)}
+        onPointerUp={() => setPaused(false)}
+        onPointerCancel={() => setPaused(false)}
+      >
         <div
           className="flex h-full w-[300%] transition-transform duration-500 [transition-timing-function:cubic-bezier(0.5,0.05,0.18,1)]"
           style={{ transform: `translateX(-${(page * 100) / 3}%)` }}
@@ -93,21 +117,9 @@ export default function WelcomePage() {
           {/* Page 1 — spotlight */}
           <Slide className="!pt-[64px]">
             <div className="flex-1 flex items-center justify-center">
-              {/* Framed spotlight — the mark in a viewfinder ring with outer source ticks (official brand spotlight) */}
-              <svg viewBox="0 0 100 100" width={210} height={210} className="overflow-visible" role="img" aria-hidden>
-                <g stroke="var(--border)" strokeWidth={3} strokeLinecap="round">
-                  <line x1="6" y1="22" x2="17" y2="22" />
-                  <line x1="2" y1="50" x2="14" y2="50" />
-                  <line x1="6" y1="78" x2="17" y2="78" />
-                  <line x1="83" y1="22" x2="94" y2="22" />
-                  <line x1="86" y1="50" x2="98" y2="50" />
-                  <line x1="83" y1="78" x2="94" y2="78" />
-                </g>
-                <circle cx="50" cy="50" r="26" fill="none" stroke="var(--border-subtle)" strokeWidth={1} />
-                <path d="M35 26 H22 V74 H35" fill="none" stroke="var(--text-primary)" strokeWidth={5} strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M65 26 H78 V74 H65" fill="none" stroke="var(--text-primary)" strokeWidth={5} strokeLinecap="round" strokeLinejoin="round" />
-                <circle cx="50" cy="50" r="7.5" fill="var(--accent)" />
-              </svg>
+              {/* The canonical animated mark — official kit geometry (story lines INSIDE the
+                  brackets). Replaces a hand-drawn "spotlight" variant that put ticks outside. */}
+              <AnimatedMark size={210} />
             </div>
             <Kicker>News intelligence</Kicker>
             <Headline>
@@ -196,23 +208,32 @@ export default function WelcomePage() {
         </div>
       </div>
 
-      {/* Bottom: dots + next */}
+      {/* Bottom: dots (tappable, ≥44px hit areas) + next */}
       <div className="h-24 flex items-center justify-between px-6 pb-[var(--safe-bottom)] shrink-0 z-10">
-        <div className="flex gap-[7px] items-center">
+        <div className="flex items-center">
           {[0, 1, 2].map((i) => (
-            <span
+            <button
               key={i}
-              className={cn(
-                "h-1.5 rounded-full transition-all duration-300",
-                i === page ? "w-5 bg-[var(--text-primary)]" : "w-1.5 bg-[var(--text-ghost)]"
-              )}
-            />
+              aria-label={`Page ${i + 1}`}
+              onClick={() => {
+                setPaused(true); // jumping pages = self-paced from here on
+                setPage(i);
+              }}
+              className="h-11 w-6 flex items-center justify-center"
+            >
+              <span
+                className={cn(
+                  "h-1.5 rounded-full transition-all duration-300",
+                  i === page ? "w-5 bg-[var(--text-primary)]" : "w-1.5 bg-[var(--text-ghost)]"
+                )}
+              />
+            </button>
           ))}
         </div>
         {page < 2 && (
           <button
             onClick={next}
-            className="h-[46px] px-6 rounded-full bg-[var(--text-primary)] text-[#0C0C0E] font-medium text-[14.5px] flex items-center gap-2"
+            className="h-12 pl-7 pr-6 rounded-full bg-[var(--text-primary)] text-[#0C0C0E] font-medium text-[15px] flex items-center gap-2 active:scale-[0.97] transition-transform"
           >
             Next &rarr;
           </button>

--- a/frontend/src/components/ArticleView.tsx
+++ b/frontend/src/components/ArticleView.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import DeepDiveView from "@/components/DeepDiveView";
+import { Badge } from "@/components/ui/Badge";
+import { getArticle, type ArticleDetail } from "@/lib/api";
+import { relativeTime } from "@/lib/utils";
+
+/**
+ * Single-article detail for briefing-fallback stories (article not clustered yet).
+ * If the server resolves a cluster for the article, upgrade straight to the deep dive.
+ */
+export function ArticleView({ articleId }: { articleId: number }) {
+  const router = useRouter();
+  const [article, setArticle] = useState<ArticleDetail | null>(null);
+  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+
+  useEffect(() => {
+    getArticle(articleId)
+      .then((a) => {
+        setArticle(a);
+        setState("ready");
+      })
+      .catch(() => setState("error"));
+  }, [articleId]);
+
+  if (state === "loading") {
+    return (
+      <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)] py-6 space-y-4">
+        <div className="skeleton h-8 w-3/4" />
+        <div className="skeleton h-24 w-full" />
+      </div>
+    );
+  }
+
+  if (state === "error" || !article) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-body text-[var(--text-muted)]">Story unavailable — try again shortly.</p>
+      </div>
+    );
+  }
+
+  // The article got clustered since the briefing was built — show the real deep dive.
+  if (article.cluster_id != null) {
+    return <DeepDiveView clusterIdOverride={article.cluster_id} />;
+  }
+
+  return (
+    <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)] py-6">
+      <button
+        onClick={() => router.back()}
+        className="min-h-12 flex items-center gap-1 text-mono uppercase text-[var(--text-secondary)] active:opacity-60 transition-opacity"
+      >
+        ← Back
+      </button>
+
+      <div className="flex items-center gap-2 mb-3 mt-2">
+        <Badge variant="accent" size="md">
+          {article.source_name}
+        </Badge>
+        {article.is_paywalled && (
+          <Badge variant="paywall" size="md">
+            Paywalled
+          </Badge>
+        )}
+        {article.published_at && (
+          <span className="text-mono text-[var(--text-ghost)]">
+            {relativeTime(article.published_at)}
+          </span>
+        )}
+      </div>
+
+      <h1 className="text-h1 text-[var(--text-primary)] font-[family-name:var(--font-fraunces)] mb-4">
+        {article.title}
+      </h1>
+
+      {article.snippet && (
+        <p className="text-body text-[var(--text-secondary)] mb-6">{article.snippet}</p>
+      )}
+
+      <p className="text-mono text-[var(--text-ghost)] mb-4">
+        This story is still being processed — the multi-source deep dive appears once related
+        coverage is clustered.
+      </p>
+
+      <a
+        href={article.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-2 rounded-[var(--radius-md)] bg-[var(--accent)] px-5 py-3 text-small font-medium text-[#0C0C0E] transition-opacity hover:opacity-90"
+      >
+        Read the original →
+      </a>
+    </div>
+  );
+}

--- a/frontend/src/components/BackButtonHandler.tsx
+++ b/frontend/src/components/BackButtonHandler.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { Capacitor } from "@capacitor/core";
+
+/** Bottom-tab roots: hardware back from any of these minimizes the app instead of navigating. */
+const ROOTS = new Set(["/", "/discover", "/search", "/saved", "/following", "/settings"]);
+
+/**
+ * Android hardware back support. A Capacitor WebView receives NO back-button behavior by
+ * default — without this listener the system back button does nothing (device-QA #5).
+ * In-app history → router.back(); at a tab root (or no history) → minimize, never exit.
+ */
+export function BackButtonHandler() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+
+    let remove: (() => void) | undefined;
+    import("@capacitor/app").then(({ App }) => {
+      App.addListener("backButton", ({ canGoBack }) => {
+        if (!ROOTS.has(pathname) && canGoBack) {
+          router.back();
+        } else {
+          App.minimizeApp(); // keep state; never exitApp()
+        }
+      }).then((sub) => {
+        remove = () => sub.remove();
+      });
+    });
+    return () => remove?.();
+  }, [pathname, router]);
+
+  return null;
+}

--- a/frontend/src/components/DiscoverCard.tsx
+++ b/frontend/src/components/DiscoverCard.tsx
@@ -78,7 +78,9 @@ export function DiscoverCard({
   return (
     <motion.div
       className={cn(
-        "absolute inset-x-0 rounded-[var(--radius-lg)] overflow-hidden",
+        // inset-0: the card FILLS the stack container (page owns the height) — the old
+        // inset-x-0 + own-height pair let the card overflow the container onto the buttons.
+        "absolute inset-0 rounded-[var(--radius-lg)] overflow-hidden",
         "bg-[var(--surface-card)] border border-[var(--glass-border)]",
         isTop ? "cursor-grab active:cursor-grabbing" : "pointer-events-none"
       )}
@@ -116,11 +118,8 @@ export function DiscoverCard({
         </>
       )}
 
-      {/* Card content */}
-      <div
-        className={cn("p-4 flex flex-col", !isTop && "invisible")}
-        style={{ height: "min(420px, calc(100dvh - 240px))" }}
-      >
+      {/* Card content — fills the card; no competing height math */}
+      <div className={cn("p-4 flex flex-col h-full", !isTop && "invisible")}>
         {/* Header: topic badge + agreement */}
         <div className="flex items-center justify-between gap-2">
           <Badge variant="topic" size="md" color={topicColor}>
@@ -153,9 +152,9 @@ export function DiscoverCard({
           </div>
         )}
 
-        {/* Facts */}
-        <ul className="mt-4 space-y-2.5 flex-1 overflow-hidden">
-          {card.facts.map((fact, i) => (
+        {/* Facts — top 3, clipped cleanly (never mid-line) */}
+        <ul className="mt-4 space-y-2.5 flex-1 min-h-0 overflow-hidden">
+          {card.facts.slice(0, 3).map((fact, i) => (
             <li key={i} className="text-small text-[var(--text-secondary)] flex items-start gap-2.5">
               <span className="w-1.5 h-1.5 rounded-full shrink-0 mt-[7px]" style={{ backgroundColor: topicColor }} />
               <span className="line-clamp-2">{fact}</span>
@@ -163,8 +162,8 @@ export function DiscoverCard({
           ))}
         </ul>
 
-        {/* Source chips */}
-        <div className="flex items-center gap-1.5 flex-wrap mt-4 pt-3 border-t border-[var(--glass-border)]">
+        {/* Source chips — pinned to the card bottom */}
+        <div className="flex items-center gap-1.5 flex-wrap mt-auto pt-3 border-t border-[var(--glass-border)]">
           {card.sources.slice(0, 3).map((s) => (
             <span key={s} className="text-mono text-[10px] px-2 py-0.5 rounded-full bg-[var(--surface-raised)] text-[var(--text-secondary)]">
               {s}

--- a/frontend/src/components/HeroStoryCard.tsx
+++ b/frontend/src/components/HeroStoryCard.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { Badge } from "@/components/ui/Badge";
 import { ConfidenceScore } from "@/components/ui/ConfidenceScore";
-import { relativeTime, storyHref } from "@/lib/utils";
+import { articleHref, relativeTime, storyHref } from "@/lib/utils";
 import type { BriefingStory } from "@/lib/api";
 
 interface HeroStoryCardProps {
@@ -12,8 +12,13 @@ interface HeroStoryCardProps {
 }
 
 export function HeroStoryCard({ story }: HeroStoryCardProps) {
-  // Fallback stories (article not clustered yet) have no deep dive — render inert.
-  const clickable = story.cluster_id != null;
+  // Clustered → deep dive; unclustered fallback → single-article view; neither → inert.
+  const href =
+    story.cluster_id != null
+      ? storyHref(story.cluster_id)
+      : story.article_id != null
+        ? articleHref(story.article_id)
+        : null;
   return (
     <motion.div
       initial={{ opacity: 0, y: 16 }}
@@ -22,9 +27,9 @@ export function HeroStoryCard({ story }: HeroStoryCardProps) {
       transition={{ duration: 0.4, ease: "easeOut" }}
     >
       <Link
-        href={clickable ? storyHref(story.cluster_id as number) : "#"}
-        aria-disabled={!clickable}
-        style={clickable ? undefined : { pointerEvents: "none" }}
+        href={href ?? "#"}
+        aria-disabled={href === null}
+        style={href === null ? { pointerEvents: "none" } : undefined}
         className="block gradient-border rounded-[var(--radius-lg)] p-4 transition-all duration-[var(--duration-short)] hover:shadow-[var(--shadow-md)]"
       >
         <div className="flex items-center gap-2 mb-3">

--- a/frontend/src/components/LaunchScreen.tsx
+++ b/frontend/src/components/LaunchScreen.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { Button } from "@/components/ui/Button";
-import { Logo } from "@/components/ui/BrandMark";
+import { BrandMark } from "@/components/ui/BrandMark";
+import { AnimatedMark } from "@/components/SplashScreen";
 
 interface LaunchScreenProps {
   /** Re-check whether the briefing is ready. */
@@ -42,8 +43,19 @@ export function LaunchScreen({ onRetry, refreshing = false }: LaunchScreenProps)
 
   return (
     <div className="flex flex-col items-center justify-center text-center min-h-[70vh] px-[var(--space-lg)]">
-      {/* Wordmark */}
-      <Logo markSize={28} textClassName="text-[28px]" className="mb-[var(--space-lg)]" />
+      {/* The designed loader — the mark ANIMATES while the news resolves (kit loop),
+          not a static wordmark over skeletons. */}
+      <div className="mb-[var(--space-md)]">
+        {reduce ? <div className="text-[var(--text-primary)]"><BrandMark size={120} /></div> : <AnimatedMark size={120} loop />}
+      </div>
+      <div className="flex items-baseline mb-[var(--space-lg)]">
+        <span className="text-[28px] leading-none font-semibold tracking-[-0.02em] text-[var(--text-primary)] font-[family-name:var(--font-fraunces)]">
+          News
+        </span>
+        <span className="text-[28px] leading-none font-semibold tracking-[-0.02em] text-[var(--accent)] font-[family-name:var(--font-fraunces)]">
+          Lens
+        </span>
+      </div>
 
       <h1 className="text-title text-[var(--text-primary)]">
         Preparing your first briefing

--- a/frontend/src/components/SplashScreen.tsx
+++ b/frontend/src/components/SplashScreen.tsx
@@ -19,8 +19,14 @@ import { BrandMark } from "@/components/ui/BrandMark";
  */
 const SEEN_KEY = "newslens-splash-seen";
 
-/** One-shot mark animation — kit keyframes retimed from the 5.5s loop to a single ~1.7s reveal. */
-function AnimatedMark({ size = 150 }: { size?: number }) {
+/**
+ * Official mark choreography (brand kit "NewsLens Mark - Animated"): ticks gather →
+ * brackets close in while drawing on → the story-dot pops with a resolution ring.
+ * Default = one-shot reveal (splash). `loop` = the kit's original 5.5s infinite cycle
+ * (loaders — the "logo animates while news resolves" screen).
+ */
+export function AnimatedMark({ size = 150, loop = false }: { size?: number; loop?: boolean }) {
+  const cls = loop ? "lp" : "os";
   return (
     <div style={{ width: size, height: size }}>
       <style>{`
@@ -29,24 +35,35 @@ function AnimatedMark({ size = 150 }: { size?: number }) {
         @keyframes nlTickIn{0%{opacity:0}55%{opacity:var(--to)}100%{opacity:calc(var(--to)*0.32)}}
         @keyframes nlDotPop{0%,62%{transform:scale(0);opacity:0}78%{transform:scale(1.22);opacity:1}90%{transform:scale(1)}100%{transform:scale(1);opacity:1}}
         @keyframes nlRingOut{0%,64%{transform:scale(1);opacity:0}70%{transform:scale(1.12);opacity:.55}100%{transform:scale(3.4);opacity:0}}
-        .nl-bl{stroke-dasharray:74;transform-box:view-box;animation:nlBracketL .9s cubic-bezier(.5,.05,.18,1) .15s both}
-        .nl-br{stroke-dasharray:74;transform-box:view-box;animation:nlBracketR .9s cubic-bezier(.5,.05,.18,1) .15s both}
-        .nl-t{animation:nlTickIn 1.35s ease-in-out both}
-        .nl-dot{transform-box:fill-box;transform-origin:center;animation:nlDotPop 1.75s cubic-bezier(.34,1.56,.64,1) both}
-        .nl-ring{transform-box:fill-box;transform-origin:center;animation:nlRingOut 1.75s ease-out both}
+        .os-bl{stroke-dasharray:74;transform-box:view-box;animation:nlBracketL .9s cubic-bezier(.5,.05,.18,1) .15s both}
+        .os-br{stroke-dasharray:74;transform-box:view-box;animation:nlBracketR .9s cubic-bezier(.5,.05,.18,1) .15s both}
+        .os-t{animation:nlTickIn 1.35s ease-in-out both}
+        .os-dot{transform-box:fill-box;transform-origin:center;animation:nlDotPop 1.75s cubic-bezier(.34,1.56,.64,1) both}
+        .os-ring{transform-box:fill-box;transform-origin:center;animation:nlRingOut 1.75s ease-out both}
+        /* loop mode — kit's original infinite cycle (percentages from the standalone HTML) */
+        @keyframes nlBracketLoopL{0%,7%{stroke-dashoffset:74;opacity:0;transform:translateX(-7px)}16%{opacity:1}38%{stroke-dashoffset:0;opacity:1;transform:translateX(0)}86%{stroke-dashoffset:0;opacity:1;transform:translateX(0)}100%{stroke-dashoffset:74;opacity:0;transform:translateX(-7px)}}
+        @keyframes nlBracketLoopR{0%,7%{stroke-dashoffset:74;opacity:0;transform:translateX(7px)}16%{opacity:1}38%{stroke-dashoffset:0;opacity:1;transform:translateX(0)}86%{stroke-dashoffset:0;opacity:1;transform:translateX(0)}100%{stroke-dashoffset:74;opacity:0;transform:translateX(7px)}}
+        @keyframes nlTickLoop{0%,4%{opacity:0}22%{opacity:var(--to)}40%{opacity:var(--to)}54%{opacity:calc(var(--to)*0.32)}86%{opacity:calc(var(--to)*0.32)}100%{opacity:0}}
+        @keyframes nlDotLoop{0%,40%{transform:scale(0);opacity:0}50%{transform:scale(1.22);opacity:1}58%{transform:scale(1);opacity:1}86%{transform:scale(1);opacity:1}100%{transform:scale(0.55);opacity:0}}
+        @keyframes nlRingLoop{0%,42%{transform:scale(1);opacity:0}46%{transform:scale(1.12);opacity:.55}64%{transform:scale(3.4);opacity:0}100%{transform:scale(3.4);opacity:0}}
+        .lp-bl{stroke-dasharray:74;transform-box:view-box;animation:nlBracketLoopL 5.5s cubic-bezier(.5,.05,.18,1) infinite}
+        .lp-br{stroke-dasharray:74;transform-box:view-box;animation:nlBracketLoopR 5.5s cubic-bezier(.5,.05,.18,1) infinite}
+        .lp-t{animation:nlTickLoop 5.5s ease-in-out infinite}
+        .lp-dot{transform-box:fill-box;transform-origin:center;animation:nlDotLoop 5.5s cubic-bezier(.34,1.56,.64,1) infinite}
+        .lp-ring{transform-box:fill-box;transform-origin:center;animation:nlRingLoop 5.5s ease-out infinite}
       `}</style>
       <svg viewBox="0 0 100 100" style={{ display: "block", width: "100%", height: "100%", overflow: "visible" }}>
         {/* source ticks: faint reports waiting to be resolved — always INSIDE the brackets */}
-        <line x1="33" y1="41" x2="44" y2="41" stroke="#3F3F46" strokeWidth="4" strokeLinecap="round" className="nl-t" style={{ ["--to" as string]: 0.85, animationDelay: "0.12s" }} />
-        <line x1="29" y1="50" x2="43" y2="50" stroke="#A1A1AA" strokeWidth="4" strokeLinecap="round" className="nl-t" style={{ ["--to" as string]: 1, animationDelay: "0.05s" }} />
-        <line x1="33" y1="59" x2="44" y2="59" stroke="#3F3F46" strokeWidth="4" strokeLinecap="round" className="nl-t" style={{ ["--to" as string]: 0.85, animationDelay: "0.19s" }} />
+        <line x1="33" y1="41" x2="44" y2="41" stroke="#3F3F46" strokeWidth="4" strokeLinecap="round" className={`${cls}-t`} style={{ ["--to" as string]: 0.85, animationDelay: "0.12s" }} />
+        <line x1="29" y1="50" x2="43" y2="50" stroke="#A1A1AA" strokeWidth="4" strokeLinecap="round" className={`${cls}-t`} style={{ ["--to" as string]: 1, animationDelay: "0.05s" }} />
+        <line x1="33" y1="59" x2="44" y2="59" stroke="#3F3F46" strokeWidth="4" strokeLinecap="round" className={`${cls}-t`} style={{ ["--to" as string]: 0.85, animationDelay: "0.19s" }} />
         {/* the resolution ring — expands once at the instant of focus */}
-        <circle cx="50" cy="50" r="8" fill="none" stroke="#F97316" strokeWidth="1.4" className="nl-ring" />
+        <circle cx="50" cy="50" r="8" fill="none" stroke="#F97316" strokeWidth="1.4" className={`${cls}-ring`} />
         {/* editorial brackets closing in */}
-        <path d="M35 26 H22 V74 H35" fill="none" stroke="#E4E4E7" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" className="nl-bl" />
-        <path d="M65 26 H78 V74 H65" fill="none" stroke="#E4E4E7" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" className="nl-br" />
+        <path d="M35 26 H22 V74 H35" fill="none" stroke="#E4E4E7" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" className={`${cls}-bl`} />
+        <path d="M65 26 H78 V74 H65" fill="none" stroke="#E4E4E7" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" className={`${cls}-br`} />
         {/* the single story, in focus */}
-        <circle cx="50" cy="50" r="7" fill="#F97316" className="nl-dot" />
+        <circle cx="50" cy="50" r="7" fill="#F97316" className={`${cls}-dot`} />
       </svg>
     </div>
   );

--- a/frontend/src/components/StoryCard.tsx
+++ b/frontend/src/components/StoryCard.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { Badge } from "@/components/ui/Badge";
 import { ConfidenceScore } from "@/components/ui/ConfidenceScore";
-import { relativeTime, storyHref } from "@/lib/utils";
+import { articleHref, cn, relativeTime, storyHref } from "@/lib/utils";
 import type { BriefingStory } from "@/lib/api";
 
 const topicColorMap: Record<string, string> = {
@@ -29,9 +29,14 @@ interface StoryCardProps {
 
 export function StoryCard({ story }: StoryCardProps) {
   const topicColor = getTopicColor(story.category || "");
-  // cluster_id is null for fallback stories whose article isn't clustered yet — no deep dive
-  // exists, so the card renders inert instead of linking to a nonexistent cluster.
-  const clickable = story.cluster_id != null;
+  // Clustered → deep dive. Unclustered fallback → single-article view (/story?aid=N).
+  // Only a story with NEITHER id renders inert.
+  const href =
+    story.cluster_id != null
+      ? storyHref(story.cluster_id)
+      : story.article_id != null
+        ? articleHref(story.article_id)
+        : null;
 
   return (
     <motion.div
@@ -41,9 +46,13 @@ export function StoryCard({ story }: StoryCardProps) {
       transition={{ duration: 0.3, ease: "easeOut" }}
     >
       <Link
-        href={clickable ? storyHref(story.cluster_id as number) : "#"}
-        aria-disabled={!clickable}
-        className={`flex gap-3 py-4 border-b border-[var(--border-subtle)] transition-colors hover:bg-[var(--accent-subtle)] -mx-4 px-4 rounded-[var(--radius-md)]${clickable ? "" : " pointer-events-none"}`}
+        href={href ?? "#"}
+        aria-disabled={href === null}
+        className={cn(
+          "flex gap-3 py-4 border-b border-[var(--border-subtle)] transition-colors hover:bg-[var(--accent-subtle)] -mx-4 px-4 rounded-[var(--radius-md)]",
+          !story.is_read && "bg-[var(--accent-subtle)]", // unread = subtle row tint (no layout shift)
+          href === null && "pointer-events-none"
+        )}
       >
         {/* Category color indicator */}
         <div
@@ -52,17 +61,16 @@ export function StoryCard({ story }: StoryCardProps) {
         />
 
         <div className="flex-1 min-w-0">
-          {/* Title row */}
-          <div className="flex items-start gap-2">
-            {!story.is_read && (
-              <span className="mt-2 shrink-0">
-                <Badge variant="dot" />
-              </span>
+          {/* Title — flush-left always. Unread is signalled by the row tint + semibold title +
+              the dot in the meta row, NOT a leading dot that indents the headline (device-QA #3). */}
+          <h3
+            className={cn(
+              "text-heading text-[var(--text-primary)]",
+              !story.is_read && "font-semibold"
             )}
-            <h3 className="text-heading text-[var(--text-primary)] flex-1">
-              {story.title}
-            </h3>
-          </div>
+          >
+            {story.title}
+          </h3>
 
           {/* Summary */}
           <p className="text-small text-[var(--text-secondary)] mt-1 line-clamp-2">
@@ -76,17 +84,27 @@ export function StoryCard({ story }: StoryCardProps) {
             </p>
           )}
 
-          {/* Meta row */}
+          {/* Meta row — unread dot lives here (never beside the headline) */}
           <div className="flex items-center justify-between gap-3 mt-2">
-            <ConfidenceScore
-              sourceCount={story.source_count}
-              coherence={story.coherence}
-            />
-            {story.category && (
-              <Badge variant="topic" size="sm" color={topicColor}>
-                {story.category.toUpperCase()}
-              </Badge>
-            )}
+            <span className="flex items-center gap-1.5">
+              {!story.is_read && <Badge variant="dot" />}
+              <ConfidenceScore
+                sourceCount={story.source_count}
+                coherence={story.coherence}
+              />
+            </span>
+            <span className="flex items-center gap-1.5">
+              {story.region && story.region !== story.category && (
+                <Badge variant="outline" size="sm">
+                  {story.region.toUpperCase()}
+                </Badge>
+              )}
+              {story.category && (
+                <Badge variant="topic" size="sm" color={topicColor}>
+                  {story.category.toUpperCase()}
+                </Badge>
+              )}
+            </span>
           </div>
         </div>
       </Link>

--- a/frontend/src/components/ui/Chip.tsx
+++ b/frontend/src/components/ui/Chip.tsx
@@ -24,12 +24,15 @@ export function Chip({
       transition={{ duration: 0.1 }}
       onClick={onClick}
       className={cn(
-        "inline-flex items-center px-3 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap",
+        // shrink-0: chips must NEVER compress in a scroll row (device-QA #7 — WebViews squeezed
+        // pills until adjacent labels collided: "General AI", "BusinessEurope").
+        "inline-flex shrink-0 items-center px-3 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap",
         "transition-colors duration-[var(--duration-short)]",
         "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]",
         selected
           ? "bg-[var(--accent)] text-[var(--gray-950)]"
-          : "bg-transparent border border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]",
+          : // solid surface (not transparent) so unselected pills read as discrete objects on #0C0C0E
+            "bg-[var(--surface)] border border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]",
         className
       )}
       style={

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,14 +74,34 @@ export interface Topic {
 export interface BriefingStory {
   title: string;
   summary: string;
-  /** null on the article-fallback path (article not clustered yet) — no deep-dive to link to. */
+  /** null on the article-fallback path (article not clustered yet). */
   cluster_id: number | null;
+  /** set on fallback stories so the card can open the single-article view (/story?aid=N). */
+  article_id?: number | null;
+  /** reader-facing region tag, e.g. "India" */
+  region?: string | null;
   category: string;
   source_count: number;
   coherence: number;
   is_read?: boolean;
   // E6/Wave Q1: best-effort WIIFM one-liner ("why you're seeing this"), when cached
   impact_headline?: string | null;
+}
+
+export interface ArticleDetail {
+  id: number;
+  title: string;
+  snippet: string | null;
+  url: string;
+  source_name: string;
+  is_paywalled: boolean;
+  published_at: string | null;
+  /** resolved server-side — when set, the client upgrades to the full deep dive */
+  cluster_id: number | null;
+}
+
+export function getArticle(id: number): Promise<ArticleDetail> {
+  return fetchJSON(`/articles/${id}`);
 }
 
 export interface Briefing {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -30,6 +30,11 @@ export function storyHref(clusterId: number): string {
   return `/story/${clusterId}`;
 }
 
+/** Detail link for an UNCLUSTERED article (briefing fallback) — single-article view. */
+export function articleHref(articleId: number): string {
+  return `/story?aid=${articleId}`;
+}
+
 /** Check if a briefing timestamp is stale (>4 hours old) */
 export function isStale(date: string | Date): boolean {
   const fourHours = 4 * 60 * 60 * 1000;


### PR DESCRIPTION
Implements the full 11-item device-QA list (diagnosed by a 4-agent parallel investigation with file:line fix specs).

## Blockers
1. **Cards not clickable** *(regression from the honest-null fix)* — fallback stories now open a new **single-article view** (`GET /articles/{id}` + `/story?aid=N`), which auto-upgrades to the deep dive once the article is clustered. Cards: cluster → deep dive · article → article view · inert only when neither.
2. **Hardware back button** — `@capacitor/app` + `BackButtonHandler`: back navigates; at a tab root it minimizes (never exits).

## Brand kit (provided assets, not rebuilt)
3. **Welcome mark fixed** — the hand-drawn "spotlight" SVG (ticks *outside* the brackets) is deleted; the canonical kit mark renders (verified: 0 outer ticks, lines 29–44 inside brackets 22–78).
4. **Designed loader is live** — `AnimatedMark` gained the kit's original 5.5s `loop` choreography; first-load and LaunchScreen show the animated logo instead of skeletons.
5. **Welcome auto-advances** every 4s (verified live); pauses on interaction.
6. **44–48px tap targets** on all welcome controls (verified live).

## UI polish
7. **Unread dot** → meta row; unread = subtle row tint + semibold title; headlines flush-left.
8. **Chips** → `shrink-0`, solid surface, one scrollable row (no more "General AI" collisions).
9. **Discover** → card fills its container (was overflowing 60px onto the buttons), facts clamp to 3, footer pinned, frozen counter, no empty-state flash.

## AI content
10. **AI headlines** — summarizer emits `{headline, summary}` (JSON mode): punchy, ≤90 chars, fully fact-supported, title-fallback on any failure; rolls out via the 4h refresh.
11. **Classification** — topic → source-category → General in both briefing paths (fallback had 10 hardcoded Western outlets → everything Indian read "General"); `region: India` badge.
12. **Depth toggle is real** — Brief/Standard/Expert changes retrieval budget + answer style on Key Facts/5Ws/For-You, with depth-scoped cache keys (no cross-serving; standard caches untouched).

## Validation
Backend **260 / 1 skipped** · tsc clean · build ✓ · vitest **51/51** · copy-guard ✓ · preview-verified mark/auto-advance/tap-targets.

## After merge
Backend redeploy (headlines/classification/depth/articles endpoint) + **APK rebuild** (everything client-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)