### PR TITLE
Phase 2: source-tier badges + credibility ranking + follow-source opt-in [TDD]

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -14,6 +14,7 @@ from app.models import (
     FeedbackType,
     Follow,
     Source,
+    SourceType,
     StoryCluster,
     Topic,
     User,
@@ -102,6 +103,7 @@ async def health_check():
 @router.get("/feed", response_model=FeedResponse, dependencies=[Depends(get_current_user)])
 async def get_feed(
     topic: int | None = None,
+    source_type: str | None = None,
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
     db: AsyncSession = Depends(get_db),
@@ -125,11 +127,28 @@ async def get_feed(
     from app.services import audience as _audience
     _profession, _ = await _user_profession_locale(db)
     _tags = _audience.tags_for_profession(_profession)
+    _followed = await _audience.followed_source_ids(db, current_user_id())  # #81 opt-in override
     query = query.where(
         Article.source_id.in_(
-            _audience.allowed_source_ids(_tags, floor=app_settings.credibility_feed_floor)
+            _audience.allowed_source_ids(
+                _tags, floor=app_settings.credibility_feed_floor, followed_source_ids=_followed
+            )
         )
     )
+
+    # #82: source-type filter chips ("All / News / Research / Experts"). Composes with the persona
+    # gate above — filtering to a tier never bypasses it. "news" = the non-gated tiers.
+    if source_type and source_type.lower() != "all":
+        from fastapi import HTTPException
+        st = source_type.lower()
+        _gated_types = [SourceType.research, SourceType.expert]
+        if st == "news":
+            type_cond = Source.source_type.notin_(_gated_types)
+        elif st in ("research", "expert"):
+            type_cond = Source.source_type == SourceType(st)
+        else:
+            raise HTTPException(status_code=400, detail="invalid source_type")
+        query = query.where(Article.source_id.in_(select(Source.id).where(type_cond)))
 
     # G2: when personalizing, fetch a bounded recent pool and rerank it (recency + entity relevance)
     # BEFORE paginating, so a high-affinity story can cross page boundaries within the horizon. When
@@ -192,11 +211,17 @@ async def get_feed(
         span = (hi - lo) or 1.0
         ratio = app_settings.uer_feed_blend_ratio
 
+        def _cred_mult(a: Article) -> float:
+            # #79: bounded ×[0.9, 1.1] credibility nudge. NULL (news) → neutral → ×1.0.
+            score = a.source.credibility_score if (a.source and a.source.credibility_score is not None) \
+                else app_settings.credibility_rank_neutral
+            return 0.9 + 0.2 * score / 100
+
         def _blend(a: Article) -> float:
             t = pub_ts[a.id]
             recency = 0.0 if t is None else (1.0 if hi == lo else (t - lo) / span)
             rel = min(1.0, scores.get(art_to_cluster.get(a.id), 0.0))
-            return (1 - ratio) * recency + ratio * rel
+            return ((1 - ratio) * recency + ratio * rel) * _cred_mult(a)
 
         blends = {a.id: _blend(a) for a in articles}
         articles.sort(
@@ -564,8 +589,10 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
     from sqlalchemy import exists as _sa_exists
     from app.services import audience as _audience
     _profession, _ = await _user_profession_locale(db)
+    _tags = _audience.tags_for_profession(_profession)  # #80: for the "in your field" bonus below
+    _followed = await _audience.followed_source_ids(db, current_user_id())  # #81 opt-in override
     _allowed = _audience.allowed_source_ids(
-        _audience.tags_for_profession(_profession), floor=app_settings.credibility_briefing_floor
+        _tags, floor=app_settings.credibility_briefing_floor, followed_source_ids=_followed
     )
     _visible = _sa_exists().where(
         ClusterArticle.cluster_id == StoryCluster.id,
@@ -659,8 +686,21 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
         # (orthogonal to the explicit topic preference — a followed-entity story can climb even with
         # no topic preference; a zero-signal user gets +0, so ordering is identical to today).
         pref_weight = prefs.get(topic_id, 0.0) if topic_id else 0.0
+        # #80: "in your field" bonus — a research/expert cluster whose source audience overlaps the
+        # user's profession tags gets a small additive lift so it reliably reaches the top-8. A
+        # profession-less user has empty tags → never matches → briefing ordering is unchanged. An
+        # audience-null general source (visible to everyone) is NOT "your field" → no bonus.
+        field_match = any(
+            ca.article.source
+            and ca.article.source.source_type in (SourceType.research, SourceType.expert)
+            and ca.article.source.audience
+            and (set(ca.article.source.audience) & _tags)
+            for ca in cluster.articles
+        )
         story_weights[cluster.id] = (
-            pref_weight + app_settings.uer_briefing_blend_weight * cluster_scores.get(cluster.id, 0.0)
+            pref_weight
+            + app_settings.uer_briefing_blend_weight * cluster_scores.get(cluster.id, 0.0)
+            + (app_settings.credibility_briefing_bonus if field_match else 0.0)
         )
 
         # E6: best-effort WIIFM headline from ALREADY-cached impact_json (no LLM calls).
@@ -691,7 +731,9 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
 
     stories = stories[:8]
 
-    # Fallback: if no clusters, build briefing from recent articles
+    # Fallback: if no clusters, build briefing from recent articles. Apply the SAME persona gate as
+    # the cluster path (#81) — otherwise a profession-less user with sparse content would leak gated
+    # research/expert articles here, defeating the gate. `_allowed` already folds in followed sources.
     if not stories:
         article_result = await db.execute(
             select(Article)
@@ -699,7 +741,7 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
                 selectinload(Article.source),
                 selectinload(Article.topics).selectinload(ArticleTopic.topic),
             )
-            .where(Article.snippet.isnot(None))
+            .where(Article.snippet.isnot(None), Article.source_id.in_(_allowed))
             .order_by(Article.published_at.desc().nullslast())
             .limit(8)
         )
@@ -783,17 +825,33 @@ async def get_discover_deck(
     Returns a deck of 20-30 cards for the discover/swipe interface.
     MVP: returns recent articles with cluster context.
     """
-    result = await db.execute(
-        select(Article)
-        .options(
-            selectinload(Article.source),
-            selectinload(Article.topics).selectinload(ArticleTopic.topic),
-        )
-        .where(Article.snippet.isnot(None))
-        .order_by(func.random())
-        .limit(25)
+    from app.config import settings as app_settings
+
+    _gated_types = [SourceType.research, SourceType.expert]
+    _opts = (
+        selectinload(Article.source),
+        selectinload(Article.topics).selectinload(ArticleTopic.topic),
     )
-    articles = result.scalars().all()
+    # #83: the discover deck is the OPT-IN surface for the gated tiers. Reserve up to ~5 slots for
+    # research/expert cards regardless of the user's profession (this is exactly where a non-matching
+    # user discovers and follows them); fill the rest from the NON-gated (news) pool so gated cards
+    # only ever arrive via this flagged reserved sample — never unflagged through the main pool.
+    gated_result = await db.execute(
+        select(Article).options(*_opts)
+        .join(Source, Article.source_id == Source.id)
+        .where(Article.snippet.isnot(None), Source.source_type.in_(_gated_types))
+        .order_by(func.random())
+        .limit(app_settings.discover_gated_slots)
+    )
+    gated_articles = gated_result.scalars().all()
+    news_result = await db.execute(
+        select(Article).options(*_opts)
+        .join(Source, Article.source_id == Source.id)
+        .where(Article.snippet.isnot(None), Source.source_type.notin_(_gated_types))
+        .order_by(func.random())
+        .limit(25 - len(gated_articles))
+    )
+    articles = list(gated_articles) + list(news_result.scalars().all())
 
     cards: list[DiscoverCardOut] = []
     for i, article in enumerate(articles):
@@ -812,6 +870,8 @@ async def get_discover_deck(
         sentences = [s.strip() for s in snippet.split(". ") if s.strip()]
         facts = sentences[:3] if sentences else ["No details available."]
 
+        src = article.source
+        is_gated = bool(src and src.source_type in _gated_types)
         cards.append(
             DiscoverCardOut(
                 id=i + 1,
@@ -819,10 +879,16 @@ async def get_discover_deck(
                 title=article.title,
                 tension_line=article.title,  # MVP: title as tension line
                 facts=facts,
-                sources=[article.source.name],
+                sources=[src.name] if src else [],
                 topic_id=topic_id,
                 topic_name=topic_name,
                 coherence=0.82,  # placeholder
+                source_id=src.id if src else None,
+                source_type=src.source_type.value if (src and src.source_type) else None,
+                is_gated=is_gated,
+                is_preprint=bool(src and src.is_preprint),
+                author_name=src.author_name if src else None,
+                credibility_score=src.credibility_score if src else None,
             )
         )
 
@@ -1495,7 +1561,8 @@ async def auth_me(user: User = Depends(get_current_user)):
 
 
 # ── Wave C: standing follows + "while you were away" digest ──
-_FOLLOW_KINDS = {"topic", "entity", "saved_search"}
+# Phase 2 · #81: "source" — value is the source id; following bypasses the persona gate.
+_FOLLOW_KINDS = {"topic", "entity", "saved_search", "source"}
 
 
 @router.get("/follows", response_model=list[FollowOut], dependencies=[Depends(get_current_user)])
@@ -1516,6 +1583,15 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
     value = (body.value or "").strip()
     if kind not in _FOLLOW_KINDS or not value:
         raise HTTPException(status_code=400, detail="invalid kind or empty value")
+    # #81: a source-follow must reference a real source (value = source id) — 404 otherwise, so a
+    # typo can't create a dangling opt-in that silently does nothing.
+    if kind == "source":
+        try:
+            _sid = int(value)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="source follow value must be a source id")
+        if (await db.execute(select(Source.id).where(Source.id == _sid))).scalar_one_or_none() is None:
+            raise HTTPException(status_code=404, detail="source not found")
     # Idempotent: a duplicate (user, kind, value) returns the existing row.
     existing = (
         await db.execute(

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -212,9 +212,12 @@ async def get_feed(
         ratio = app_settings.uer_feed_blend_ratio
 
         def _cred_mult(a: Article) -> float:
-            # #79: bounded ×[0.9, 1.1] credibility nudge. NULL (news) → neutral → ×1.0.
+            # #79: bounded ×[0.9, 1.1] credibility nudge. NULL (news) → neutral → ×1.0. Clamp to
+            # [0,100] so a bad stored score can never break the bound and drown fresher news —
+            # defense at the point of use, independent of the write-side validation.
             score = a.source.credibility_score if (a.source and a.source.credibility_score is not None) \
                 else app_settings.credibility_rank_neutral
+            score = min(100, max(0, score))
             return 0.9 + 0.2 * score / 100
 
         def _blend(a: Article) -> float:
@@ -1800,6 +1803,10 @@ async def create_source(body: dict, db: AsyncSession = Depends(get_db)):
             status_code=400,
             detail="research/expert sources require a credibility_score",
         )
+    # Scores are a 0-100 scale; a value outside it would break the ×[0.9,1.1] feed-rank bound
+    # (the "credibility can never drown fresher news" guarantee). Reject at the write boundary.
+    if credibility_score is not None and not (0 <= credibility_score <= 100):
+        raise HTTPException(status_code=400, detail="credibility_score must be between 0 and 100")
 
     # UPSERT: if a source with the same url OR rss_url exists, update it in place.
     match_clauses = [Source.url == url]

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -697,6 +697,16 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
             and (set(ca.article.source.audience) & _tags)
             for ca in cluster.articles
         )
+        # #78: expose the gated tier (if any) so the card can show a RESEARCH/EXPERT badge.
+        tier = next(
+            (
+                ca.article.source.source_type.value
+                for ca in cluster.articles
+                if ca.article.source
+                and ca.article.source.source_type in (SourceType.research, SourceType.expert)
+            ),
+            None,
+        )
         story_weights[cluster.id] = (
             pref_weight
             + app_settings.uer_briefing_blend_weight * cluster_scores.get(cluster.id, 0.0)
@@ -717,6 +727,7 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
                 coherence=coherence,
                 is_read=is_read,
                 impact_headline=impact_headline,
+                tier=tier,
             )
         )
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -115,6 +115,15 @@ class Settings(BaseSettings):
     # the briefing. News sources (NULL credibility) are never floored.
     credibility_feed_floor: int = 55
     credibility_briefing_floor: int = 70
+    # Phase 2 · #79 — credibility nudges feed ordering via a bounded multiplier on the rank blend:
+    # × (0.9 + 0.2 × score/100) ⇒ ×[0.9, 1.1]. News (NULL credibility) is treated as this neutral
+    # score → ×1.0. The ±10% cap means credibility curates ordering but can never drown fresher news.
+    credibility_rank_neutral: int = 75
+    # Phase 2 · #83 — reserved research/expert slots in the ~25-card discover deck (the opt-in surface).
+    discover_gated_slots: int = 5
+    # Phase 2 · #80 — additive story_weights bonus for a persona-matched research/expert cluster, so
+    # "research in your field" reliably reaches the briefing top-8 without a singleton dominating.
+    credibility_briefing_bonus: float = 0.15
 
     # DB SSL: verified by default for cloud (Neon/Supabase). Opt out only if a cert
     # chain genuinely can't be verified in your environment.

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -176,6 +176,15 @@ class DiscoverCardOut(BaseModel):
     topic_id: int
     topic_name: str
     coherence: float
+    # Phase 2 · #83 — gated-tier opt-in surface. `is_gated` marks a research/expert card (from the
+    # reserved discovery sample) so the UI can badge it and offer "Follow source"; `source_id` is the
+    # follow target. All default-None/False → news cards and older clients are unaffected.
+    source_id: int | None = None
+    source_type: str | None = None
+    is_gated: bool = False
+    is_preprint: bool = False
+    author_name: str | None = None
+    credibility_score: int | None = None
 
 
 class SwipeRequest(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -144,6 +144,10 @@ class BriefingStory(BaseModel):
     is_read: bool = False
     # E6: best-effort WIIFM headline from already-cached impact_json (no new LLM calls)
     impact_headline: str | None = None
+    # Phase 2 · #78 — "research"/"expert" when the story comes from a gated-tier source (the UI shows
+    # a RESEARCH/EXPERT badge, the "for your field" cue that pairs with the #80 ranking bonus). None
+    # for ordinary news stories.
+    tier: str | None = None
 
 
 class ArticleDetail(BaseModel):

--- a/backend/app/services/audience.py
+++ b/backend/app/services/audience.py
@@ -50,12 +50,17 @@ def tags_for_profession(profession: str | None) -> set[str]:
     return {tag for tag, kws in _KEYWORDS.items() if any(kw in text for kw in kws)}
 
 
-def allowed_source_ids(user_tags: set[str], *, floor: int):
+def allowed_source_ids(user_tags: set[str], *, floor: int, followed_source_ids=None):
     """A subquery of source ids a user may see, given their audience tags.
 
     News (non-gated) sources are always allowed. A gated (research/expert) source is allowed only
     when it clears the credibility floor AND its audience overlaps the user's tags (or has no
     audience). A user with no tags sees no audience-tagged gated sources — the pre-expansion feed.
+
+    `followed_source_ids` (#81) is the opt-in escape hatch: a source the user explicitly follows is
+    allowed unconditionally — bypassing BOTH the floor and the audience match — on the same
+    "explicit intent" principle by which search is never gated. Empty/None ⇒ no override (the feed
+    stays byte-identical for a user with no source-follows).
     """
     from sqlalchemy import and_, or_, select
 
@@ -72,8 +77,30 @@ def allowed_source_ids(user_tags: set[str], *, floor: int):
         or_(Source.credibility_score.is_(None), Source.credibility_score >= floor),
         audience_ok,
     )
-    cond = or_(
+    branches = [
         Source.source_type.notin_([SourceType.research, SourceType.expert]),
         gated_ok,
-    )
-    return select(Source.id).where(cond)
+    ]
+    if followed_source_ids:
+        branches.append(Source.id.in_(sorted(followed_source_ids)))
+    return select(Source.id).where(or_(*branches))
+
+
+async def followed_source_ids(db, user_id: int) -> set[int]:
+    """The set of source ids this user follows (follows.kind == "source", value = the id string)."""
+    from sqlalchemy import select
+
+    from app.models import Follow
+
+    rows = (
+        await db.execute(
+            select(Follow.value).where(Follow.user_id == user_id, Follow.kind == "source")
+        )
+    ).scalars().all()
+    ids = set()
+    for v in rows:
+        try:
+            ids.add(int(v))
+        except (TypeError, ValueError):
+            continue
+    return ids

--- a/backend/tests/integration/test_phase2_discover.py
+++ b/backend/tests/integration/test_phase2_discover.py
@@ -1,0 +1,54 @@
+"""Phase 2 · #83 — discover deck is the opt-in surface for the gated tiers.
+
+Up to ~5 of the ~25 cards are research/expert regardless of profession match, each flagged so the
+UI can badge them and offer "Follow source". The rest of the deck is news (non-gated).
+"""
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+
+from app.models import Article, Source, SourceType, User
+
+
+async def _profession_less(db_session):
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = None
+    await db_session.flush()
+
+
+async def _src_with_article(db_session, name, source_type, title, **kw):
+    s = Source(name=name, url=f"https://{name}.example", rss_url=f"https://{name}.example/rss",
+               source_type=source_type, region="global", category=kw.pop("category", "world"), **kw)
+    db_session.add(s)
+    await db_session.flush()
+    db_session.add(Article(title=title, url=f"https://{name}.example/a1", source_id=s.id,
+                           snippet="A snippet long enough to build the discover card facts here.",
+                           published_at=datetime(2026, 7, 3, tzinfo=timezone.utc)))
+    await db_session.flush()
+    return s
+
+
+async def test_deck_surfaces_gated_sources_as_optin(aclient, db_session):
+    await _profession_less(db_session)
+    for i in range(3):
+        await _src_with_article(db_session, f"news{i}", SourceType.wire, f"News {i}")
+    await _src_with_article(db_session, "NEJM", SourceType.research, "Cardiology paper",
+                            category="research", credibility_score=98, audience=["medicine"], is_preprint=False)
+    await _src_with_article(db_session, "arXiv", SourceType.research, "AI preprint",
+                            category="research", credibility_score=80, audience=["ai"], is_preprint=True)
+
+    resp = await aclient.get("/discover/deck")
+    assert resp.status_code == 200
+    cards = resp.json()
+    gated = [c for c in cards if c["is_gated"]]
+    assert 1 <= len(gated) <= 5                                   # opt-in surfacing, capped
+    assert all(c["source_type"] in ("research", "expert") for c in gated)
+    assert all(c["source_id"] for c in gated)                    # frontend can POST a source-follow
+    # The main pool is news-only → a non-gated card is never a research/expert source.
+    nongated = [c for c in cards if not c["is_gated"]]
+    assert all(c["source_type"] not in ("research", "expert") for c in nongated)
+    # Preprint flag rides along for the badge.
+    assert any(c["is_preprint"] for c in gated if c["title"] == "AI preprint")

--- a/backend/tests/integration/test_phase2_discover.py
+++ b/backend/tests/integration/test_phase2_discover.py
@@ -52,3 +52,30 @@ async def test_deck_surfaces_gated_sources_as_optin(aclient, db_session):
     assert all(c["source_type"] not in ("research", "expert") for c in nongated)
     # Preprint flag rides along for the badge.
     assert any(c["is_preprint"] for c in gated if c["title"] == "AI preprint")
+
+
+async def test_gated_slots_capped_at_five(aclient, db_session):
+    """With more gated sources than the cap, the deck admits exactly discover_gated_slots (5) of
+    them; the remaining ~20 cards are all non-gated news. Guards the LIMIT against a silent widening."""
+    await _profession_less(db_session)
+    for i in range(8):  # 8 gated sources > the cap of 5
+        await _src_with_article(db_session, f"journal{i}", SourceType.research, f"Paper {i}",
+                                category="research", credibility_score=90, audience=["medicine"])
+    for i in range(10):  # plenty of news to fill the rest
+        await _src_with_article(db_session, f"news{i}", SourceType.wire, f"News {i}")
+
+    cards = (await aclient.get("/discover/deck")).json()
+    gated = [c for c in cards if c["is_gated"]]
+    assert len(gated) == 5  # exactly the cap, not all 8
+    assert all(c["source_type"] not in ("research", "expert") for c in cards if not c["is_gated"])
+
+
+async def test_deck_is_all_news_when_no_gated_sources(aclient, db_session):
+    """No research/expert sources at all → a full, non-empty news deck (the 25 - 0 split is valid)."""
+    await _profession_less(db_session)
+    for i in range(6):
+        await _src_with_article(db_session, f"news{i}", SourceType.wire, f"News {i}")
+
+    cards = (await aclient.get("/discover/deck")).json()
+    assert len(cards) == 6
+    assert all(not c["is_gated"] for c in cards)

--- a/backend/tests/integration/test_phase2_filter.py
+++ b/backend/tests/integration/test_phase2_filter.py
@@ -56,3 +56,33 @@ async def test_invalid_source_type_is_400(aclient, db_session):
     await _seed(db_session)
     r = await aclient.get("/feed?source_type=bogus")
     assert r.status_code == 400
+
+
+async def test_source_type_filter_composes_with_follow_override(aclient, db_session):
+    """A followed research source (opt-in past the gate) must still obey the type filter: it appears
+    under ?source_type=research but NOT under ?source_type=news. Guards that the follow-override
+    bypasses the persona gate WITHOUT bypassing the orthogonal source-type filter."""
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = None  # profession-less → research only visible via the follow
+    news = Source(name="Reuters", url="https://reuters.example", rss_url="https://reuters.example/rss",
+                  source_type=SourceType.wire, region="global", category="world")
+    research = Source(name="NEJM", url="https://nejm.example", rss_url="https://nejm.example/rss",
+                      source_type=SourceType.research, region="global", category="research",
+                      credibility_score=98, audience=["medicine"])
+    db_session.add_all([news, research])
+    await db_session.flush()
+    db_session.add_all([
+        Article(title="News item", url="https://reuters.example/a1", source_id=news.id,
+                snippet="news snippet long enough here.", published_at=datetime(2026, 7, 3, tzinfo=timezone.utc)),
+        Article(title="Research item", url="https://nejm.example/a1", source_id=research.id,
+                snippet="research snippet long enough.", published_at=datetime(2026, 7, 3, 1, tzinfo=timezone.utc)),
+    ])
+    await db_session.flush()
+    await aclient.post("/follows", json={"kind": "source", "value": str(research.id)})
+
+    assert await _titles(aclient, "&source_type=research") == {"Research item"}
+    news_titles = await _titles(aclient, "&source_type=news")
+    assert "News item" in news_titles and "Research item" not in news_titles  # follow ≠ filter bypass

--- a/backend/tests/integration/test_phase2_filter.py
+++ b/backend/tests/integration/test_phase2_filter.py
@@ -1,0 +1,58 @@
+"""Phase 2 · #82 — feed source-type filter (GET /feed?source_type=news|research|expert)."""
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+
+from app.models import Article, Source, SourceType, User
+
+
+async def _seed(db_session):
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = "Cardiologist"  # so the medicine-tagged research source is visible
+    news = Source(name="Reuters", url="https://reuters.example", rss_url="https://reuters.example/rss",
+                  source_type=SourceType.wire, region="global", category="world")
+    research = Source(name="NEJM", url="https://nejm.example", rss_url="https://nejm.example/rss",
+                      source_type=SourceType.research, region="global", category="research",
+                      credibility_score=98, audience=["medicine"])
+    db_session.add_all([news, research])
+    await db_session.flush()
+    db_session.add_all([
+        Article(title="News item", url="https://reuters.example/a1", source_id=news.id,
+                snippet="news snippet long enough here.", published_at=datetime(2026, 7, 3, tzinfo=timezone.utc)),
+        Article(title="Research item", url="https://nejm.example/a1", source_id=research.id,
+                snippet="research snippet long enough.", published_at=datetime(2026, 7, 3, 1, tzinfo=timezone.utc)),
+    ])
+    await db_session.flush()
+
+
+async def _titles(aclient, qs=""):
+    r = await aclient.get(f"/feed?per_page=50{qs}")
+    assert r.status_code == 200
+    return {a["title"] for a in r.json()["articles"]}
+
+
+async def test_filter_research_returns_only_research(aclient, db_session):
+    await _seed(db_session)
+    t = await _titles(aclient, "&source_type=research")
+    assert t == {"Research item"}
+
+
+async def test_filter_news_excludes_gated(aclient, db_session):
+    await _seed(db_session)
+    t = await _titles(aclient, "&source_type=news")
+    assert "News item" in t and "Research item" not in t
+
+
+async def test_no_filter_returns_all_visible(aclient, db_session):
+    await _seed(db_session)
+    t = await _titles(aclient)  # doctor sees both
+    assert {"News item", "Research item"} <= t
+
+
+async def test_invalid_source_type_is_400(aclient, db_session):
+    await _seed(db_session)
+    r = await aclient.get("/feed?source_type=bogus")
+    assert r.status_code == 400

--- a/backend/tests/integration/test_phase2_follow_source.py
+++ b/backend/tests/integration/test_phase2_follow_source.py
@@ -1,0 +1,95 @@
+"""Phase 2 · #81 — follow a source to opt in past the persona gate.
+
+`follows.kind="source"` (value = source id). A followed source bypasses BOTH the audience match and
+the credibility floor (explicit opt-in = explicit intent), in the feed and the briefing.
+"""
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+
+from app.models import Article, Source, SourceType, User
+
+
+async def _gated(db_session, name, score, audience, source_type=SourceType.research):
+    s = Source(name=name, url=f"https://{name}.example", rss_url=f"https://{name}.example/rss",
+               source_type=source_type, region="global", category="research",
+               credibility_score=score, audience=list(audience))
+    db_session.add(s)
+    await db_session.flush()
+    db_session.add(Article(title=f"{name} story", url=f"https://{name}.example/a1", source_id=s.id,
+                           snippet="A long enough snippet for the card body text here.",
+                           published_at=datetime(2026, 7, 3, tzinfo=timezone.utc)))
+    await db_session.flush()
+    return s
+
+
+async def _profession_less(db_session):
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = None
+    await db_session.flush()
+
+
+async def _feed_titles(aclient):
+    r = await aclient.get("/feed?per_page=50")
+    assert r.status_code == 200
+    return {a["title"] for a in r.json()["articles"]}
+
+
+async def test_following_a_source_reveals_it_in_feed(aclient, db_session):
+    await _profession_less(db_session)
+    nejm = await _gated(db_session, "NEJM", 98, ["medicine"])
+
+    assert "NEJM story" not in await _feed_titles(aclient)  # gated out for a non-doctor
+
+    r = await aclient.post("/follows", json={"kind": "source", "value": str(nejm.id)})
+    assert r.status_code == 201
+
+    assert "NEJM story" in await _feed_titles(aclient)  # follow bypasses the gate
+
+
+async def test_unfollowing_reverts_the_gate(aclient, db_session):
+    await _profession_less(db_session)
+    nejm = await _gated(db_session, "NEJM", 98, ["medicine"])
+    fid = (await aclient.post("/follows", json={"kind": "source", "value": str(nejm.id)})).json()["id"]
+    assert "NEJM story" in await _feed_titles(aclient)
+
+    assert (await aclient.delete(f"/follows/{fid}")).status_code == 204
+    assert "NEJM story" not in await _feed_titles(aclient)  # gate restored
+
+
+async def test_follow_overrides_the_credibility_floor(aclient, db_session):
+    """A followed source below the feed floor (Zvi at 54) still appears — explicit opt-in wins."""
+    await _profession_less(db_session)
+    zvi = await _gated(db_session, "Zvi", 54, ["ai"], source_type=SourceType.expert)  # 54 < floor 55
+    assert "Zvi story" not in await _feed_titles(aclient)
+
+    await aclient.post("/follows", json={"kind": "source", "value": str(zvi.id)})
+    assert "Zvi story" in await _feed_titles(aclient)
+
+
+async def test_follow_reveals_in_briefing(aclient, db_session, fake_llm):
+    from app.models import ClusterArticle, StoryCluster
+    await _profession_less(db_session)
+    nejm = await _gated(db_session, "NEJM", 98, ["medicine"])
+    art = (await db_session.execute(sa.select(Article).where(Article.source_id == nejm.id))).scalar_one()
+    cl = StoryCluster(title="NEJM story", summary="cached summary", coherence=0.9)
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db_session.flush()
+
+    t0 = {s["title"] for s in (await aclient.get("/briefing")).json()["stories"]}
+    assert "NEJM story" not in t0
+
+    await aclient.post("/follows", json={"kind": "source", "value": str(nejm.id)})
+    t1 = {s["title"] for s in (await aclient.get("/briefing")).json()["stories"]}
+    assert "NEJM story" in t1
+
+
+async def test_source_follow_nonexistent_returns_404(aclient, db_session):
+    await _profession_less(db_session)
+    r = await aclient.post("/follows", json={"kind": "source", "value": "999999"})
+    assert r.status_code == 404

--- a/backend/tests/integration/test_phase2_follow_source.py
+++ b/backend/tests/integration/test_phase2_follow_source.py
@@ -93,3 +93,43 @@ async def test_source_follow_nonexistent_returns_404(aclient, db_session):
     await _profession_less(db_session)
     r = await aclient.post("/follows", json={"kind": "source", "value": "999999"})
     assert r.status_code == 404
+
+
+async def test_source_follow_non_integer_value_is_400(aclient, db_session):
+    await _profession_less(db_session)
+    r = await aclient.post("/follows", json={"kind": "source", "value": "not-a-number"})
+    assert r.status_code == 400  # a source-follow value must be a source id
+
+
+async def test_unfollow_reverts_the_briefing_gate(aclient, db_session, fake_llm):
+    """The briefing must symmetrically restore the gate on unfollow (not just the feed)."""
+    from app.models import ClusterArticle, StoryCluster
+    await _profession_less(db_session)
+    nejm = await _gated(db_session, "NEJM", 98, ["medicine"])
+    art = (await db_session.execute(sa.select(Article).where(Article.source_id == nejm.id))).scalar_one()
+    cl = StoryCluster(title="NEJM story", summary="cached summary", coherence=0.9)
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db_session.flush()
+
+    fid = (await aclient.post("/follows", json={"kind": "source", "value": str(nejm.id)})).json()["id"]
+    assert "NEJM story" in {s["title"] for s in (await aclient.get("/briefing")).json()["stories"]}
+
+    assert (await aclient.delete(f"/follows/{fid}")).status_code == 204
+    assert "NEJM story" not in {s["title"] for s in (await aclient.get("/briefing")).json()["stories"]}
+
+
+async def test_briefing_fallback_path_still_gates_gated_sources(aclient, db_session, fake_llm):
+    """Regression guard for the fallback-leak fix: with NO clusters at all, the briefing's
+    article-fallback must still hide a gated source from a non-matching user — and reveal it on
+    follow. Without the `_allowed` gate on the fallback query, the research article would leak."""
+    await _profession_less(db_session)
+    nejm = await _gated(db_session, "NEJM", 98, ["medicine"])  # article, no cluster
+
+    t0 = {s["title"] for s in (await aclient.get("/briefing")).json()["stories"]}
+    assert "NEJM story" not in t0  # fallback is gated → no leak
+
+    await aclient.post("/follows", json={"kind": "source", "value": str(nejm.id)})
+    t1 = {s["title"] for s in (await aclient.get("/briefing")).json()["stories"]}
+    assert "NEJM story" in t1  # follow reveals it even through the fallback path

--- a/backend/tests/integration/test_phase2_ranking.py
+++ b/backend/tests/integration/test_phase2_ranking.py
@@ -75,6 +75,43 @@ async def test_credibility_cannot_drown_fresher_news(aclient, db_session):
     assert titles.index("Breaking wire story") < titles.index("Older expert analysis")
 
 
+async def test_credibility_score_over_100_is_clamped(aclient, db_session):
+    """An out-of-range stored score (e.g. 150) is clamped to 100 → the ×[0.9,1.1] bound still holds,
+    so a much fresher news story is NOT drowned. Without the clamp, ×1.2 would flip the order."""
+    await _ai_engineer(db_session)
+    now = datetime(2026, 7, 3, 12, tzinfo=timezone.utc)
+    filler = await _news(db_session, "filler")
+    await _article(db_session, filler, "Old filler", now - timedelta(hours=100))
+    huge = await _expert(db_session, "overscored", 150)  # out of range; must be clamped
+    await _article(db_session, huge, "Older over-scored take", now - timedelta(hours=10))
+    news = await _news(db_session, "wire")
+    await _article(db_session, news, "Breaking wire story", now)
+
+    r = await aclient.get("/feed?per_page=20")
+    titles = [a["title"] for a in r.json()["articles"]]
+    assert titles.index("Breaking wire story") < titles.index("Older over-scored take")
+
+
+async def test_audience_null_gated_source_gets_no_field_bonus(aclient, db_session, fake_llm):
+    """The +0.15 bonus requires a real audience match. A general (audience-null) research source is
+    visible to everyone but is NOT "your field" → no bonus → it does not jump the fresher news."""
+    await _set_profession(db_session, None)  # profession-less
+    base = datetime(2026, 7, 3, 12, tzinfo=timezone.utc)
+    general = Source(name="Quanta", url="https://quanta.example", rss_url="https://quanta.example/rss",
+                     source_type=SourceType.research, region="global", category="research",
+                     credibility_score=90, audience=None)  # audience-null → shown to all, no field match
+    db_session.add(general)
+    await db_session.flush()
+    await _cluster(db_session, general, "General science piece", base - timedelta(hours=100))  # oldest
+    for i in range(8):
+        news = await _news(db_session, f"news{i}")
+        await _cluster(db_session, news, f"World story {i}", base - timedelta(hours=i))
+
+    r = await aclient.get("/briefing")
+    titles = {s["title"] for s in r.json()["stories"]}
+    assert "General science piece" not in titles  # no bonus → stays dropped as the oldest
+
+
 # ── #80 briefing bonus ──
 async def _cluster(db_session, source, title, created_at):
     from app.models import ClusterArticle, StoryCluster
@@ -120,5 +157,9 @@ async def test_matched_research_cluster_makes_briefing_top8(aclient, db_session,
 
     r = await aclient.get("/briefing")
     assert r.status_code == 200
-    titles = {s["title"] for s in r.json()["stories"]}
-    assert "New cardiology trial" in titles
+    stories = r.json()["stories"]
+    by_title = {s["title"]: s for s in stories}
+    assert "New cardiology trial" in by_title
+    # #78: the API exposes the gated tier for the badge; news stories carry no tier.
+    assert by_title["New cardiology trial"]["tier"] == "research"
+    assert all(s["tier"] is None for s in stories if s["title"].startswith("World story"))

--- a/backend/tests/integration/test_phase2_ranking.py
+++ b/backend/tests/integration/test_phase2_ranking.py
@@ -1,0 +1,124 @@
+"""Phase 2 · #79 credibility-weighted feed ranking + #80 briefing bonus.
+
+Behavior through /feed and /briefing. The credibility multiplier lives in the feed ranking blend
+(UER path, the default); it nudges ordering within ×[0.9, 1.1] and can never drown fresher news.
+"""
+from datetime import datetime, timedelta, timezone
+
+from app.models import Article, Source, SourceType, User
+
+
+async def _expert(db_session, name, score, *, audience=("ai",)):
+    s = Source(name=name, url=f"https://{name}.example", rss_url=f"https://{name}.example/rss",
+               source_type=SourceType.expert, region="global", category="technology",
+               credibility_score=score, audience=list(audience))
+    db_session.add(s)
+    await db_session.flush()
+    return s
+
+
+async def _article(db_session, source, title, when):
+    a = Article(title=title, url=f"https://{source.name}.example/{title.replace(' ', '-')}",
+                source_id=source.id, snippet="body text goes here for the card.", published_at=when)
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+async def _ai_engineer(db_session):
+    u = (await db_session.execute(
+        __import__("sqlalchemy").select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = "AI Engineer"
+    await db_session.flush()
+
+
+async def test_higher_credibility_ranks_first_at_equal_recency(aclient, db_session):
+    await _ai_engineer(db_session)
+    now = datetime(2026, 7, 3, 12, tzinfo=timezone.utc)
+    high = await _expert(db_session, "highcred", 95)
+    low = await _expert(db_session, "lowcred", 60)
+    # Insert the HIGH-cred article FIRST (lower id) so the existing (recency, pub_ts, id-desc)
+    # tiebreak actively works AGAINST it — only the credibility multiplier can put it on top.
+    await _article(db_session, high, "High cred take", now)
+    await _article(db_session, low, "Low cred take", now)  # higher id → wins id-desc tiebreak
+
+    r = await aclient.get("/feed?per_page=20")
+    assert r.status_code == 200
+    titles = [a["title"] for a in r.json()["articles"]]
+    assert titles.index("High cred take") < titles.index("Low cred take")
+
+
+async def _news(db_session, name):
+    s = Source(name=name, url=f"https://{name}.example", rss_url=f"https://{name}.example/rss",
+               source_type=SourceType.wire, region="global", category="world")  # NULL credibility
+    db_session.add(s)
+    await db_session.flush()
+    return s
+
+
+async def test_credibility_cannot_drown_fresher_news(aclient, db_session):
+    """The ±10% cap means a much fresher news story stays above an older max-credibility expert."""
+    await _ai_engineer(db_session)
+    now = datetime(2026, 7, 3, 12, tzinfo=timezone.utc)
+    filler = await _news(db_session, "filler")   # sets the recency span floor
+    await _article(db_session, filler, "Old filler", now - timedelta(hours=100))
+    expert = await _expert(db_session, "topexpert", 98)
+    await _article(db_session, expert, "Older expert analysis", now - timedelta(hours=10))
+    news = await _news(db_session, "wire")
+    await _article(db_session, news, "Breaking wire story", now)  # freshest, NULL credibility
+
+    r = await aclient.get("/feed?per_page=20")
+    titles = [a["title"] for a in r.json()["articles"]]
+    assert titles.index("Breaking wire story") < titles.index("Older expert analysis")
+
+
+# ── #80 briefing bonus ──
+async def _cluster(db_session, source, title, created_at):
+    from app.models import ClusterArticle, StoryCluster
+    art = Article(title=title, url=f"https://{source.name}.example/{title.replace(' ', '-')}",
+                  source_id=source.id, snippet="A sufficiently long snippet for the story card body.",
+                  published_at=created_at)
+    db_session.add(art)
+    await db_session.flush()
+    cl = StoryCluster(title=title, summary="Cached summary so the briefing skips the LLM.",
+                      coherence=0.9, created_at=created_at)
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db_session.flush()
+    return cl
+
+
+async def _set_profession(db_session, profession):
+    import sqlalchemy as sa
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = profession
+    await db_session.flush()
+
+
+async def test_matched_research_cluster_makes_briefing_top8(aclient, db_session, fake_llm):
+    """A cardiologist's cardiology paper reaches the top-8 even as the OLDEST cluster, because the
+    persona-match bonus lifts it past 8 fresher news clusters (without the bonus it is dropped)."""
+    await _set_profession(db_session, "Cardiologist")
+    base = datetime(2026, 7, 3, 12, tzinfo=timezone.utc)
+    nejm = Source(name="NEJM", url="https://nejm.example", rss_url="https://nejm.example/rss",
+                  source_type=SourceType.research, region="global", category="research",
+                  credibility_score=98, audience=["medicine"])
+    db_session.add(nejm)
+    await db_session.flush()
+    # Oldest cluster of the nine → without the bonus it sorts to position 9 and is dropped.
+    await _cluster(db_session, nejm, "New cardiology trial", base - timedelta(hours=100))
+    for i in range(8):  # 8 fresher news clusters
+        news = await _news(db_session, f"news{i}")
+        await _cluster(db_session, news, f"World story {i}", base - timedelta(hours=i))
+
+    r = await aclient.get("/briefing")
+    assert r.status_code == 200
+    titles = {s["title"] for s in r.json()["stories"]}
+    assert "New cardiology trial" in titles

--- a/backend/tests/integration/test_source_expansion.py
+++ b/backend/tests/integration/test_source_expansion.py
@@ -203,3 +203,12 @@ async def test_admin_create_expert_with_credibility_persists_tier_fields(aclient
     assert s.credibility_score == 84 and s.author_name == "Brian Potter"
     assert s.audience == ["science", "business"]
     assert (s.credibility_meta or {}).get("reviewed_by") == "admin"  # human-published ⇒ locked
+
+
+async def test_admin_rejects_out_of_range_credibility(aclient):
+    """A score outside 0-100 would break the ×[0.9,1.1] feed-rank bound → rejected at the boundary."""
+    r = await aclient.post("/admin/sources", json={
+        "name": "Overscored", "url": "https://overscored.example",
+        "source_type": "expert", "credibility_score": 500,
+    })
+    assert r.status_code == 400

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -9,6 +9,7 @@ import {
   getDiscoverDeck,
   recordSwipe,
   getTopicCards,
+  addFollow,
   type DiscoverCard as DiscoverCardType,
 } from "@/lib/api";
 
@@ -80,6 +81,12 @@ export default function DiscoverPage() {
       setTotalSwiped((prev) => prev + 1);
 
       recordSwipe(card.article_id, direction).catch(() => {});
+
+      // #83: a right swipe on a gated (research/expert) card also follows the source — the
+      // frictionless opt-in. Idempotent server-side, so a repeat swipe is harmless.
+      if (direction === "right" && card.is_gated && card.source_id != null) {
+        addFollow("source", String(card.source_id)).catch(() => {});
+      }
 
       if (direction === "up" && card.topic_id > 0) {
         try {

--- a/frontend/src/components/DeepDiveView.tsx
+++ b/frontend/src/components/DeepDiveView.tsx
@@ -283,6 +283,11 @@ export default function DeepDiveView({
                     isFree={sourceCard.is_free}
                     publishedAt={sourceCard.article.published_at}
                     index={index}
+                    sourceId={sourceCard.article.source.id}
+                    sourceType={sourceCard.article.source.source_type}
+                    authorName={sourceCard.article.source.author_name}
+                    credibilityScore={sourceCard.article.source.credibility_score}
+                    isPreprint={sourceCard.article.source.is_preprint}
                   />
                 ))}
               </div>

--- a/frontend/src/components/DiscoverCard.test.tsx
+++ b/frontend/src/components/DiscoverCard.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/api", () => ({ addFollow: vi.fn() }));
+
+import { DiscoverCard } from "./DiscoverCard";
+import { addFollow } from "@/lib/api";
+import type { DiscoverCard as DiscoverCardType } from "@/lib/api";
+
+const gated: DiscoverCardType = {
+  id: 1, article_id: 10, title: "AI preprint", tension_line: "AI preprint",
+  facts: ["fact one"], sources: ["arXiv"], topic_id: 0, topic_name: "technology",
+  coherence: 0.8, source_id: 9, source_type: "expert", is_gated: true,
+  is_preprint: false, author_name: "Ethan Mollick", credibility_score: 92,
+};
+const news: DiscoverCardType = {
+  ...gated, id: 2, title: "World news", sources: ["Reuters"],
+  source_id: 3, source_type: "wire", is_gated: false, author_name: null, credibility_score: null,
+};
+
+describe("DiscoverCard gated opt-in (Phase 2 · #78/#83)", () => {
+  beforeEach(() => vi.mocked(addFollow).mockResolvedValue({ id: 1, kind: "source", value: "9" }));
+
+  it("badges a gated card and offers Follow source", async () => {
+    render(<DiscoverCard card={gated} onSwipe={() => {}} isTop stackIndex={0} />);
+    expect(screen.getByText("EXPERT")).toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: /follow source/i });
+    await userEvent.click(btn);
+    expect(addFollow).toHaveBeenCalledWith("source", "9");
+  });
+
+  it("shows no follow affordance or tier badge for a news card", () => {
+    render(<DiscoverCard card={news} onSwipe={() => {}} isTop stackIndex={0} />);
+    expect(screen.queryByRole("button", { name: /follow source/i })).toBeNull();
+    expect(screen.queryByText("EXPERT")).toBeNull();
+    expect(screen.queryByText("RESEARCH")).toBeNull();
+  });
+});

--- a/frontend/src/components/DiscoverCard.tsx
+++ b/frontend/src/components/DiscoverCard.tsx
@@ -6,10 +6,11 @@ import {
   useTransform,
   type PanInfo,
 } from "framer-motion";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { Badge } from "@/components/ui/Badge";
+import { SourceTierBadge } from "@/components/ui/SourceTierBadge";
 import { cn } from "@/lib/utils";
-import type { DiscoverCard as DiscoverCardType } from "@/lib/api";
+import { addFollow, type DiscoverCard as DiscoverCardType } from "@/lib/api";
 
 interface DiscoverCardProps {
   card: DiscoverCardType;
@@ -75,6 +76,23 @@ export function DiscoverCard({
     [onSwipe]
   );
 
+  // #83: discover is the opt-in surface for gated tiers. A lightweight, optimistic follow (no
+  // getFollows round-trip — 25 cards mount at once; addFollow is idempotent server-side).
+  const [followed, setFollowed] = useState(false);
+  const followSource = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (followed || card.source_id == null) return;
+      setFollowed(true);
+      try {
+        await addFollow("source", String(card.source_id));
+      } catch {
+        setFollowed(false);
+      }
+    },
+    [followed, card.source_id]
+  );
+
   return (
     <motion.div
       className={cn(
@@ -120,11 +138,20 @@ export function DiscoverCard({
 
       {/* Card content — fills the card; no competing height math */}
       <div className={cn("p-4 flex flex-col h-full", !isTop && "invisible")}>
-        {/* Header: topic badge + agreement */}
+        {/* Header: topic badge (+ tier badge) + agreement */}
         <div className="flex items-center justify-between gap-2">
-          <Badge variant="topic" size="md" color={topicColor}>
-            {card.topic_name}
-          </Badge>
+          <span className="flex items-center gap-1.5 flex-wrap min-w-0">
+            <Badge variant="topic" size="md" color={topicColor}>
+              {card.topic_name}
+            </Badge>
+            {/* #78: provenance badge — nothing for a news card. */}
+            <SourceTierBadge
+              sourceType={card.source_type}
+              authorName={card.author_name}
+              credibilityScore={card.credibility_score}
+              isPreprint={card.is_preprint}
+            />
+          </span>
           <span className="text-mono inline-flex items-center gap-1.5" style={{ color: aColor }}>
             {pct}%
             <span className="inline-flex items-center gap-[2px]" aria-hidden="true">
@@ -173,6 +200,24 @@ export function DiscoverCard({
             <span className="text-mono text-[10px] px-2 py-0.5 rounded-full bg-[var(--surface-raised)] text-[var(--text-muted)]">
               +{card.sources.length - 3}
             </span>
+          )}
+          {/* #83: opt-in "Follow source" for gated cards. stop pointer-capture so the tap never
+              starts a drag/swipe. */}
+          {card.is_gated && card.source_id != null && (
+            <button
+              type="button"
+              onPointerDownCapture={(e) => e.stopPropagation()}
+              onClick={followSource}
+              aria-pressed={followed}
+              className={cn(
+                "ml-auto text-mono text-[10px] px-2.5 py-1 rounded-full border transition-colors",
+                followed
+                  ? "border-[var(--accent-muted)] bg-[var(--accent-subtle)] text-[var(--accent)]"
+                  : "border-[var(--border)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+              )}
+            >
+              {followed ? "Following" : "Follow source"}
+            </button>
           )}
         </div>
       </div>

--- a/frontend/src/components/SourceCard.test.tsx
+++ b/frontend/src/components/SourceCard.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// SourceCard renders a FollowButton, which self-fetches follows on mount.
+vi.mock("@/lib/api", () => ({
+  getFollows: vi.fn(),
+  addFollow: vi.fn(),
+  removeFollow: vi.fn(),
+}));
+
+import { SourceCard } from "./SourceCard";
+import { getFollows } from "@/lib/api";
+
+const base = {
+  sourceName: "NEJM",
+  url: "https://nejm.example/a",
+  snippet: "A source excerpt.",
+  isFree: true,
+};
+
+describe("SourceCard tier badges + follow (Phase 2 · #78/#81)", () => {
+  beforeEach(() => vi.mocked(getFollows).mockResolvedValue([]));
+
+  it("badges a research source and offers a source-follow", () => {
+    render(<SourceCard {...base} sourceType="research" sourceId={7} isPreprint />);
+    expect(screen.getByText("RESEARCH")).toBeInTheDocument();
+    expect(screen.getByText("PREPRINT")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /follow/i })).toBeInTheDocument();
+  });
+
+  it("badges an expert source with author + score", () => {
+    render(
+      <SourceCard {...base} sourceName="Stratechery" sourceType="expert"
+        authorName="Ben Thompson" credibilityScore={88} sourceId={9} />
+    );
+    expect(screen.getByText("EXPERT")).toBeInTheDocument();
+    expect(screen.getByText(/Ben Thompson/)).toBeInTheDocument();
+    expect(screen.getByText(/88/)).toBeInTheDocument();
+  });
+
+  it("shows no tier badge and no follow control for a plain news source", () => {
+    render(<SourceCard {...base} sourceName="Reuters" sourceType="wire" sourceId={3} />);
+    expect(screen.queryByText("RESEARCH")).toBeNull();
+    expect(screen.queryByText("EXPERT")).toBeNull();
+    expect(screen.queryByRole("button", { name: /follow/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/SourceCard.tsx
+++ b/frontend/src/components/SourceCard.tsx
@@ -2,6 +2,8 @@
 
 import { motion } from "framer-motion";
 import { Badge } from "@/components/ui/Badge";
+import { FollowButton } from "@/components/ui/FollowButton";
+import { SourceTierBadge } from "@/components/ui/SourceTierBadge";
 
 interface SourceCardProps {
   sourceName: string;
@@ -10,6 +12,12 @@ interface SourceCardProps {
   isFree: boolean;
   publishedAt?: string | null;
   index?: number;
+  // Phase 2 · #78/#81 — gated-tier provenance + opt-in follow (null/absent for plain news sources).
+  sourceId?: number | null;
+  sourceType?: string | null;
+  authorName?: string | null;
+  credibilityScore?: number | null;
+  isPreprint?: boolean;
 }
 
 function getInitial(name: string): string {
@@ -40,9 +48,15 @@ export function SourceCard({
   isFree,
   publishedAt,
   index = 0,
+  sourceId,
+  sourceType,
+  authorName,
+  credibilityScore,
+  isPreprint,
 }: SourceCardProps) {
   const avatarColor = getAvatarColor(sourceName);
   const borderColor = isFree ? "var(--agree)" : "var(--accent)";
+  const isGated = sourceType === "research" || sourceType === "expert";
 
   return (
     <motion.div
@@ -67,13 +81,20 @@ export function SourceCard({
             {getInitial(sourceName)}
           </div>
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
               <span className="text-small font-semibold text-[var(--text-primary)] truncate">
                 {sourceName}
               </span>
               <Badge variant={isFree ? "free" : "paywall"} size="sm">
                 {isFree ? "FREE" : "PAYWALL"}
               </Badge>
+              {/* #78: provenance badges — nothing rendered for a plain news source. */}
+              <SourceTierBadge
+                sourceType={sourceType}
+                authorName={authorName}
+                credibilityScore={credibilityScore}
+                isPreprint={isPreprint}
+              />
             </div>
             {publishedAt && (
               <span className="text-mono text-[var(--text-ghost)]">
@@ -84,6 +105,10 @@ export function SourceCard({
               </span>
             )}
           </div>
+          {/* #81: opt-in follow — only for gated tiers (following a news source is a no-op). */}
+          {isGated && sourceId != null && (
+            <FollowButton kind="source" value={String(sourceId)} label="Follow source" className="shrink-0" />
+          )}
         </div>
 
         {/* Excerpt */}

--- a/frontend/src/components/StoryCard.test.tsx
+++ b/frontend/src/components/StoryCard.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StoryCard } from "./StoryCard";
+import type { BriefingStory } from "@/lib/api";
+
+const base: BriefingStory = {
+  title: "A story", summary: "Summary text.", cluster_id: 1, category: "world",
+  source_count: 2, coherence: 0.9, is_read: true,
+};
+
+describe("StoryCard tier badge (Phase 2 · #78)", () => {
+  it("shows a RESEARCH badge for a research-tier story", () => {
+    render(<StoryCard story={{ ...base, title: "Cardiology trial", tier: "research" }} />);
+    expect(screen.getByText("RESEARCH")).toBeInTheDocument();
+  });
+
+  it("shows no tier badge for an ordinary news story", () => {
+    render(<StoryCard story={{ ...base, tier: null }} />);
+    expect(screen.queryByText("RESEARCH")).toBeNull();
+    expect(screen.queryByText("EXPERT")).toBeNull();
+  });
+});

--- a/frontend/src/components/StoryCard.tsx
+++ b/frontend/src/components/StoryCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { Badge } from "@/components/ui/Badge";
 import { ConfidenceScore } from "@/components/ui/ConfidenceScore";
+import { SourceTierBadge } from "@/components/ui/SourceTierBadge";
 import { articleHref, cn, relativeTime, storyHref } from "@/lib/utils";
 import type { BriefingStory } from "@/lib/api";
 
@@ -94,6 +95,8 @@ export function StoryCard({ story }: StoryCardProps) {
               />
             </span>
             <span className="flex items-center gap-1.5">
+              {/* #78: "for your field" cue — RESEARCH/EXPERT badge on gated-tier stories. */}
+              <SourceTierBadge sourceType={story.tier} />
               {story.region && story.region !== story.category && (
                 <Badge variant="outline" size="sm">
                   {story.region.toUpperCase()}

--- a/frontend/src/components/ui/FollowButton.tsx
+++ b/frontend/src/components/ui/FollowButton.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { addFollow, getFollows, removeFollow, type FollowItem } from "@/lib/api";
 
 // The API client types `kind` as a plain string; constrain it here for the UI.
-type FollowKind = "topic" | "entity" | "saved_search";
+type FollowKind = "topic" | "entity" | "saved_search" | "source";
 
 interface FollowButtonProps {
   kind: FollowKind;

--- a/frontend/src/components/ui/SourceTierBadge.test.tsx
+++ b/frontend/src/components/ui/SourceTierBadge.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SourceTierBadge } from "./SourceTierBadge";
+
+describe("SourceTierBadge (Phase 2 · #78)", () => {
+  it("shows a RESEARCH badge for a research source", () => {
+    render(<SourceTierBadge sourceType="research" />);
+    expect(screen.getByText("RESEARCH")).toBeInTheDocument();
+  });
+
+  it("shows EXPERT with author and credibility score", () => {
+    render(
+      <SourceTierBadge sourceType="expert" authorName="Ben Thompson" credibilityScore={88} />
+    );
+    expect(screen.getByText("EXPERT")).toBeInTheDocument();
+    expect(screen.getByText(/Ben Thompson/)).toBeInTheDocument();
+    expect(screen.getByText(/88/)).toBeInTheDocument();
+  });
+
+  it("adds a PREPRINT · not peer-reviewed badge for preprints", () => {
+    render(<SourceTierBadge sourceType="research" isPreprint />);
+    expect(screen.getByText("PREPRINT")).toBeInTheDocument();
+    expect(screen.getByText(/not peer-reviewed/)).toBeInTheDocument();
+  });
+
+  it("renders nothing for a plain news source", () => {
+    const { container } = render(<SourceTierBadge sourceType="wire" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the tier is unknown/null", () => {
+    const { container } = render(<SourceTierBadge sourceType={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/ui/SourceTierBadge.tsx
+++ b/frontend/src/components/ui/SourceTierBadge.tsx
@@ -1,0 +1,66 @@
+import { Badge } from "@/components/ui/Badge";
+
+/**
+ * Phase 2 · #78 — provenance badges for the gated source tiers.
+ *   research → RESEARCH   ·   expert → EXPERT · <author> · <score>   ·   preprint → PREPRINT · not peer-reviewed
+ * A plain news source (or an unknown/NULL tier) renders nothing, so news cards are visually unchanged.
+ */
+interface SourceTierBadgeProps {
+  sourceType?: string | null;
+  authorName?: string | null;
+  credibilityScore?: number | null;
+  isPreprint?: boolean;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function SourceTierBadge({
+  sourceType,
+  authorName,
+  credibilityScore,
+  isPreprint,
+  size = "sm",
+  className,
+}: SourceTierBadgeProps) {
+  const isResearch = sourceType === "research";
+  const isExpert = sourceType === "expert";
+  if (!isResearch && !isExpert) return null;
+
+  // Author + score ride alongside the uppercase chip as normal-case mono text (the Badge itself
+  // upper-cases, which would mangle a name like "Ben Thompson").
+  const meta = [authorName, credibilityScore != null ? String(credibilityScore) : null]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${className ?? ""}`}>
+      {isResearch && (
+        <Badge variant="signal" size={size}>
+          RESEARCH
+        </Badge>
+      )}
+      {isExpert && (
+        <>
+          <Badge variant="accent" size={size}>
+            EXPERT
+          </Badge>
+          {meta && (
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-[var(--text-muted)]">
+              {meta}
+            </span>
+          )}
+        </>
+      )}
+      {isPreprint && (
+        <span className="inline-flex items-center gap-1.5">
+          <Badge variant="outline" size={size}>
+            PREPRINT
+          </Badge>
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-[var(--text-ghost)]">
+            not peer-reviewed
+          </span>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -48,6 +48,11 @@ export interface Source {
   name: string;
   url: string;
   is_paywalled: boolean;
+  // Phase 2 · #78 — gated-tier provenance (null for plain news sources).
+  source_type?: string | null;
+  author_name?: string | null;
+  credibility_score?: number | null;
+  is_preprint?: boolean;
 }
 
 export interface Article {
@@ -86,6 +91,8 @@ export interface BriefingStory {
   is_read?: boolean;
   // E6/Wave Q1: best-effort WIIFM one-liner ("why you're seeing this"), when cached
   impact_headline?: string | null;
+  // Phase 2 · #78 — "research"/"expert" for a gated-tier story (→ RESEARCH/EXPERT badge). null for news.
+  tier?: string | null;
 }
 
 export interface ArticleDetail {
@@ -147,6 +154,14 @@ export interface DiscoverCard {
   topic_id: number;
   topic_name: string;
   coherence: number;
+  // Phase 2 · #83 — gated-tier opt-in surface: a research/expert card carries its source so the UI
+  // can badge it and offer "Follow source". null/false for the news cards that fill the rest.
+  source_id?: number | null;
+  source_type?: string | null;
+  is_gated?: boolean;
+  is_preprint?: boolean;
+  author_name?: string | null;
+  credibility_score?: number | null;
 }
 
 export interface FeedResponse {
@@ -180,13 +195,16 @@ export async function getBriefing(): Promise<Briefing> {
 export async function getFeed(
   page = 1,
   perPage = 20,
-  topicId?: number
+  topicId?: number,
+  // Phase 2 · #82 — source-type filter: "news" | "research" | "expert" (omit/"all" = every tier).
+  sourceType?: string
 ): Promise<FeedResponse> {
   const params = new URLSearchParams({
     page: String(page),
     per_page: String(perPage),
   });
   if (topicId) params.set("topic", String(topicId));
+  if (sourceType && sourceType !== "all") params.set("source_type", sourceType);
   return fetchJSON(`/feed?${params}`);
 }
 


### PR DESCRIPTION
## What

Phase 2 of the source-expansion plan — **badges + ranking + opt-in**. Closes #78 #79 #80 #81 #83 and partially #82. Built test-first (`to-issues` → red→green per slice), then hardened by a multi-agent adversarial review.

> **Stacked on #77 (Phase 1).** Base is the Phase-1 branch so this diff is Phase-2-only. Retarget to `master` once #77 merges.

## Issues → slices

| # | Slice | Where |
|---|-------|-------|
| #78 | `RESEARCH` / `EXPERT·author·score` / `PREPRINT·not peer-reviewed` badges | SourceCard, DiscoverCard, briefing StoryCard (new `BriefingStory.tier`) |
| #79 | Credibility-weighted feed ranking — bounded ×[0.9,1.1] blend, news→neutral 75 | `get_feed` |
| #80 | "For your field" briefing bonus — +0.15 for a persona-matched gated cluster | `get_briefing` |
| #81 | Follow a source — `follows.kind="source"`, bypasses **both** floor & audience | `allowed_source_ids` + feed/briefing + SourceCard control |
| #82 | `?source_type=` filter | **backend + api client only** — see deferral |
| #83 | Discover opt-in — ≤5 reserved gated cards + "Follow source" (tap or swipe-right) | `get_discover_deck` + DiscoverCard |

## Notable

- **Closed a real gating leak found mid-build:** the briefing article-*fallback* had no persona gate, so a profession-less user with sparse content could leak gated research. Now gated + regression-guarded.
- **Follow = explicit intent:** following a gated source overrides the credibility floor too (same principle as search never being gated).
- **#82 UI deferred (honest):** `GET /feed` isn't rendered anywhere (home is the briefing), so the filter chips have no host screen. Backend + `getFeed(sourceType)` are done; chips need a feed screen first. Noted on #82.

## Adversarial review (multi-agent)

Ran a 5-dimension review (gating-leak · ranking-math · backend-correctness · frontend · test-coverage), each finding adversarially verified. **The three security-critical reviewers returned clean.** Acted on:
- **1 real defect:** `_cred_mult` was unclamped — a stored score >100 (admin write) would break the ×[0.9,1.1] bound. Clamped at the point of use **and** rejected at the write boundary (400).
- **11 confirmed regression guards** added (filter×follow composition, fallback-gate leak, audience-null "no bonus", unfollow-reverts-briefing, tier contract, discover cap, 400 validation, …).

## Verification

- Backend **302 passed** / 1 skipped · Frontend **63 passed** · `lint:copy` 0 errors · production build clean
- Migration parity unaffected (Phase 2 is code-only; no new migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)