### PR TITLE
Phase 3: credibility ops + personal research feeds [TDD]

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -125,8 +125,9 @@ async def get_feed(
     # Phase 1: persona-gate the research/expert tiers — a source is in the feed only if it's news,
     # or clears the credibility floor and matches the user's profession-derived audience tags.
     from app.services import audience as _audience
-    _profession, _ = await _user_profession_locale(db)
-    _tags = _audience.tags_for_profession(_profession)
+    _profession, _, _pv = await _user_profession_locale(db)
+    # #88: keyword map first, LLM fallback for the long tail (cached on persona_version).
+    _tags = await _audience.resolve_tags(_profession, user_id=current_user_id(), persona_version=_pv)
     _followed = await _audience.followed_source_ids(db, current_user_id())  # #81 opt-in override
     query = query.where(
         Article.source_id.in_(
@@ -591,8 +592,9 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
     # cardiology paper from everyone except doctors, at the briefing floor.
     from sqlalchemy import exists as _sa_exists
     from app.services import audience as _audience
-    _profession, _ = await _user_profession_locale(db)
-    _tags = _audience.tags_for_profession(_profession)  # #80: for the "in your field" bonus below
+    _profession, _, _pv = await _user_profession_locale(db)
+    # #80/#88: keyword map first, LLM fallback for the long tail (cached on persona_version).
+    _tags = await _audience.resolve_tags(_profession, user_id=current_user_id(), persona_version=_pv)
     _followed = await _audience.followed_source_ids(db, current_user_id())  # #81 opt-in override
     _allowed = _audience.allowed_source_ids(
         _tags, floor=app_settings.credibility_briefing_floor, followed_source_ids=_followed
@@ -1272,7 +1274,11 @@ async def _user_profession_locale(db: AsyncSession):
     u = (
         await db.execute(select(User).where(User.id == current_user_id()))
     ).scalar_one_or_none()
-    return (u.profession if u else None), (u.locale if u and u.locale else "IN")
+    return (
+        (u.profession if u else None),
+        (u.locale if u and u.locale else "IN"),
+        (u.persona_version if u and u.persona_version else 1),  # #88 cache key for the LLM classifier
+    )
 
 
 async def _user_persona(db: AsyncSession) -> dict:
@@ -1496,7 +1502,7 @@ async def cluster_analysis(
 
     if lens not in ("key_facts", "5ws", "profession"):
         raise HTTPException(status_code=400, detail="invalid lens")
-    profession, _ = await _user_profession_locale(db)
+    profession, _, _ = await _user_profession_locale(db)
     # Depth toggle (Brief/Standard/Expert) genuinely changes retrieval budget + answer style.
     u = (
         await db.execute(select(User).where(User.id == current_user_id()))
@@ -1843,6 +1849,34 @@ async def create_source(body: dict, db: AsyncSession = Depends(get_db)):
     db.add(s)
     await db.commit()
     return {"id": s.id, "name": s.name, "updated": False}
+
+
+@router.put("/admin/sources/{source_id}/credibility", dependencies=[Depends(get_current_user)])
+async def apply_credibility(source_id: int, body: dict, db: AsyncSession = Depends(get_db)):
+    """Phase 3 · #85 — the human half of the credibility-review loop. An admin applies a (proposed
+    or corrected) score; we stamp credibility_meta.reviewed_by="admin", which locks the row against
+    the 10-minute seed re-upsert (fetcher._upsert_sources), so a manual correction is never silently
+    clobbered by sources.json."""
+    from fastapi import HTTPException
+
+    score = body.get("credibility_score")
+    if score is None or not (0 <= score <= 100):
+        raise HTTPException(status_code=400, detail="credibility_score must be between 0 and 100")
+
+    source = (await db.execute(select(Source).where(Source.id == source_id))).scalar_one_or_none()
+    if source is None:
+        raise HTTPException(status_code=404, detail="source not found")
+
+    # Merge into existing meta so the LLM proposal / rationale / affiliation history is preserved.
+    meta = dict(source.credibility_meta or {})
+    meta["reviewed_by"] = "admin"
+    meta["applied_score"] = score
+    if body.get("rationale"):
+        meta["rationale"] = body["rationale"]
+    source.credibility_score = score
+    source.credibility_meta = meta
+    await db.commit()
+    return {"id": source.id, "credibility_score": score, "reviewed_by": "admin"}
 
 
 # ── E4: hybrid search (semantic + keyword; keyword ranks above semantic-only) ──

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -88,6 +88,7 @@ class Settings(BaseSettings):
     graph_salience_floor: float = 0.3          # drop entities below this salience at extraction
     graph_extract_batch_size: int = 20         # clusters per backfill run
     graph_extract_min_sources: int = 2         # only extract "settled" clusters (>= this many sources)
+    graph_extract_research_min_sources: int = 1  # #89: research clusters are singletons → extract at 1
     graph_use_platform_key: bool = True        # extract on the platform key, never the owner's per-user key
     graph_extract_interval_minutes: int = 15   # backfill cadence
 
@@ -121,6 +122,16 @@ class Settings(BaseSettings):
     credibility_rank_neutral: int = 75
     # Phase 2 · #83 — reserved research/expert slots in the ~25-card discover deck (the opt-in surface).
     discover_gated_slots: int = 5
+    # Phase 3 · #90 — a gated source is re-proposed by the monthly LLM review job once its last
+    # review is older than this many days (propose-only; a human applies via the admin endpoint).
+    credibility_review_stale_days: int = 90
+    # Phase 3 · #86 — PubMed personal research feed. E-utilities are usable without a key at a lower
+    # rate; an NCBI api_key raises the ceiling to ~10 req/s (we still self-throttle). No key → the
+    # job runs unauthenticated (still rate-limited). pubmed_enabled=false disables ingestion.
+    ncbi_api_key: str = ""
+    pubmed_enabled: bool = True
+    pubmed_min_request_interval: float = 0.34  # ≤3 req/s (unauthenticated NCBI limit)
+    pubmed_retmax: int = 25                     # papers/specialty/run (mirrors research per_fetch_cap)
     # Phase 2 · #80 — additive story_weights bonus for a persona-matched research/expert cluster, so
     # "research in your field" reliably reaches the briefing top-8 without a singleton dominating.
     credibility_briefing_bonus: float = 0.15

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -150,6 +150,9 @@ async def start_scheduler():
     from app.services.summarizer import backfill_summaries
     from app.services.fetcher import backfill_topic_assignments
     from app.services.entities import backfill_entities
+    from app.services.credibility import review_credibility
+    from app.services.pubmed import ingest_pubmed
+    from app.services.arxiv_gen import generate_arxiv_sources
 
     scheduler = AsyncIOScheduler()
     # One-shot: seed topic embeddings 10s after startup (non-blocking)
@@ -223,6 +226,46 @@ async def start_scheduler():
         max_instances=1,
         coalesce=True,
         misfire_grace_time=300,
+    )
+    # Phase 3 · #90: monthly LLM credibility review (propose-only). 03:00 on the 1st of each month.
+    # Propose-only + admin-lock-preserving, so this never mutates a live score on its own.
+    scheduler.add_job(
+        review_credibility,
+        "cron",
+        day=1,
+        hour=3,
+        id="credibility_review",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=3600,
+    )
+    # Phase 3 · #86: weekly PubMed personal research feed. 04:00 Monday. Ingests fresh abstracts for
+    # each medical profession among the users; no-op when pubmed_enabled=false or no medical user.
+    scheduler.add_job(
+        ingest_pubmed,
+        "cron",
+        day_of_week="mon",
+        hour=4,
+        id="pubmed_ingest",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=3600,
+    )
+    # Phase 3 · #87: weekly arXiv-by-interest source generation. 04:30 Monday. Idempotent — picks up
+    # new interests (subscribed topics) and adds the matching arXiv category feeds; no-op otherwise.
+    scheduler.add_job(
+        generate_arxiv_sources,
+        "cron",
+        day_of_week="mon",
+        hour=4,
+        minute=30,
+        id="arxiv_generate",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=3600,
     )
     scheduler.start()
     logger.info("scheduler_started", jobs=len(scheduler.get_jobs()))

--- a/backend/app/services/arxiv_gen.py
+++ b/backend/app/services/arxiv_gen.py
@@ -1,0 +1,96 @@
+"""Phase 3 · #87 — generate arXiv category feeds from user interests.
+
+Phase 1 seeded four arXiv feeds (cs.AI, cs.LG, econ.GN, q-fin). This maps the interests users
+actually hold (their subscribed topics) to further arXiv categories and ensures those research
+sources exist — so a computer-vision or robotics enthusiast gets that category's preprints. Source
+creation reuses fetcher._upsert_sources, so it's idempotent and honors the admin-lock.
+"""
+import structlog
+from sqlalchemy import select
+
+from app.database import async_session
+from app.models import Source, Topic, UserPreference
+
+logger = structlog.get_logger()
+
+# interest keyword (substring of a topic name) → (arXiv category, audience tags). Categories already
+# seeded in Phase 1 (cs.AI, cs.LG) are intentionally omittable here; _upsert_sources dedups anyway.
+_INTEREST_ARXIV: dict[str, tuple[str, list[str]]] = {
+    "computer vision": ("cs.CV", ["ai", "technology"]),
+    "vision": ("cs.CV", ["ai", "technology"]),
+    "language": ("cs.CL", ["ai"]),
+    "nlp": ("cs.CL", ["ai"]),
+    "robotic": ("cs.RO", ["engineering", "ai"]),
+    "security": ("cs.CR", ["software", "technology"]),
+    "cryptograph": ("cs.CR", ["software", "technology"]),
+    "quantum": ("quant-ph", ["science"]),
+    "biolog": ("q-bio", ["science", "medicine"]),
+    "statistic": ("stat.ML", ["ai", "science"]),
+    "distributed": ("cs.DC", ["software", "technology"]),
+    "systems": ("cs.DC", ["software", "technology"]),
+    "graphics": ("cs.GR", ["technology"]),
+    "database": ("cs.DB", ["software"]),
+}
+
+
+def arxiv_categories_for_interests(interests) -> dict[str, list[str]]:
+    """Map free-text interests to arXiv categories → audience tags (deduped by category)."""
+    out: dict[str, list[str]] = {}
+    for interest in interests or []:
+        if not interest:
+            continue
+        text = f" {interest.lower()} "
+        for kw, (cat, tags) in _INTEREST_ARXIV.items():
+            if kw in text:
+                out[cat] = tags
+    return out
+
+
+def arxiv_source_spec(cat: str, tags: list[str]) -> dict:
+    """A sources.json-shaped spec for an arXiv category feed."""
+    return {
+        "name": f"arXiv {cat}",
+        "url": f"https://arxiv.org/list/{cat}/recent",
+        "rss_url": f"https://rss.arxiv.org/rss/{cat}",
+        "is_paywalled": False,
+        "source_type": "research",
+        "region": "global",
+        "category": "research",
+        "credibility_score": 80,
+        "audience": tags,
+        "is_preprint": True,
+        "per_fetch_cap": 25,
+    }
+
+
+async def generate_arxiv_sources(session=None, interests=None) -> int:
+    """Ensure arXiv sources for the given interests (or all users' subscribed topics). Returns the
+    number of newly-created sources. Idempotent — an existing (or admin-locked) source is untouched."""
+    if session is not None:
+        return await _generate(session, interests)
+    async with async_session() as s:
+        return await _generate(s, interests)
+
+
+async def _generate(session, interests) -> int:
+    from app.services import fetcher  # local import avoids any import cycle at module load
+
+    if interests is None:
+        rows = await session.execute(
+            select(Topic.name).join(UserPreference, UserPreference.topic_id == Topic.id).distinct()
+        )
+        interests = [r[0] for r in rows.all()]
+
+    cats = arxiv_categories_for_interests(interests)
+    if not cats:
+        return 0
+    specs = [arxiv_source_spec(cat, tags) for cat, tags in sorted(cats.items())]
+
+    rss_urls = [s["rss_url"] for s in specs]
+    existing = set(
+        (await session.execute(select(Source.rss_url).where(Source.rss_url.in_(rss_urls)))).scalars().all()
+    )
+    await fetcher._upsert_sources(session, specs)
+    created = sum(1 for u in rss_urls if u not in existing)
+    logger.info("arxiv_sources_generated", categories=len(specs), created=created)
+    return created

--- a/backend/app/services/audience.py
+++ b/backend/app/services/audience.py
@@ -61,10 +61,12 @@ _TAG_SCHEMA = {
 }
 
 
-async def classify_profession_llm(profession: str) -> set[str]:
-    """Map a profession to the FIXED audience-tag vocabulary via the platform LLM. Empty on failure.
+async def classify_profession_llm(profession: str) -> set[str] | None:
+    """Map a profession to the FIXED audience-tag vocabulary via the platform LLM.
 
-    The result is constrained to `_KEYWORDS` keys so the model can never invent a tag no source uses.
+    Returns the tag set on success (constrained to `_KEYWORDS` keys, so the model can never invent a
+    tag no source uses), or None when the LLM CALL FAILED — the caller must not cache a failure as an
+    empty result (that would permanently deny the user their sources until a profile edit / restart).
     """
     from app.services import llm
 
@@ -76,16 +78,19 @@ async def classify_profession_llm(profession: str) -> set[str]:
     )
     try:
         result = await llm.generate(prompt, schema=_TAG_SCHEMA, force_platform_key=True)
-    except Exception:  # noqa: BLE001 — the classifier is a fallback; degrade to keyword-only, never crash
-        return set()
+    except Exception:  # noqa: BLE001 — call failed; signal None so resolve_tags degrades WITHOUT caching
+        return None
     raw = result.get("tags") if isinstance(result, dict) else None
-    return {t for t in (raw or []) if t in _KEYWORDS}
+    # isinstance(str) guard: a malformed tags array (a dict/list element) would otherwise raise
+    # TypeError on `t in _KEYWORDS` — on the feed/briefing HOT PATH. Non-string entries are dropped.
+    return {t for t in (raw or []) if isinstance(t, str) and t in _KEYWORDS}
 
 
 async def resolve_tags(profession: str | None, *, user_id=None, persona_version=None) -> set[str]:
     """Audience tags for a profession: keyword map first (fast, offline), LLM fallback for the tail.
 
-    A keyword hit never calls the LLM. The LLM result is cached on (user_id, persona_version).
+    A keyword hit never calls the LLM. A successful LLM result is cached on (user_id, persona_version);
+    a transient LLM failure is NOT cached, so the next request retries.
     """
     base = tags_for_profession(profession)
     if base:
@@ -96,6 +101,8 @@ async def resolve_tags(profession: str | None, *, user_id=None, persona_version=
     if key in _llm_tag_cache:
         return set(_llm_tag_cache[key])
     tags = await classify_profession_llm(profession)
+    if tags is None:
+        return set()  # LLM call failed → keyword-only this time, do not poison the cache
     _llm_tag_cache[key] = frozenset(tags)
     return tags
 

--- a/backend/app/services/audience.py
+++ b/backend/app/services/audience.py
@@ -50,6 +50,56 @@ def tags_for_profession(profession: str | None) -> set[str]:
     return {tag for tag, kws in _KEYWORDS.items() if any(kw in text for kw in kws)}
 
 
+# Phase 3 · #88 — LLM fallback for the long tail of professions the keyword map misses. Cached per
+# user on persona_version (bumped on any profile edit), so the LLM runs at most once per profession.
+# Process-local cache — a restart just re-classifies; no migration, no per-request cost on the hot path.
+_llm_tag_cache: dict[tuple, frozenset] = {}
+_TAG_SCHEMA = {
+    "type": "object",
+    "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+    "required": ["tags"],
+}
+
+
+async def classify_profession_llm(profession: str) -> set[str]:
+    """Map a profession to the FIXED audience-tag vocabulary via the platform LLM. Empty on failure.
+
+    The result is constrained to `_KEYWORDS` keys so the model can never invent a tag no source uses.
+    """
+    from app.services import llm
+
+    vocab = sorted(_KEYWORDS.keys())
+    prompt = (
+        f"Map this profession to zero or more audience tags from EXACTLY this list: {vocab}. "
+        f"Choose only tags whose news a person in that role would want. "
+        f"Profession: {profession!r}. Return JSON {{\"tags\": [...]}} using only tags from the list."
+    )
+    try:
+        result = await llm.generate(prompt, schema=_TAG_SCHEMA, force_platform_key=True)
+    except Exception:  # noqa: BLE001 — the classifier is a fallback; degrade to keyword-only, never crash
+        return set()
+    raw = result.get("tags") if isinstance(result, dict) else None
+    return {t for t in (raw or []) if t in _KEYWORDS}
+
+
+async def resolve_tags(profession: str | None, *, user_id=None, persona_version=None) -> set[str]:
+    """Audience tags for a profession: keyword map first (fast, offline), LLM fallback for the tail.
+
+    A keyword hit never calls the LLM. The LLM result is cached on (user_id, persona_version).
+    """
+    base = tags_for_profession(profession)
+    if base:
+        return base
+    if not profession or not profession.strip():
+        return set()
+    key = (user_id, persona_version)
+    if key in _llm_tag_cache:
+        return set(_llm_tag_cache[key])
+    tags = await classify_profession_llm(profession)
+    _llm_tag_cache[key] = frozenset(tags)
+    return tags
+
+
 def allowed_source_ids(user_tags: set[str], *, floor: int, followed_source_ids=None):
     """A subquery of source ids a user may see, given their audience tags.
 

--- a/backend/app/services/credibility.py
+++ b/backend/app/services/credibility.py
@@ -40,15 +40,17 @@ async def _propose_score(source: Source) -> int | None:
     )
     try:
         result = await llm.generate(prompt, schema=_SCORE_SCHEMA, force_platform_key=True)
+        score = result.get("score") if isinstance(result, dict) else None
+        if score is None:
+            return None
+        # int() is INSIDE the try: an LLM that returns {"score": "high"} / [85] / "85%" must not
+        # abort the whole monthly run and discard the proposals already written for earlier rows.
+        return max(0, min(100, int(score)))
     except llm.LLMUnavailable:
         return None
     except Exception as e:  # noqa: BLE001 — a bad LLM response must not abort the whole run
         logger.warning("credibility_propose_failed", source=source.name, error=str(e))
         return None
-    score = result.get("score") if isinstance(result, dict) else None
-    if score is None:
-        return None
-    return max(0, min(100, int(score)))
 
 
 def _is_stale(meta: dict, cutoff: datetime) -> bool:
@@ -56,9 +58,12 @@ def _is_stale(meta: dict, cutoff: datetime) -> bool:
     if not last:
         return True  # never reviewed
     try:
-        return datetime.fromisoformat(last) <= cutoff
+        dt = datetime.fromisoformat(last)
     except (TypeError, ValueError):
         return True  # unparseable → treat as stale, re-stamp it
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)  # tolerate a naive/date-only stored value vs aware cutoff
+    return dt <= cutoff
 
 
 async def review_credibility(session=None, *, now=None) -> int:

--- a/backend/app/services/credibility.py
+++ b/backend/app/services/credibility.py
@@ -1,0 +1,109 @@
+"""Phase 3 · #90 — monthly LLM credibility review (propose-only).
+
+Re-assesses gated (expert/research) sources whose credibility hasn't been reviewed in >90 days and
+writes a PROPOSAL — never a live change. It sets `credibility_meta.proposed_score` (+ `last_reviewed`
++ `reviewed_by="llm-proposed"`) and leaves the live `credibility_score` untouched; a human applies it
+via PUT /admin/sources/{id}/credibility (#85). An admin-locked row keeps its lock and live score.
+
+The score is an *editorial* estimate from model knowledge, never an objective ranking of a person.
+"""
+from datetime import datetime, timezone
+
+import structlog
+
+from app.config import settings
+from app.database import async_session
+from app.models import Source, SourceType
+from app.services import llm
+
+logger = structlog.get_logger()
+
+_RUBRIC = (
+    "Rate the editorial credibility of this source's author on a 0-100 scale using: affiliation/"
+    "institutional role (30), education/credentials (20), track record/mainstream citation (25), "
+    "audience scale (15), original analysis vs aggregation (10). 90+ canonical authority, 75-89 "
+    "established expert, 60-74 credible practitioner, <55 discover-only."
+)
+
+_SCORE_SCHEMA = {
+    "type": "object",
+    "properties": {"score": {"type": "integer"}, "rationale": {"type": "string"}},
+    "required": ["score"],
+}
+
+
+async def _propose_score(source: Source) -> int | None:
+    """Ask the platform LLM to re-estimate a 0-100 credibility score. Returns None on unavailability."""
+    prompt = (
+        f"{_RUBRIC}\n\nSource: {source.name}\nAuthor: {source.author_name or 'unknown'}\n"
+        f"Current score: {source.credibility_score}\nReturn JSON {{\"score\": <0-100>, \"rationale\": <str>}}."
+    )
+    try:
+        result = await llm.generate(prompt, schema=_SCORE_SCHEMA, force_platform_key=True)
+    except llm.LLMUnavailable:
+        return None
+    except Exception as e:  # noqa: BLE001 — a bad LLM response must not abort the whole run
+        logger.warning("credibility_propose_failed", source=source.name, error=str(e))
+        return None
+    score = result.get("score") if isinstance(result, dict) else None
+    if score is None:
+        return None
+    return max(0, min(100, int(score)))
+
+
+def _is_stale(meta: dict, cutoff: datetime) -> bool:
+    last = (meta or {}).get("last_reviewed")
+    if not last:
+        return True  # never reviewed
+    try:
+        return datetime.fromisoformat(last) <= cutoff
+    except (TypeError, ValueError):
+        return True  # unparseable → treat as stale, re-stamp it
+
+
+async def review_credibility(session=None, *, now=None) -> int:
+    """Propose fresh scores for stale gated sources. Returns the number of proposals written.
+
+    `now` is injectable for deterministic tests. Accepts an optional session (tests); otherwise
+    opens its own (the scheduler path).
+    """
+    if session is not None:
+        return await _review(session, now=now)
+    async with async_session() as s:
+        return await _review(s, now=now)
+
+
+async def _review(session, *, now=None) -> int:
+    from datetime import timedelta
+
+    from sqlalchemy import select
+
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=settings.credibility_review_stale_days)
+
+    sources = (
+        await session.execute(
+            select(Source).where(Source.source_type.in_([SourceType.expert, SourceType.research]))
+        )
+    ).scalars().all()
+
+    proposed = 0
+    for source in sources:
+        meta = dict(source.credibility_meta or {})
+        if not _is_stale(meta, cutoff):
+            continue
+        score = await _propose_score(source)
+        if score is None:
+            continue  # LLM unavailable / bad response → skip this row, no-op
+        meta["proposed_score"] = score
+        meta["last_reviewed"] = now.isoformat()
+        # Never downgrade an admin lock — a proposal is recorded, but the human decision stands.
+        if meta.get("reviewed_by") != "admin":
+            meta["reviewed_by"] = "llm-proposed"
+        source.credibility_meta = meta
+        # The live `credibility_score` is DELIBERATELY untouched — this job proposes, never decides.
+        proposed += 1
+
+    await session.commit()
+    logger.info("credibility_review_complete", candidates=len(sources), proposed=proposed)
+    return proposed

--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -8,13 +8,14 @@ entity ids + content version + persona/depth (+ user scope at G2), or it will se
 answers. The G1 endpoints are uncached pure-SQL reads, so the trap does not bite yet.
 """
 import structlog
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database import async_session
 from app.models import (
-    ArticleEntity, ClusterArticle, Entity, EntityAlias, StoryCluster, UserEntityRelevance,
+    Article, ArticleEntity, ClusterArticle, Entity, EntityAlias, Source, SourceType,
+    StoryCluster, UserEntityRelevance,
 )
 from app.schemas import EntityExtraction
 from app.services import llm, retrieval
@@ -283,6 +284,36 @@ async def resolve_and_persist(db: AsyncSession, articles: list, extraction: Enti
 
 # ── Decoupled backfill job (G1 S5) ──────────────────────────────────────────────────
 
+async def _extraction_candidates(session) -> list[int]:
+    """Cluster ids eligible for entity extraction.
+
+    News/general clusters must be 'settled' (>= graph_extract_min_sources articles). #89: a
+    research-tier cluster is eligible at just 1 source — a paper's abstract won't cluster with news
+    (cosine 0.15), so it stays a singleton, and we still want its people/institutions extracted.
+    """
+    research_articles = func.count(
+        case((Source.source_type == SourceType.research, 1))
+    )
+    rows = (
+        await session.execute(
+            select(StoryCluster.id)
+            .join(ClusterArticle, ClusterArticle.cluster_id == StoryCluster.id)
+            .join(Article, Article.id == ClusterArticle.article_id)
+            .join(Source, Source.id == Article.source_id)
+            .group_by(StoryCluster.id)
+            .having(
+                or_(
+                    func.count(ClusterArticle.id) >= settings.graph_extract_min_sources,
+                    research_articles >= settings.graph_extract_research_min_sources,
+                )
+            )
+            .order_by(StoryCluster.created_at.desc())
+            .limit(settings.graph_extract_batch_size)
+        )
+    ).all()
+    return [r[0] for r in rows]
+
+
 async def backfill_entities() -> None:
     """APScheduler job: extract entities for SETTLED, CHANGED clusters. Modeled on
     summarizer.backfill_summaries — selects candidate ids in one session, then processes each in
@@ -294,17 +325,7 @@ async def backfill_entities() -> None:
         return
 
     async with async_session() as session:
-        rows = (
-            await session.execute(
-                select(StoryCluster.id)
-                .join(ClusterArticle, ClusterArticle.cluster_id == StoryCluster.id)
-                .group_by(StoryCluster.id)
-                .having(func.count(ClusterArticle.id) >= settings.graph_extract_min_sources)
-                .order_by(StoryCluster.created_at.desc())
-                .limit(settings.graph_extract_batch_size)
-            )
-        ).all()
-        cluster_ids = [r[0] for r in rows]
+        cluster_ids = await _extraction_candidates(session)
 
     if not cluster_ids:
         return

--- a/backend/app/services/pubmed.py
+++ b/backend/app/services/pubmed.py
@@ -108,7 +108,9 @@ def _parse_efetch(xml_text: str) -> list[dict]:
         if not pmid:
             continue
         title_el = art.find(".//ArticleTitle")
-        title = (title_el.text or "").strip() if title_el is not None else ""
+        # itertext (not .text): PubMed titles carry inline markup (<i> species, <sub>/<sup>, <b>);
+        # .text would truncate the title at the first such child element.
+        title = "".join(title_el.itertext()).strip() if title_el is not None else ""
         parts = ["".join(a.itertext()).strip() for a in art.findall(".//Abstract/AbstractText")]
         abstract = " ".join(p for p in parts if p).strip()
         items.append({"pmid": pmid, "title": title, "abstract": abstract})

--- a/backend/app/services/pubmed.py
+++ b/backend/app/services/pubmed.py
@@ -1,0 +1,209 @@
+"""Phase 3 · #86 — PubMed E-utilities adapter + per-specialty ingestion.
+
+A doctor's personal research feed. A weekly job maps each active user's profession → a PubMed search
+term, calls NCBI E-utilities esearch (last 7 days) → efetch (abstract XML), and ingests each result
+as a research Article under a per-specialty research Source (audience=["medicine"]). Those articles
+then flow through the existing embedding → clustering → persona-gate pipeline with no new surface.
+
+The session-gated PubMed RSS GUID path (pubmed.ncbi.nlm.nih.gov/rss/search/<GUID>/) 403s for scripts
+— this adapter uses the VERIFIED E-utilities JSON/XML endpoints instead. Throttled to ≤3 req/s.
+"""
+import asyncio
+import time
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
+import httpx
+import structlog
+from sqlalchemy import select
+
+from app.config import settings
+from app.database import async_session
+from app.models import Article, Source, SourceType, User
+
+logger = structlog.get_logger()
+
+ESEARCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+EFETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+
+# Medical specialty → PubMed search term. PubMed is a medical database, so only medical professions
+# map; everything else returns None (no PubMed feed). Matched as a substring of the profession text.
+_PROFESSION_TERMS: dict[str, str] = {
+    "cardiolog": "cardiology",
+    "oncolog": "oncology",
+    "neurolog": "neurology",
+    "psychiatr": "psychiatry",
+    "radiolog": "radiology",
+    "pediatric": "pediatrics",
+    "paediatric": "pediatrics",
+    "epidemiolog": "epidemiology",
+    "dermatolog": "dermatology",
+    "endocrinolog": "endocrinology",
+    "gastroenterolog": "gastroenterology",
+    "nephrolog": "nephrology",
+    "pulmonolog": "pulmonology",
+    "rheumatolog": "rheumatology",
+    "surgeon": "surgery",
+    "anesthesiolog": "anesthesiology",
+    "anaesthesiolog": "anesthesiology",
+    "ophthalmolog": "ophthalmology",
+    "obstetric": "obstetrics",
+    "gynecolog": "gynecology",
+}
+_GENERIC_MEDICAL = ("doctor", "physician", "mbbs", "clinician", "medical", "medicine", "nurse")
+
+
+def term_for_profession(profession: str | None) -> str | None:
+    """Map a free-text profession to a PubMed search term (None for non-medical / unset)."""
+    if not profession or not profession.strip():
+        return None
+    text = f" {profession.lower()} "
+    for kw, term in _PROFESSION_TERMS.items():
+        if kw in text:
+            return term
+    if any(k in text for k in _GENERIC_MEDICAL):
+        return "medicine"
+    return None
+
+
+_last_request = 0.0
+
+
+async def _rate_limit() -> None:
+    """Enforce ≤ 1/interval requests/sec against NCBI (default 0.34s ⇒ ≤3 req/s)."""
+    global _last_request
+    interval = settings.pubmed_min_request_interval
+    if interval <= 0:
+        return
+    wait = interval - (time.monotonic() - _last_request)
+    if wait > 0:
+        await asyncio.sleep(wait)
+    _last_request = time.monotonic()
+
+
+async def esearch(client: httpx.AsyncClient, term: str, *, reldate: int = 7,
+                  api_key: str | None = None, retmax: int = 25) -> list[str]:
+    """Return recent PubMed IDs for a term (edat within `reldate` days)."""
+    await _rate_limit()
+    params = {"db": "pubmed", "term": term, "reldate": reldate, "datetype": "edat",
+              "retmode": "json", "retmax": retmax}
+    if api_key:
+        params["api_key"] = api_key
+    resp = await client.get(ESEARCH_URL, params=params, timeout=30.0)
+    resp.raise_for_status()
+    data = resp.json()
+    return list((data or {}).get("esearchresult", {}).get("idlist", []))
+
+
+def _parse_efetch(xml_text: str) -> list[dict]:
+    items: list[dict] = []
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        logger.warning("pubmed_efetch_parse_error", error=str(e))
+        return items
+    for art in root.findall(".//PubmedArticle"):
+        pmid_el = art.find(".//PMID")
+        pmid = (pmid_el.text or "").strip() if pmid_el is not None else ""
+        if not pmid:
+            continue
+        title_el = art.find(".//ArticleTitle")
+        title = (title_el.text or "").strip() if title_el is not None else ""
+        parts = ["".join(a.itertext()).strip() for a in art.findall(".//Abstract/AbstractText")]
+        abstract = " ".join(p for p in parts if p).strip()
+        items.append({"pmid": pmid, "title": title, "abstract": abstract})
+    return items
+
+
+async def efetch(client: httpx.AsyncClient, pmids: list[str], *, api_key: str | None = None) -> list[dict]:
+    """Fetch + parse abstracts for a batch of PMIDs → [{pmid, title, abstract}]."""
+    if not pmids:
+        return []
+    await _rate_limit()
+    params = {"db": "pubmed", "id": ",".join(pmids), "rettype": "abstract", "retmode": "xml"}
+    if api_key:
+        params["api_key"] = api_key
+    resp = await client.get(EFETCH_URL, params=params, timeout=30.0)
+    resp.raise_for_status()
+    return _parse_efetch(resp.text)
+
+
+async def _ensure_specialty_source(session, term: str) -> Source:
+    """Get-or-create the per-specialty PubMed research source (audience-tagged for doctors)."""
+    url = f"https://pubmed.ncbi.nlm.nih.gov/?term={term}"
+    existing = (await session.execute(select(Source).where(Source.url == url))).scalar_one_or_none()
+    if existing is not None:
+        return existing
+    source = Source(
+        name=f"PubMed · {term.title()}", url=url, rss_url=None,
+        source_type=SourceType.research, region="global", category="research",
+        credibility_score=92, audience=["medicine"], is_preprint=False,
+        per_fetch_cap=settings.pubmed_retmax,
+        credibility_meta={"reviewed_by": "seed", "note": "PubMed E-utilities specialty feed"},
+    )
+    session.add(source)
+    await session.flush()
+    return source
+
+
+async def ingest_pubmed(session=None) -> int:
+    """Weekly job: ingest fresh PubMed abstracts for every medical profession among the users.
+
+    Returns the number of new articles created. Accepts an optional session (tests); otherwise opens
+    its own (the scheduler path). No-op when disabled or when no user has a medical profession.
+    """
+    if not settings.pubmed_enabled:
+        logger.info("pubmed_disabled")
+        return 0
+    if session is not None:
+        return await _ingest(session)
+    async with async_session() as s:
+        return await _ingest(s)
+
+
+async def _ingest(session) -> int:
+    professions = (
+        await session.execute(select(User.profession).where(User.profession.isnot(None)))
+    ).scalars().all()
+    terms = sorted({t for p in professions if (t := term_for_profession(p))})
+    if not terms:
+        return 0
+
+    api_key = settings.ncbi_api_key or None
+    created = 0
+    async with httpx.AsyncClient(
+        headers={"User-Agent": "NewsLens/0.1 (research feed)"}, follow_redirects=True
+    ) as client:
+        for term in terms:
+            try:
+                pmids = await esearch(client, term, reldate=7, api_key=api_key,
+                                      retmax=settings.pubmed_retmax)
+                results = await efetch(client, pmids, api_key=api_key)
+            except httpx.HTTPError as e:
+                logger.warning("pubmed_fetch_failed", term=term, error=str(e))
+                continue
+            if not results:
+                continue
+            source = await _ensure_specialty_source(session, term)
+            for r in results:
+                title = (r.get("title") or "").strip()
+                if not title:
+                    continue
+                url = f"https://pubmed.ncbi.nlm.nih.gov/{r['pmid']}/"
+                dup = (
+                    await session.execute(select(Article.id).where(Article.url == url))
+                ).scalar_one_or_none()
+                if dup is not None:
+                    continue  # dedup by PMID
+                abstract = (r.get("abstract") or "").strip()
+                session.add(Article(
+                    title=title, url=url, source_id=source.id,
+                    snippet=abstract[:300] if len(abstract) >= settings.min_snippet_length else None,
+                    extracted_text=abstract or None,
+                    published_at=datetime.now(timezone.utc),
+                ))
+                created += 1
+
+    await session.commit()
+    logger.info("pubmed_ingest_complete", terms=len(terms), created=created)
+    return created

--- a/backend/tests/integration/test_phase3_arxiv.py
+++ b/backend/tests/integration/test_phase3_arxiv.py
@@ -1,0 +1,58 @@
+"""Phase 3 · #87 — arXiv-by-interest generation (idempotent) + visibility to a matching user."""
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+
+from app.models import Article, Source, SourceType, Topic, User, UserPreference
+from app.services import arxiv_gen
+
+
+async def _interest(db_session, name):
+    t = Topic(name=name)
+    db_session.add(t)
+    await db_session.flush()
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    await db_session.flush()
+    db_session.add(UserPreference(user_id=1, topic_id=t.id, weight=1.0))
+    await db_session.flush()
+    return u
+
+
+async def test_generate_arxiv_sources_from_interests_is_idempotent(db_session):
+    await _interest(db_session, "Computer Vision")
+
+    created = await arxiv_gen.generate_arxiv_sources(db_session)  # gathers from user prefs
+    assert created == 1
+
+    src = (await db_session.execute(
+        sa.select(Source).where(Source.rss_url == "https://rss.arxiv.org/rss/cs.CV"))).scalar_one()
+    assert src.source_type is SourceType.research and src.is_preprint is True
+    assert set(src.audience) == {"ai", "technology"} and src.per_fetch_cap == 25
+
+    again = await arxiv_gen.generate_arxiv_sources(db_session)
+    assert again == 0  # existing source untouched
+
+
+async def test_generated_arxiv_source_is_visible_to_matching_user(aclient, db_session):
+    u = await _interest(db_session, "Computer Vision")
+    u.profession = "AI Engineer"  # tags include ai/technology → clears the gate for cs.CV
+    await db_session.flush()
+    await arxiv_gen.generate_arxiv_sources(db_session)
+
+    src = (await db_session.execute(
+        sa.select(Source).where(Source.rss_url == "https://rss.arxiv.org/rss/cs.CV"))).scalar_one()
+    db_session.add(Article(title="A vision preprint", url="https://arxiv.org/abs/2607.00001",
+                           source_id=src.id, snippet="A convolutional architecture with strong results.",
+                           published_at=datetime(2026, 7, 3, tzinfo=timezone.utc)))
+    await db_session.flush()
+
+    titles = {a["title"] for a in (await aclient.get("/feed?per_page=50")).json()["articles"]}
+    assert "A vision preprint" in titles
+
+
+async def test_generate_arxiv_no_interests_is_noop(db_session):
+    created = await arxiv_gen.generate_arxiv_sources(db_session, interests=["Cooking", "Gardening"])
+    assert created == 0

--- a/backend/tests/integration/test_phase3_classifier.py
+++ b/backend/tests/integration/test_phase3_classifier.py
@@ -83,3 +83,82 @@ async def test_long_tail_profession_sees_gated_content_in_feed(aclient, db_sessi
 
     titles = {a["title"] for a in (await aclient.get("/feed?per_page=50")).json()["articles"]}
     assert "Macro outlook" in titles  # visible thanks to the LLM-classified `finance` tag
+
+
+async def test_profession_less_user_never_calls_the_llm(monkeypatch):
+    audience._llm_tag_cache.clear()
+    counter = {"n": 0}
+    monkeypatch.setattr(llm, "generate", _stub_generate(["finance"], counter))
+    assert await audience.resolve_tags(None, user_id=1, persona_version=1) == set()
+    assert await audience.resolve_tags("  ", user_id=1, persona_version=1) == set()
+    assert counter["n"] == 0  # empty profession → no LLM call, no cache write
+
+
+async def test_cache_is_isolated_per_user(monkeypatch):
+    audience._llm_tag_cache.clear()
+    counter = {"n": 0}
+
+    async def _gen(prompt, *a, **k):
+        counter["n"] += 1
+        return {"tags": ["finance"] if "Actuary" in prompt else ["science"]}
+    monkeypatch.setattr(llm, "generate", _gen)
+
+    a = await audience.resolve_tags("Actuary", user_id=1, persona_version=1)
+    b = await audience.resolve_tags("Sommelier", user_id=2, persona_version=1)  # same persona_version
+    assert a == {"finance"} and b == {"science"}   # user 2 got ITS own tags, not user 1's cache
+    assert counter["n"] == 2
+
+
+async def test_llm_failure_is_not_negative_cached(monkeypatch):
+    audience._llm_tag_cache.clear()
+    calls = {"n": 0}
+
+    async def _flaky(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise llm.LLMUnavailable("transient")
+        return {"tags": ["finance"]}
+    monkeypatch.setattr(llm, "generate", _flaky)
+
+    first = await audience.resolve_tags("Actuary", user_id=1, persona_version=1)
+    assert first == set()                                   # transient failure → keyword-only
+    second = await audience.resolve_tags("Actuary", user_id=1, persona_version=1)
+    assert second == {"finance"}                            # retried (failure was NOT cached)
+
+
+async def test_long_tail_profession_sees_gated_content_in_briefing(aclient, db_session, monkeypatch, fake_llm):
+    """Briefing gate also flows through resolve_tags — an LLM-classified Actuary sees finance research."""
+    import sqlalchemy as sa
+    from datetime import datetime, timezone
+
+    from app.models import Article, ClusterArticle, Source, SourceType, StoryCluster, User
+    audience._llm_tag_cache.clear()
+
+    async def _gen(prompt, *a, **k):
+        return {"tags": ["finance"]}
+    monkeypatch.setattr(llm, "generate", _gen)
+
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = "Actuary"
+    await db_session.flush()
+
+    src = Source(name="Noahpinion", url="https://noahpinion.example", rss_url="https://noahpinion.example/rss",
+                 source_type=SourceType.expert, region="global", category="business",
+                 credibility_score=90, audience=["finance"])  # 90 >= briefing floor 70
+    db_session.add(src)
+    await db_session.flush()
+    art = Article(title="Macro briefing", url="https://noahpinion.example/b1", source_id=src.id,
+                  snippet="a snippet", published_at=datetime(2026, 7, 3, tzinfo=timezone.utc))
+    db_session.add(art)
+    await db_session.flush()
+    cl = StoryCluster(title="Macro briefing", summary="cached summary", coherence=0.9)
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db_session.flush()
+
+    titles = {s["title"] for s in (await aclient.get("/briefing")).json()["stories"]}
+    assert "Macro briefing" in titles

--- a/backend/tests/integration/test_phase3_classifier.py
+++ b/backend/tests/integration/test_phase3_classifier.py
@@ -1,0 +1,85 @@
+"""Phase 3 · #88 — LLM profession→tags classifier (keyword fast-path, LLM fallback, cached on persona_version)."""
+from app.services import audience, llm
+
+
+def _stub_generate(tags, counter):
+    async def _gen(*a, **k):
+        counter["n"] += 1
+        return {"tags": tags}
+    return _gen
+
+
+async def test_keyword_hit_skips_the_llm(monkeypatch):
+    audience._llm_tag_cache.clear()
+    counter = {"n": 0}
+    monkeypatch.setattr(llm, "generate", _stub_generate(["finance"], counter))
+    tags = await audience.resolve_tags("Cardiologist", user_id=1, persona_version=1)
+    assert "medicine" in tags
+    assert counter["n"] == 0  # keyword map answered → no LLM call
+
+
+async def test_keyword_miss_falls_back_to_llm(monkeypatch):
+    audience._llm_tag_cache.clear()
+    counter = {"n": 0}
+    monkeypatch.setattr(llm, "generate", _stub_generate(["finance"], counter))
+    tags = await audience.resolve_tags("Actuary", user_id=1, persona_version=1)
+    assert tags == {"finance"} and counter["n"] == 1
+
+
+async def test_classification_cached_on_persona_version(monkeypatch):
+    audience._llm_tag_cache.clear()
+    counter = {"n": 0}
+    monkeypatch.setattr(llm, "generate", _stub_generate(["finance"], counter))
+    await audience.resolve_tags("Actuary", user_id=1, persona_version=1)
+    await audience.resolve_tags("Actuary", user_id=1, persona_version=1)  # cache hit
+    assert counter["n"] == 1
+    await audience.resolve_tags("Actuary", user_id=1, persona_version=2)  # profession changed
+    assert counter["n"] == 2
+
+
+async def test_llm_is_constrained_to_the_tag_vocabulary(monkeypatch):
+    audience._llm_tag_cache.clear()
+    counter = {"n": 0}
+    monkeypatch.setattr(llm, "generate", _stub_generate(["finance", "cooking", "astrology"], counter))
+    tags = await audience.resolve_tags("Actuary", user_id=1, persona_version=1)
+    assert tags == {"finance"}  # invented tags dropped
+
+
+async def test_no_llm_key_returns_keyword_result(monkeypatch):
+    audience._llm_tag_cache.clear()
+
+    async def _raise(*a, **k):
+        raise llm.LLMUnavailable("no key")
+    monkeypatch.setattr(llm, "generate", _raise)
+    assert await audience.resolve_tags("Actuary", user_id=1, persona_version=1) == set()
+
+
+async def test_long_tail_profession_sees_gated_content_in_feed(aclient, db_session, monkeypatch):
+    """End-to-end: a profession the keyword map misses ("Actuary") is LLM-classified to `finance`, so
+    the feed gate now admits a finance-tagged expert source for that user."""
+    import sqlalchemy as sa
+
+    from app.models import Article, Source, SourceType, User
+    audience._llm_tag_cache.clear()
+    counter = {"n": 0}
+    monkeypatch.setattr(llm, "generate", _stub_generate(["finance"], counter))
+
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = "Actuary"  # keyword map returns nothing → LLM fallback
+    await db_session.flush()
+
+    src = Source(name="Noahpinion", url="https://noahpinion.example", rss_url="https://noahpinion.example/rss",
+                 source_type=SourceType.expert, region="global", category="business",
+                 credibility_score=90, audience=["finance"])
+    db_session.add(src)
+    await db_session.flush()
+    db_session.add(Article(title="Macro outlook", url="https://noahpinion.example/a1", source_id=src.id,
+                           snippet="A long enough snippet for the feed card body text.",
+                           published_at=__import__("datetime").datetime(2026, 7, 3, tzinfo=__import__("datetime").timezone.utc)))
+    await db_session.flush()
+
+    titles = {a["title"] for a in (await aclient.get("/feed?per_page=50")).json()["articles"]}
+    assert "Macro outlook" in titles  # visible thanks to the LLM-classified `finance` tag

--- a/backend/tests/integration/test_phase3_credibility_ops.py
+++ b/backend/tests/integration/test_phase3_credibility_ops.py
@@ -120,3 +120,42 @@ async def test_review_no_llm_key_is_noop(db_session, monkeypatch):
 
     fresh = (await db_session.execute(select(Source).where(Source.id == s.id))).scalar_one()
     assert "proposed_score" not in (fresh.credibility_meta or {})
+
+
+async def test_review_ignores_news_tier_sources(db_session, monkeypatch):
+    """The propose-only job must only touch expert/research — never burn LLM calls on the news corpus."""
+    from app.services import credibility
+    news = Source(name="Reuters", url="https://reuters.example", rss_url="https://reuters.example/rss",
+                  source_type=SourceType.wire, region="global", category="world")  # stale (meta=None)
+    expert = await _expert(db_session, score=70, meta=None)
+    db_session.add(news)
+    await db_session.flush()
+    monkeypatch.setattr(credibility, "_propose_score", _stub_score(82))
+
+    await credibility.review_credibility(db_session)
+
+    fresh_news = (await db_session.execute(select(Source).where(Source.id == news.id))).scalar_one()
+    fresh_expert = (await db_session.execute(select(Source).where(Source.id == expert.id))).scalar_one()
+    assert "proposed_score" not in (fresh_news.credibility_meta or {})   # news untouched
+    assert fresh_expert.credibility_meta["proposed_score"] == 82          # expert proposed
+
+
+async def test_propose_score_survives_non_integer_llm_response(monkeypatch):
+    """A JSON-parseable but non-numeric score must degrade to None, not crash the whole run."""
+    from types import SimpleNamespace
+
+    from app.services import credibility, llm
+
+    async def _bad(*a, **k):
+        return {"score": "high"}  # not an int
+    monkeypatch.setattr(llm, "generate", _bad)
+    src = SimpleNamespace(name="X", author_name="Y", credibility_score=70)
+    assert await credibility._propose_score(src) is None
+
+
+def test_is_stale_handles_garbage_and_naive_timestamps():
+    from app.services import credibility
+    cutoff = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    assert credibility._is_stale({"last_reviewed": "not-a-date"}, cutoff) is True
+    assert credibility._is_stale({"last_reviewed": "2020-01-01T00:00:00"}, cutoff) is True  # naive + old
+    assert credibility._is_stale({"last_reviewed": "2099-01-01T00:00:00+00:00"}, cutoff) is False

--- a/backend/tests/integration/test_phase3_credibility_ops.py
+++ b/backend/tests/integration/test_phase3_credibility_ops.py
@@ -1,0 +1,122 @@
+"""Phase 3 · #85 — apply a reviewed credibility score (PUT /admin/sources/{id}/credibility).
+
+Applying a score stamps reviewed_by="admin", which locks the row against the seed re-upsert.
+"""
+from sqlalchemy import select
+
+from app.models import Source, SourceType
+from app.services import fetcher
+
+
+async def _expert(db_session, *, score=70, meta=None):
+    s = Source(
+        name="Stratechery", url="https://stratechery.example", rss_url="https://stratechery.example/feed",
+        source_type=SourceType.expert, region="global", category="technology",
+        author_name="Ben Thompson", credibility_score=score, audience=["ai", "business"],
+        credibility_meta=meta,
+    )
+    db_session.add(s)
+    await db_session.flush()
+    return s
+
+
+async def test_apply_credibility_updates_and_locks(aclient, db_session):
+    s = await _expert(db_session, score=70,
+                      meta={"affiliation": "Stratechery LLC", "proposed_score": 85,
+                            "reviewed_by": "llm-proposed"})
+    r = await aclient.put(f"/admin/sources/{s.id}/credibility",
+                          json={"credibility_score": 85, "rationale": "Applied the proposal."})
+    assert r.status_code == 200
+
+    fresh = (await db_session.execute(select(Source).where(Source.id == s.id))).scalar_one()
+    assert fresh.credibility_score == 85
+    assert fresh.credibility_meta["reviewed_by"] == "admin"          # human decision
+    assert fresh.credibility_meta["affiliation"] == "Stratechery LLC"  # other keys preserved
+    assert fresh.credibility_meta.get("rationale") == "Applied the proposal."
+
+
+async def test_applied_score_survives_seed_reupsert(aclient, db_session):
+    """After an admin applies a score, the 10-min sources.json re-upsert must not clobber it."""
+    s = await _expert(db_session, score=70, meta=None)
+    await aclient.put(f"/admin/sources/{s.id}/credibility", json={"credibility_score": 88})
+    # sources.json ships a DIFFERENT seed score for the same feed url
+    feed = {"name": "Stratechery", "url": "https://stratechery.example",
+            "rss_url": "https://stratechery.example/feed", "source_type": "expert",
+            "credibility_score": 82, "audience": ["ai"], "region": "global", "category": "technology"}
+    await fetcher._upsert_sources(db_session, [feed])
+    fresh = (await db_session.execute(select(Source).where(Source.id == s.id))).scalar_one()
+    assert fresh.credibility_score == 88  # admin value held, not clobbered to 82
+
+
+async def test_apply_credibility_out_of_range_is_400(aclient, db_session):
+    s = await _expert(db_session)
+    r = await aclient.put(f"/admin/sources/{s.id}/credibility", json={"credibility_score": 500})
+    assert r.status_code == 400
+
+
+async def test_apply_credibility_unknown_source_is_404(aclient, db_session):
+    r = await aclient.put("/admin/sources/999999/credibility", json={"credibility_score": 80})
+    assert r.status_code == 404
+
+
+# ── #90 monthly LLM credibility review (propose-only) ──
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def _stub_score(value):
+    async def _score(src):
+        return value
+    return _score
+
+
+async def test_review_proposes_for_stale_row_without_touching_live_score(db_session, monkeypatch):
+    from app.services import credibility
+    s = await _expert(db_session, score=70, meta=None)  # never reviewed → stale
+    monkeypatch.setattr(credibility, "_propose_score", _stub_score(82))
+
+    await credibility.review_credibility(db_session)
+
+    fresh = (await db_session.execute(select(Source).where(Source.id == s.id))).scalar_one()
+    assert fresh.credibility_meta["proposed_score"] == 82          # proposal recorded
+    assert fresh.credibility_meta["reviewed_by"] == "llm-proposed"
+    assert fresh.credibility_score == 70                            # LIVE score untouched
+
+
+async def test_review_skips_recently_reviewed_row(db_session, monkeypatch):
+    from app.services import credibility
+    recent = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+    s = await _expert(db_session, score=70, meta={"last_reviewed": recent})
+    monkeypatch.setattr(credibility, "_propose_score", _stub_score(82))
+
+    await credibility.review_credibility(db_session)
+
+    fresh = (await db_session.execute(select(Source).where(Source.id == s.id))).scalar_one()
+    assert "proposed_score" not in (fresh.credibility_meta or {})  # fresh → skipped
+
+
+async def test_review_preserves_admin_lock(db_session, monkeypatch):
+    from app.services import credibility
+    old = (datetime.now(timezone.utc) - timedelta(days=200)).isoformat()
+    s = await _expert(db_session, score=88, meta={"reviewed_by": "admin", "last_reviewed": old})
+    monkeypatch.setattr(credibility, "_propose_score", _stub_score(60))
+
+    await credibility.review_credibility(db_session)
+
+    fresh = (await db_session.execute(select(Source).where(Source.id == s.id))).scalar_one()
+    assert fresh.credibility_meta["proposed_score"] == 60   # a fresh proposal is recorded
+    assert fresh.credibility_score == 88                    # but the live score is untouched
+    assert fresh.credibility_meta["reviewed_by"] == "admin"  # and the lock holds
+
+
+async def test_review_no_llm_key_is_noop(db_session, monkeypatch):
+    from app.services import credibility, llm
+    s = await _expert(db_session, score=70, meta=None)
+
+    async def _raise(*a, **k):
+        raise llm.LLMUnavailable("no key")
+    monkeypatch.setattr(llm, "generate", _raise)
+
+    await credibility.review_credibility(db_session)  # must not crash
+
+    fresh = (await db_session.execute(select(Source).where(Source.id == s.id))).scalar_one()
+    assert "proposed_score" not in (fresh.credibility_meta or {})

--- a/backend/tests/integration/test_phase3_entity_relax.py
+++ b/backend/tests/integration/test_phase3_entity_relax.py
@@ -1,0 +1,64 @@
+"""Phase 3 · #89 — relax entity-extraction eligibility to 1 source for research-tier clusters."""
+from datetime import datetime, timezone
+
+from app.models import Article, ClusterArticle, Source, SourceType, StoryCluster
+from app.services import entities
+
+
+async def _cluster(db_session, source, title):
+    art = Article(title=title, url=f"https://{source.name}.example/{title.replace(' ', '-')}",
+                  source_id=source.id, snippet="body text here.",
+                  published_at=datetime(2026, 7, 3, tzinfo=timezone.utc))
+    db_session.add(art)
+    await db_session.flush()
+    cl = StoryCluster(title=title, summary="s", coherence=0.9)
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db_session.flush()
+    return cl, art
+
+
+async def _source(db_session, name, source_type, **kw):
+    s = Source(name=name, url=f"https://{name}.example", rss_url=f"https://{name}.example/rss",
+               source_type=source_type, region="global", category=kw.pop("category", "world"), **kw)
+    db_session.add(s)
+    await db_session.flush()
+    return s
+
+
+async def test_research_singleton_is_extraction_candidate(db_session):
+    research = await _source(db_session, "NEJM", SourceType.research, category="research",
+                             credibility_score=98, audience=["medicine"])
+    cl, _ = await _cluster(db_session, research, "A lone research paper")
+
+    candidates = await entities._extraction_candidates(db_session)
+    assert cl.id in candidates  # a single research source is enough
+
+
+async def test_news_singleton_is_not_a_candidate(db_session):
+    wire = await _source(db_session, "Reuters", SourceType.wire)
+    cl, _ = await _cluster(db_session, wire, "A lone news item")
+
+    candidates = await entities._extraction_candidates(db_session)
+    assert cl.id not in candidates  # news still needs the min-2 "settled" bar
+
+
+async def test_two_source_news_cluster_is_a_candidate(db_session):
+    a = await _source(db_session, "BBC", SourceType.wire)
+    b = await _source(db_session, "Guardian", SourceType.newspaper)
+    art_a = Article(title="Shared story", url="https://bbc.example/x", source_id=a.id,
+                    snippet="b", published_at=datetime(2026, 7, 3, tzinfo=timezone.utc))
+    art_b = Article(title="Shared story", url="https://guardian.example/x", source_id=b.id,
+                    snippet="b", published_at=datetime(2026, 7, 3, tzinfo=timezone.utc))
+    db_session.add_all([art_a, art_b])
+    await db_session.flush()
+    cl = StoryCluster(title="Shared story", summary="s", coherence=0.9)
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add_all([ClusterArticle(cluster_id=cl.id, article_id=art_a.id),
+                        ClusterArticle(cluster_id=cl.id, article_id=art_b.id)])
+    await db_session.flush()
+
+    candidates = await entities._extraction_candidates(db_session)
+    assert cl.id in candidates

--- a/backend/tests/integration/test_phase3_entity_relax.py
+++ b/backend/tests/integration/test_phase3_entity_relax.py
@@ -62,3 +62,13 @@ async def test_two_source_news_cluster_is_a_candidate(db_session):
 
     candidates = await entities._extraction_candidates(db_session)
     assert cl.id in candidates
+
+
+async def test_expert_singleton_is_not_a_candidate(db_session):
+    """The relax is research-only — a lone expert/Substack cluster still needs the min-2 bar."""
+    expert = await _source(db_session, "Stratechery", SourceType.expert, category="technology",
+                           credibility_score=88, audience=["ai"])
+    cl, _ = await _cluster(db_session, expert, "A lone expert post")
+
+    candidates = await entities._extraction_candidates(db_session)
+    assert cl.id not in candidates

--- a/backend/tests/integration/test_phase3_pubmed.py
+++ b/backend/tests/integration/test_phase3_pubmed.py
@@ -71,3 +71,17 @@ async def test_pubmed_noop_for_non_medical_profession(db_session, monkeypatch):
 
     n = await pubmed.ingest_pubmed(db_session)
     assert n == 0
+
+
+async def test_pubmed_keeps_abstractless_paper_with_null_body(db_session, monkeypatch):
+    """A titled paper with no abstract is still ingested (title carries it), with null snippet/body."""
+    await _set_profession(db_session, "Cardiologist")
+    no_abstract = {"pmid": "40000002", "title": "A titled paper with no abstract", "abstract": ""}
+    monkeypatch.setattr(pubmed, "esearch", _stub_search(["40000002"]))
+    monkeypatch.setattr(pubmed, "efetch", _stub_fetch([no_abstract]))
+
+    n = await pubmed.ingest_pubmed(db_session)
+    assert n == 1
+    art = (await db_session.execute(
+        sa.select(Article).where(Article.title == "A titled paper with no abstract"))).scalar_one()
+    assert art.snippet is None and art.extracted_text is None

--- a/backend/tests/integration/test_phase3_pubmed.py
+++ b/backend/tests/integration/test_phase3_pubmed.py
@@ -1,0 +1,73 @@
+"""Phase 3 · #86 — PubMed ingestion: profession → specialty research articles, gated + deduped."""
+import sqlalchemy as sa
+
+from app.models import Article, Source, SourceType, User
+from app.services import pubmed
+
+
+def _stub_search(pmids):
+    async def _s(client, term, **kw):
+        return list(pmids)
+    return _s
+
+
+def _stub_fetch(items):
+    async def _f(client, pmids, **kw):
+        return [i for i in items if i["pmid"] in set(pmids)]
+    return _f
+
+
+async def _set_profession(db_session, profession):
+    u = (await db_session.execute(sa.select(User).where(User.id == 1))).scalar_one_or_none()
+    if u is None:
+        u = User(id=1, locale="IN")
+        db_session.add(u)
+    u.profession = profession
+    await db_session.flush()
+
+
+_PAPER = {"pmid": "40000001", "title": "New cardiology trial",
+          "abstract": "A randomized controlled trial with clinically meaningful results here."}
+
+
+async def test_pubmed_ingest_creates_gated_research_articles(aclient, db_session, monkeypatch):
+    await _set_profession(db_session, "Cardiologist")
+    monkeypatch.setattr(pubmed, "esearch", _stub_search(["40000001"]))
+    monkeypatch.setattr(pubmed, "efetch", _stub_fetch([_PAPER]))
+
+    n = await pubmed.ingest_pubmed(db_session)
+    assert n == 1
+
+    art = (await db_session.execute(
+        sa.select(Article).where(Article.title == "New cardiology trial"))).scalar_one()
+    src = (await db_session.execute(sa.select(Source).where(Source.id == art.source_id))).scalar_one()
+    assert src.source_type is SourceType.research
+    assert src.audience == ["medicine"] and src.is_preprint is False
+    assert art.url == "https://pubmed.ncbi.nlm.nih.gov/40000001/"
+
+    # A cardiologist sees it in the feed (medicine-tagged research clears the gate).
+    titles = {a["title"] for a in (await aclient.get("/feed?per_page=50")).json()["articles"]}
+    assert "New cardiology trial" in titles
+
+
+async def test_pubmed_ingest_is_idempotent(db_session, monkeypatch):
+    await _set_profession(db_session, "Cardiologist")
+    monkeypatch.setattr(pubmed, "esearch", _stub_search(["40000001"]))
+    monkeypatch.setattr(pubmed, "efetch", _stub_fetch([_PAPER]))
+
+    await pubmed.ingest_pubmed(db_session)
+    await pubmed.ingest_pubmed(db_session)  # same PMID again
+
+    count = (await db_session.execute(
+        sa.select(sa.func.count()).select_from(Article).where(
+            Article.url == "https://pubmed.ncbi.nlm.nih.gov/40000001/"))).scalar_one()
+    assert count == 1  # deduped by PMID
+
+
+async def test_pubmed_noop_for_non_medical_profession(db_session, monkeypatch):
+    await _set_profession(db_session, "Software Engineer")  # no PubMed term
+    monkeypatch.setattr(pubmed, "esearch", _stub_search(["40000001"]))
+    monkeypatch.setattr(pubmed, "efetch", _stub_fetch([_PAPER]))
+
+    n = await pubmed.ingest_pubmed(db_session)
+    assert n == 0

--- a/backend/tests/unit/test_arxiv_gen.py
+++ b/backend/tests/unit/test_arxiv_gen.py
@@ -1,0 +1,16 @@
+"""Phase 3 · #87 — interest → arXiv category map + source spec."""
+from app.services import arxiv_gen
+
+
+def test_interests_map_to_arxiv_categories():
+    cats = arxiv_gen.arxiv_categories_for_interests(["Computer Vision", "Robotics", "Cooking"])
+    assert "cs.CV" in cats and "cs.RO" in cats
+    assert "Cooking" not in cats and len(cats) == 2  # unmapped interest adds nothing
+
+
+def test_arxiv_source_spec_shape():
+    spec = arxiv_gen.arxiv_source_spec("cs.CV", ["ai", "technology"])
+    assert spec["rss_url"] == "https://rss.arxiv.org/rss/cs.CV"
+    assert spec["source_type"] == "research" and spec["is_preprint"] is True
+    assert spec["audience"] == ["ai", "technology"] and spec["per_fetch_cap"] == 25
+    assert spec["credibility_score"] >= 55  # feed-eligible

--- a/backend/tests/unit/test_pubmed_adapter.py
+++ b/backend/tests/unit/test_pubmed_adapter.py
@@ -1,0 +1,75 @@
+"""Phase 3 · #86 — PubMed E-utilities adapter (esearch → PMIDs, efetch → title+abstract)."""
+import pytest
+
+from app.services import pubmed
+
+
+class _FakeResponse:
+    def __init__(self, *, json_data=None, text=None):
+        self._json = json_data
+        self.text = text or ""
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json
+
+
+class _FakeClient:
+    """Records the last URL/params and returns a queued canned response."""
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+
+    async def get(self, url, params=None, timeout=None):
+        self.calls.append({"url": url, "params": params or {}})
+        return self._response
+
+
+_ESEARCH_JSON = {"esearchresult": {"idlist": ["40000001", "40000002", "40000003"]}}
+
+_EFETCH_XML = """<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle><MedlineCitation>
+    <PMID>40000001</PMID>
+    <Article>
+      <ArticleTitle>A cardiology trial</ArticleTitle>
+      <Abstract><AbstractText Label="BACKGROUND">First part.</AbstractText>
+      <AbstractText Label="RESULTS">Second part.</AbstractText></Abstract>
+    </Article>
+  </MedlineCitation></PubmedArticle>
+  <PubmedArticle><MedlineCitation>
+    <PMID>40000002</PMID>
+    <Article><ArticleTitle>No abstract paper</ArticleTitle></Article>
+  </MedlineCitation></PubmedArticle>
+</PubmedArticleSet>"""
+
+
+def test_term_for_profession_maps_specialties():
+    assert pubmed.term_for_profession("Cardiologist") == "cardiology"
+    assert pubmed.term_for_profession("Doctor (MBBS)") == "medicine"   # generic medical fallback
+    assert pubmed.term_for_profession("Software Engineer") is None      # non-medical → no PubMed
+    assert pubmed.term_for_profession(None) is None
+
+
+@pytest.mark.asyncio
+async def test_esearch_parses_idlist_and_sends_api_key():
+    client = _FakeClient(_FakeResponse(json_data=_ESEARCH_JSON))
+    ids = await pubmed.esearch(client, "cardiology", reldate=7, api_key="KEY123", retmax=25)
+    assert ids == ["40000001", "40000002", "40000003"]
+    params = client.calls[0]["params"]
+    assert params["term"] == "cardiology" and params["reldate"] == 7
+    assert params["datetype"] == "edat" and params["api_key"] == "KEY123"
+
+
+@pytest.mark.asyncio
+async def test_efetch_parses_title_and_joined_abstract():
+    client = _FakeClient(_FakeResponse(text=_EFETCH_XML))
+    items = await pubmed.efetch(client, ["40000001", "40000002"], api_key=None)
+    by_pmid = {i["pmid"]: i for i in items}
+    assert by_pmid["40000001"]["title"] == "A cardiology trial"
+    assert "First part." in by_pmid["40000001"]["abstract"]
+    assert "Second part." in by_pmid["40000001"]["abstract"]  # multi-section joined
+    # A paper with no abstract still returns (abstract empty) — the caller decides whether to keep it.
+    assert by_pmid["40000002"]["abstract"] == ""

--- a/backend/tests/unit/test_pubmed_adapter.py
+++ b/backend/tests/unit/test_pubmed_adapter.py
@@ -73,3 +73,30 @@ async def test_efetch_parses_title_and_joined_abstract():
     assert "Second part." in by_pmid["40000001"]["abstract"]  # multi-section joined
     # A paper with no abstract still returns (abstract empty) — the caller decides whether to keep it.
     assert by_pmid["40000002"]["abstract"] == ""
+
+
+_MARKUP_XML = """<?xml version="1.0"?>
+<PubmedArticleSet><PubmedArticle><MedlineCitation>
+  <PMID>40000009</PMID>
+  <Article><ArticleTitle>Effects of <i>E. coli</i> on CO<sub>2</sub> uptake</ArticleTitle></Article>
+</MedlineCitation></PubmedArticle></PubmedArticleSet>"""
+
+
+@pytest.mark.asyncio
+async def test_efetch_title_keeps_inline_markup_text():
+    """.text would truncate the title at <i>; itertext must keep the full title (species/formulae)."""
+    client = _FakeClient(_FakeResponse(text=_MARKUP_XML))
+    items = await pubmed.efetch(client, ["40000009"], api_key=None)
+    assert items[0]["title"] == "Effects of E. coli on CO2 uptake"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_disabled_when_interval_zero(monkeypatch):
+    import app.services.pubmed as pm
+
+    slept = []
+    monkeypatch.setattr(pm.asyncio, "sleep", lambda s: slept.append(s))
+    monkeypatch.setattr(pm.settings, "pubmed_min_request_interval", 0.0)
+    await pm._rate_limit()
+    await pm._rate_limit()
+    assert slept == []  # throttle off → never sleeps


### PR DESCRIPTION
## What

Phase 3 of the source-expansion plan — **credibility ops + personal research feeds**, all backend. Built test-first (`to-issues` → red→green per slice), then hardened by a multi-agent adversarial review. **No new migrations** (code + config + JSONB only).

Closes #85, closes #86, closes #87, closes #88, closes #89, closes #90.

## Issues → slices

| # | Slice | Surface |
|---|-------|---------|
| #85 | Apply a reviewed credibility score | `PUT /admin/sources/{id}/credibility` → stamps `reviewed_by="admin"` (locks vs seed re-upsert); 400/404 |
| #90 | Monthly LLM credibility review (propose-only) | proposes `proposed_score` for gated rows unreviewed >90d; **never** touches the live score or the admin lock; no key → no-op |
| #86 | PubMed personal research feed | weekly E-utilities job: profession→term→esearch→efetch → gated research Articles (audience `medicine`), ≤3 req/s, deduped by PMID |
| #87 | arXiv-by-interest generator | subscribed topics → arXiv categories (cs.CV, cs.RO, q-bio…), idempotent via `_upsert_sources` |
| #88 | LLM profession→tags classifier | keyword fast-path + LLM fallback (fixed vocab), cached on `persona_version`; wired into feed + briefing gates |
| #89 | Research-singleton entity extraction | research clusters extract at 1 source; news keeps the min-2 settled bar |

Three new cron jobs: monthly credibility review, weekly PubMed ingest, weekly arXiv generate. Every job **no-ops safely without a key**.

## Adversarial review (multi-agent)

5-dimension review (external-io · llm-invariants · gate-regression · jobs-correctness · test-coverage), each finding adversarially verified. Acted on **5 real code defects** + **11 confirmed regression guards**:

- **`_propose_score` crash** — `int(score)` was outside the try/except, so a non-integer LLM score aborted the whole monthly run. Moved inside → degrades to None.
- **Hot-path `TypeError`** — the classifier's vocab filter could raise on the feed/briefing path if the LLM returned non-string tags. Guarded with `isinstance(str)`.
- **Negative-cache bug** — an LLM *failure* was cached as an empty tag set, denying a long-tail-profession user their sources until a profile edit/restart. Now failures aren't cached (retry next request).
- **PubMed title truncation** — `.text` cut biomedical titles at the first `<i>`/`<sub>`. Switched to `itertext()`.
- **`_is_stale`** hardened against naive/date-only timestamps.

## Verification

- Backend **341 passed** / 1 skipped · ruff clean · py_compile clean
- No new migrations; no model changes → no autogenerate drift
- The persona-gate "profession-less = byte-identical" invariant is preserved (verified: `resolve_tags` short-circuits before any LLM call for an empty profession)

🤖 Generated with [Claude Code](https://claude.com/claude-code)