### PR TITLE
Pipeline: fix free-tier embedding quota (batch + circuit-breaker) + /pipeline observability + keep-alive

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,42 @@
+# Keep the Render free-tier backend awake so its in-process APScheduler actually runs.
+#
+# WHY: the data pipeline (RSS fetch → embeddings → clustering → summaries) runs on APScheduler
+# INSIDE the FastAPI process. Render's free tier spins the web service down after ~15 min with no
+# inbound HTTP, which stops the scheduler — so articles ingest but never embed/cluster, and story
+# details (which open a cluster) go missing. A periodic inbound ping resets the idle timer.
+#
+# NOTE: this only helps if embeddings SUCCEED. If GET /pipeline shows last_embedding_error.category
+# == "quota"/"auth", fix the Gemini key/quota first — a warm service still can't embed without it.
+#
+# Scheduled workflows run only from the default branch and may be delayed under GitHub load; 10 min
+# gives margin against the ~15 min sleep. Free for public repos.
+name: keep-alive
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: keepalive
+  cancel-in-progress: true
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping backend /health (cold start can take ~40s; retry a few times)
+        env:
+          BACKEND_URL: https://newslens-3gpu.onrender.com
+        run: |
+          code=000
+          for i in 1 2 3 4; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 120 "$BACKEND_URL/health" || echo 000)
+            echo "attempt $i: HTTP $code"
+            [ "$code" = "200" ] && break
+            sleep 15
+          done
+          # Surface a one-line pipeline snapshot in the run log (handy when checking why data is stale).
+          curl -sS --max-time 120 "$BACKEND_URL/pipeline" || true
+          echo
+          test "$code" = "200"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ news-app/
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | /health | Health check (DB status) |
+| GET | /pipeline | Pipeline health: article counts by `embedding_status`, cluster counts, freshness, and `last_embedding_error` (quota/auth/no_key) — diagnoses a stalled embed→cluster stage without the log stream |
 | GET | /feed | Paginated feed with explore/exploit mix |
 | GET | /feed?topic={id} | Topic-filtered feed |
 | GET | /feed?source_type={news\|research\|expert} | Source-tier-filtered feed (invalid → 400; chip UI deferred) |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -100,6 +100,44 @@ async def health_check():
     )
 
 
+@router.get("/pipeline")
+async def pipeline_status(db: AsyncSession = Depends(get_db)):
+    """At-a-glance data-pipeline health (unauthenticated, like /health). Makes a stalled stage obvious:
+    if `articles.by_embedding_status` is all pending/failed and `clusters.total` is ~0, embeddings
+    are dead → nothing clusters → story details can't open. `last_embedding_error` names WHY (quota /
+    auth / no_key) so the cause is visible without the log stream."""
+    from app.services import embeddings as _embeddings
+
+    status_rows = (
+        await db.execute(
+            select(Article.embedding_status, func.count()).group_by(Article.embedding_status)
+        )
+    ).all()
+    by_status: dict[str, int] = {}
+    for st, cnt in status_rows:
+        key = st.value if hasattr(st, "value") else str(st)
+        by_status[key] = cnt
+
+    total_clusters = (
+        await db.execute(select(func.count()).select_from(StoryCluster))
+    ).scalar_one()
+    articles_clustered = (
+        await db.execute(select(func.count(func.distinct(ClusterArticle.article_id))))
+    ).scalar_one()
+    latest_article = (await db.execute(select(func.max(Article.fetched_at)))).scalar_one()
+    latest_cluster = (await db.execute(select(func.max(StoryCluster.created_at)))).scalar_one()
+
+    return {
+        "articles": {"total": sum(by_status.values()), "by_embedding_status": by_status},
+        "clusters": {"total": total_clusters, "articles_clustered": articles_clustered},
+        "freshness": {
+            "latest_article_fetched_at": latest_article.isoformat() if latest_article else None,
+            "latest_cluster_created_at": latest_cluster.isoformat() if latest_cluster else None,
+        },
+        "last_embedding_error": _embeddings.last_embedding_error(),
+    }
+
+
 @router.get("/feed", response_model=FeedResponse, dependencies=[Depends(get_current_user)])
 async def get_feed(
     topic: int | None = None,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -181,6 +181,14 @@ class Settings(BaseSettings):
     embedding_dimensions: int = 768
     embedding_task_document: str = "retrieval_document"  # stored article/topic vectors
     embedding_task_query: str = "retrieval_query"        # search-query vectors (asymmetric retrieval)
+    # Free-tier Gemini embeddings are capped at ~1,000 requests/DAY (100 RPM). One-request-per-article
+    # torched that in a single backfill pass and then the retry-failed-every-5-min loop hammered a dead
+    # quota (all 429). So the backfill sends ONE batched request per N articles (BatchEmbedContents),
+    # and on a 429 it backs off for a cooldown instead of re-firing every cycle.
+    embedding_batch_size: int = 50               # texts per batched embed call (also the fetch limit)
+    embedding_quota_cooldown_minutes: int = 30   # after a 429, skip backfill runs this long (RPD resets)
+    embedding_error_cooldown_minutes: int = 10   # after a systemic non-quota failure (nothing embedded
+                                                 # even per-text), back off this long instead of re-firing
 
     # Summary config
     summary_model: str = "gpt-4o-mini"

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -105,19 +105,57 @@ def _embed_sync(key: str, model: str, content: str, task_type: str, output_dim: 
     return result["embedding"]
 
 
+# Last embedding failure, surfaced over HTTP by GET /pipeline so the cause of a stalled pipeline
+# (quota vs auth vs no-key) is visible at a glance WITHOUT the Render log stream. Process-local: a
+# restart clears it, and the next success clears it too (see generate_embedding).
+_last_embedding_error: dict | None = None
+
+
+def _classify_embedding_error(msg: str) -> str:
+    """Bucket an embedding error message into an actionable category. `quota` (429 / rate limit —
+    the usual free-tier Gemini embedding cap) and `auth` (bad/absent key, permission) are the two
+    that change what you do next; everything else is `other`."""
+    m = (msg or "").lower()
+    if any(k in m for k in ("429", "quota", "resource has been exhausted", "resourceexhausted",
+                            "rate limit", "rate_limit")):
+        return "quota"
+    if any(k in m for k in ("api key", "api_key", "permission", "unauthenticated", "401", "403",
+                            "invalid key", "invalid_argument api key")):
+        return "auth"
+    return "other"
+
+
+def _record_embedding_error(category: str, message: str) -> None:
+    global _last_embedding_error
+    from datetime import datetime, timezone
+
+    _last_embedding_error = {
+        "when": datetime.now(timezone.utc).isoformat(),
+        "category": category,
+        "message": (message or "")[:500],
+    }
+
+
+def last_embedding_error() -> dict | None:
+    """The most recent embedding failure (or None if the last attempt succeeded / none yet)."""
+    return _last_embedding_error
+
+
 async def generate_embedding(text: str, *, task_type: str | None = None) -> list[float] | None:
     """Generate a Gemini embedding for a text string. Returns None on failure (never raises).
 
     task_type defaults to the stored-document type; search passes the query type for asymmetric
     retrieval. Runs the synchronous SDK call in a thread so it never blocks the event loop.
     """
+    global _last_embedding_error
     key = await _resolve_embedding_key()
     if not key:
         logger.warning("embedding_no_gemini_key")
+        _record_embedding_error("no_key", "no Gemini key resolved (per-user key or GEMINI_API_KEY env)")
         return None
 
     try:
-        return await asyncio.to_thread(
+        vec = await asyncio.to_thread(
             _embed_sync,
             key,
             settings.embedding_model,
@@ -125,8 +163,13 @@ async def generate_embedding(text: str, *, task_type: str | None = None) -> list
             task_type or settings.embedding_task_document,
             settings.embedding_dimensions,
         )
+        _last_embedding_error = None  # a success clears the sticky error so /pipeline recovers
+        return vec
     except Exception as e:
-        logger.error("embedding_generation_failed", error=str(e))
+        msg = str(e)
+        category = _classify_embedding_error(msg)
+        _record_embedding_error(category, msg)
+        logger.error("embedding_generation_failed", category=category, error=msg)
         return None
 
 

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -94,6 +94,11 @@ async def _resolve_embedding_key() -> str | None:
     return await _resolve_gemini_key()
 
 
+class QuotaExceeded(Exception):
+    """A Gemini 429 (rate/daily-quota). Raised so the backfill can circuit-break instead of
+    re-firing a dead quota every 5 minutes (which torches the ~1,000/day free-tier embedding cap)."""
+
+
 def _embed_sync(key: str, model: str, content: str, task_type: str, output_dim: int) -> list[float]:
     import google.generativeai as genai  # lazy — only on the embedding path
 
@@ -103,6 +108,21 @@ def _embed_sync(key: str, model: str, content: str, task_type: str, output_dim: 
         model=model, content=content, task_type=task_type, output_dimensionality=output_dim
     )
     return result["embedding"]
+
+
+def _embed_batch_sync(
+    key: str, model: str, texts: list[str], task_type: str, output_dim: int
+) -> list[list[float]]:
+    """Embed MANY texts in ONE request (BatchEmbedContents). The SDK returns a list-of-embeddings
+    when `content` is a list — so N articles cost 1 request, not N, which is what keeps the free-tier
+    ~1,000/day embedding cap from being blown on a single backfill pass."""
+    import google.generativeai as genai
+
+    genai.configure(api_key=key)
+    result = genai.embed_content(
+        model=model, content=texts, task_type=task_type, output_dimensionality=output_dim
+    )
+    return result["embedding"]  # BatchEmbeddingDict → list aligned with `texts` order
 
 
 # Last embedding failure, surfaced over HTTP by GET /pipeline so the cause of a stalled pipeline
@@ -173,6 +193,44 @@ async def generate_embedding(text: str, *, task_type: str | None = None) -> list
         return None
 
 
+# After a 429, the backfill parks itself until this epoch so it stops hammering a spent daily quota.
+_embedding_backoff_until: float = 0.0
+
+
+async def generate_embeddings_batch(texts: list[str]) -> list[list[float]] | None:
+    """Embed a list of texts in ONE Gemini request. Returns the aligned list of vectors, or None on
+    a non-quota failure (no key / transport). Raises QuotaExceeded on a 429 so the caller can back
+    off. A success clears the sticky last-error (pipeline recovers)."""
+    global _last_embedding_error
+    if not texts:
+        return []
+    key = await _resolve_embedding_key()
+    if not key:
+        logger.warning("embedding_no_gemini_key")
+        _record_embedding_error("no_key", "no Gemini key resolved (per-user key or GEMINI_API_KEY env)")
+        return None
+
+    try:
+        vecs = await asyncio.to_thread(
+            _embed_batch_sync,
+            key,
+            settings.embedding_model,
+            texts,
+            settings.embedding_task_document,
+            settings.embedding_dimensions,
+        )
+        _last_embedding_error = None
+        return vecs
+    except Exception as e:
+        msg = str(e)
+        category = _classify_embedding_error(msg)
+        _record_embedding_error(category, msg)
+        logger.error("embedding_batch_failed", category=category, count=len(texts), error=msg)
+        if category == "quota":
+            raise QuotaExceeded(msg) from e
+        return None
+
+
 # Cache of query string -> embedding, so repeated searches for the same query
 # reuse one OpenAI call. Bounded to avoid unbounded growth from arbitrary queries.
 _query_embedding_cache: dict[str, list[float]] = {}
@@ -237,58 +295,96 @@ async def embed_article(article_id: int):
             await session.commit()
 
 
-async def backfill_embeddings():
-    """Backfill embeddings for articles with pending/failed status. Called by APScheduler."""
+def _article_embed_text(article: Article) -> str:
+    text = article.title or ""
+    if article.snippet:
+        text += " " + article.snippet
+    return text
+
+
+async def backfill_embeddings(session=None):
+    """Backfill embeddings for pending/failed articles. Called by APScheduler.
+
+    Sends ONE batched request per `embedding_batch_size` articles (not one per article) to stay
+    under the free-tier ~1,000/day cap, and parks itself for a cooldown after a 429 instead of
+    re-firing a spent quota every 5 minutes. Accepts an optional session (tests); prod opens its own.
+    """
+    import time
+
+    global _embedding_backoff_until
     if not await _resolve_embedding_key():
         # No Gemini key anywhere → articles ingest but never embed → never cluster → feed/briefing
         # stay empty while /health is green. Log it so this silent dead-stop is observable in prod.
         logger.warning("embedding_backfill_skipped_no_gemini_key")
+        _record_embedding_error("no_key", "no Gemini key resolved (per-user key or GEMINI_API_KEY env)")
         return
 
-    async with async_session() as session:
-        result = await session.execute(
-            select(Article)
-            .where(Article.embedding_status.in_([
-                EmbeddingStatus.pending,
-                EmbeddingStatus.failed,
-            ]))
-            .order_by(Article.fetched_at.desc())
-            .limit(50)
-        )
-        articles = result.scalars().all()
+    now = time.time()
+    if now < _embedding_backoff_until:
+        logger.info("embedding_backfill_cooldown", seconds_left=int(_embedding_backoff_until - now))
+        return
 
+    if session is not None:
+        return await _backfill_once(session)
+    async with async_session() as own:
+        return await _backfill_once(own)
+
+
+async def _backfill_once(session):
+    import time
+
+    global _embedding_backoff_until
+    articles = (
+        await session.execute(
+            select(Article)
+            .where(Article.embedding_status.in_([EmbeddingStatus.pending, EmbeddingStatus.failed]))
+            .order_by(Article.fetched_at.desc())
+            .limit(settings.embedding_batch_size)
+        )
+    ).scalars().all()
     if not articles:
         return
 
-    success_count = 0
-    for article in articles:
-        text = article.title
-        if article.snippet:
-            text += " " + article.snippet
+    texts = [_article_embed_text(a) for a in articles]
+    try:
+        vecs = await generate_embeddings_batch(texts)
+    except QuotaExceeded:
+        _embedding_backoff_until = time.time() + settings.embedding_quota_cooldown_minutes * 60
+        logger.warning(
+            "embedding_backfill_quota_backoff",
+            cooldown_minutes=settings.embedding_quota_cooldown_minutes,
+            pending=len(articles),
+        )
+        return  # leave the articles pending — it wasn't their fault; they retry after the cooldown
 
-        embedding = await generate_embedding(text)
-
-        async with async_session() as session:
-            if embedding:
-                await session.execute(
-                    update(Article)
-                    .where(Article.id == article.id)
-                    .values(
-                        embedding=embedding,
-                        embedding_status=EmbeddingStatus.complete,
-                    )
-                )
-                success_count += 1
+    if not vecs:
+        # Non-quota whole-batch failure. A batch fails ATOMICALLY, so one poison text (oversized /
+        # malformed) would otherwise starve every other article in the batch forever — a new failure
+        # mode that batching introduces. Fall back to per-text embedding to ISOLATE the offender:
+        # good texts still embed, only the bad one stays failed. If even that embeds nothing
+        # (transport / systemic), arm a short backoff so we don't re-fire the same work every 5 min.
+        success = 0
+        for article, text in zip(articles, texts):
+            vec = await generate_embedding(text)
+            if vec:
+                article.embedding = vec
+                article.embedding_status = EmbeddingStatus.complete
+                success += 1
             else:
-                await session.execute(
-                    update(Article)
-                    .where(Article.id == article.id)
-                    .values(embedding_status=EmbeddingStatus.failed)
-                )
-            await session.commit()
+                article.embedding_status = EmbeddingStatus.failed
+        await session.commit()
+        if success == 0:
+            _embedding_backoff_until = time.time() + settings.embedding_error_cooldown_minutes * 60
+        logger.warning("embedding_backfill_batch_fallback", processed=len(articles), success=success)
+        return
 
-    logger.info(
-        "embedding_backfill_complete",
-        processed=len(articles),
-        success=success_count,
-    )
+    success = 0
+    for article, vec in zip(articles, vecs):
+        if vec:
+            article.embedding = vec
+            article.embedding_status = EmbeddingStatus.complete
+            success += 1
+        else:
+            article.embedding_status = EmbeddingStatus.failed
+    await session.commit()
+    logger.info("embedding_backfill_complete", processed=len(articles), success=success, api_calls=1)

--- a/backend/tests/integration/test_embeddings_batch.py
+++ b/backend/tests/integration/test_embeddings_batch.py
@@ -1,0 +1,171 @@
+"""Free-tier Gemini embeddings are ~1,000 req/DAY. The backfill must (1) batch many articles into
+ONE request and (2) back off on a 429 instead of re-firing a dead quota every 5 min (the death
+spiral that produced 1,709 429s in a day). TDD.
+"""
+import time
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models import Article, EmbeddingStatus, Source, SourceType
+from app.services import embeddings
+
+
+async def _pending_articles(db, n):
+    s = Source(name="w", url="https://w.ex", rss_url="https://w.ex/r",
+               source_type=SourceType.wire, region="global", category="world")
+    db.add(s)
+    await db.flush()
+    for i in range(n):
+        db.add(Article(title=f"t{i}", snippet="a long enough snippet body for the card here",
+                       url=f"https://w.ex/{i}", source_id=s.id,
+                       embedding_status=EmbeddingStatus.pending))
+    await db.flush()
+    return s
+
+
+async def _count(db, status):
+    return (await db.execute(
+        select(func.count()).select_from(Article).where(Article.embedding_status == status)
+    )).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_backfill_embeds_all_in_ONE_batched_request(db_session, monkeypatch):
+    await _pending_articles(db_session, 5)
+    calls = {"n": 0, "count": 0}
+
+    async def _fake_batch(texts):
+        calls["n"] += 1
+        calls["count"] = len(texts)
+        return [[0.1] * 768 for _ in texts]
+
+    async def _key():
+        return "k"
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _key)
+    monkeypatch.setattr(embeddings, "generate_embeddings_batch", _fake_batch)
+    embeddings._embedding_backoff_until = 0.0
+
+    await embeddings.backfill_embeddings(session=db_session)
+
+    assert calls["n"] == 1        # ONE API request for all 5 articles, not 5
+    assert calls["count"] == 5
+    assert await _count(db_session, EmbeddingStatus.complete) >= 5
+
+
+@pytest.mark.asyncio
+async def test_backfill_backs_off_on_quota_and_skips_the_next_run(db_session, monkeypatch):
+    await _pending_articles(db_session, 3)
+    calls = {"n": 0}
+
+    async def _boom(texts):
+        calls["n"] += 1
+        raise embeddings.QuotaExceeded("429 Resource has been exhausted")
+
+    async def _key():
+        return "k"
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _key)
+    monkeypatch.setattr(embeddings, "generate_embeddings_batch", _boom)
+    embeddings._embedding_backoff_until = 0.0
+
+    await embeddings.backfill_embeddings(session=db_session)   # hits 429 → set cooldown
+    assert calls["n"] == 1
+    assert embeddings._embedding_backoff_until > time.time()   # cooldown armed
+    # articles NOT force-failed on a quota miss (it wasn't their fault) — they retry after cooldown
+    assert await _count(db_session, EmbeddingStatus.pending) == 3
+
+    await embeddings.backfill_embeddings(session=db_session)   # within cooldown → skip entirely
+    assert calls["n"] == 1                                     # the API was NOT hit again
+
+    embeddings._embedding_backoff_until = 0.0                  # cleanup for other tests
+
+
+@pytest.mark.asyncio
+async def test_non_quota_batch_failure_falls_back_to_per_text_isolating_a_poison(db_session, monkeypatch):
+    """A batch fails atomically, so one poison text could otherwise starve the rest forever. On a
+    non-quota batch failure the backfill retries each text individually — good ones still embed,
+    only the offender stays failed. The pipeline is NOT stalled."""
+    await _pending_articles(db_session, 3)  # titles t0, t1, t2
+    calls = {"single": 0}
+
+    async def _batch_none(texts):
+        return None  # non-quota whole-batch failure
+
+    async def _single(text, **kwargs):
+        calls["single"] += 1
+        return None if "t1 " in text else [0.5] * 768  # t1 is the poison
+
+    async def _key():
+        return "k"
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _key)
+    monkeypatch.setattr(embeddings, "generate_embeddings_batch", _batch_none)
+    monkeypatch.setattr(embeddings, "generate_embedding", _single)
+    embeddings._embedding_backoff_until = 0.0
+
+    await embeddings.backfill_embeddings(session=db_session)
+
+    assert calls["single"] == 3
+    assert await _count(db_session, EmbeddingStatus.complete) == 2  # the other two are unblocked
+    assert await _count(db_session, EmbeddingStatus.failed) == 1    # only the poison stays failed
+    embeddings._embedding_backoff_until = 0.0
+
+
+@pytest.mark.asyncio
+async def test_systemic_non_quota_failure_arms_a_short_backoff(db_session, monkeypatch):
+    """If even the per-text fallback embeds nothing (transport/systemic), back off instead of
+    re-firing the identical failing work every 5 minutes."""
+    await _pending_articles(db_session, 2)
+
+    async def _batch_none(texts):
+        return None
+
+    async def _single_none(text, **kwargs):
+        return None
+
+    async def _key():
+        return "k"
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _key)
+    monkeypatch.setattr(embeddings, "generate_embeddings_batch", _batch_none)
+    monkeypatch.setattr(embeddings, "generate_embedding", _single_none)
+    embeddings._embedding_backoff_until = 0.0
+
+    await embeddings.backfill_embeddings(session=db_session)
+    assert embeddings._embedding_backoff_until > time.time()  # short backoff armed
+    embeddings._embedding_backoff_until = 0.0
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_batch_raises_quota_on_429(monkeypatch):
+    async def _key():
+        return "k"
+
+    def _boom(*a, **k):
+        raise RuntimeError("429 Resource has been exhausted (quota)")
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _key)
+    monkeypatch.setattr(embeddings, "_embed_batch_sync", _boom)
+
+    with pytest.raises(embeddings.QuotaExceeded):
+        await embeddings.generate_embeddings_batch(["a", "b"])
+    assert embeddings.last_embedding_error()["category"] == "quota"
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_batch_returns_vectors_and_clears_error(monkeypatch):
+    async def _key():
+        return "k"
+
+    def _ok(key, model, texts, task_type, output_dim):
+        return [[0.1, 0.2], [0.3, 0.4]]
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _key)
+    monkeypatch.setattr(embeddings, "_embed_batch_sync", _ok)
+    embeddings._last_embedding_error = {"category": "quota", "message": "old", "when": "x"}
+
+    out = await embeddings.generate_embeddings_batch(["a", "b"])
+    assert out == [[0.1, 0.2], [0.3, 0.4]]
+    assert embeddings.last_embedding_error() is None

--- a/backend/tests/integration/test_pipeline_status.py
+++ b/backend/tests/integration/test_pipeline_status.py
@@ -1,0 +1,60 @@
+"""GET /pipeline — at-a-glance pipeline health so a stalled embedding→cluster stage is obvious
+without the Render log stream (this is what would have shown '0 embedded, 500 pending' instantly)."""
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import Article, ClusterArticle, EmbeddingStatus, Source, SourceType, StoryCluster
+from app.services import embeddings
+
+
+async def _src(db):
+    s = Source(name="wire", url="https://w.example", rss_url="https://w.example/rss",
+               source_type=SourceType.wire, region="global", category="world")
+    db.add(s)
+    await db.flush()
+    return s
+
+
+@pytest.mark.asyncio
+async def test_pipeline_status_reports_counts(aclient, db_session):
+    s = await _src(db_session)
+    statuses = [EmbeddingStatus.pending, EmbeddingStatus.pending,
+                EmbeddingStatus.complete, EmbeddingStatus.failed]
+    for i, st in enumerate(statuses):
+        db_session.add(Article(title=f"a{i}", url=f"https://w.example/{i}", source_id=s.id,
+                               embedding_status=st, published_at=datetime.now(timezone.utc)))
+    await db_session.flush()
+    art = (await db_session.execute(select(Article).where(Article.source_id == s.id))).scalars().first()
+    c = StoryCluster(title="c", summary="s")
+    db_session.add(c)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=c.id, article_id=art.id))
+    await db_session.flush()
+
+    r = await aclient.get("/pipeline")
+    assert r.status_code == 200
+    d = r.json()
+    assert d["articles"]["total"] >= 4
+    bs = d["articles"]["by_embedding_status"]
+    assert bs.get("pending", 0) >= 2
+    assert bs.get("complete", 0) >= 1
+    assert bs.get("failed", 0) >= 1
+    assert d["clusters"]["total"] >= 1
+    assert d["clusters"]["articles_clustered"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_surfaces_last_embedding_error(aclient, db_session, monkeypatch):
+    monkeypatch.setattr(embeddings, "_last_embedding_error",
+                        {"category": "quota", "message": "429 exhausted", "when": "2026-07-04T00:00:00Z"})
+    d = (await aclient.get("/pipeline")).json()
+    assert d["last_embedding_error"]["category"] == "quota"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_clean_when_no_error(aclient, db_session, monkeypatch):
+    monkeypatch.setattr(embeddings, "_last_embedding_error", None)
+    d = (await aclient.get("/pipeline")).json()
+    assert d["last_embedding_error"] is None

--- a/backend/tests/unit/test_embeddings_status.py
+++ b/backend/tests/unit/test_embeddings_status.py
@@ -1,0 +1,71 @@
+"""Pipeline observability: embedding failures are classified + recorded so /pipeline can surface WHY
+the pipeline is stalled (quota vs auth vs no-key vs other) without needing the Render log stream."""
+import pytest
+
+from app.services import embeddings
+
+
+def test_classify_embedding_error_categories():
+    c = embeddings._classify_embedding_error
+    assert c("429 Resource has been exhausted (quota)") == "quota"
+    assert c("Rate limit exceeded, retry later") == "quota"
+    assert c("API key not valid. Please pass a valid API key.") == "auth"
+    assert c("403 PERMISSION_DENIED") == "auth"
+    assert c("401 Unauthenticated") == "auth"
+    assert c("Some unexpected transport error") == "other"
+
+
+@pytest.mark.asyncio
+async def test_generate_embedding_records_last_error(monkeypatch):
+    """A failing embed call is recorded (category + message) and returns None (never raises)."""
+    embeddings._last_embedding_error = None
+
+    async def _fake_key():
+        return "fake-key"
+
+    def _boom(*a, **k):
+        raise RuntimeError("429 Resource has been exhausted (quota)")
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _fake_key)
+    monkeypatch.setattr(embeddings, "_embed_sync", _boom)
+
+    out = await embeddings.generate_embedding("hello world")
+    assert out is None
+    err = embeddings.last_embedding_error()
+    assert err is not None
+    assert err["category"] == "quota"
+    assert "exhausted" in err["message"].lower()
+    assert err.get("when")  # timestamp present
+
+
+@pytest.mark.asyncio
+async def test_generate_embedding_records_no_key(monkeypatch):
+    """The silent dead-stop (no Gemini key anywhere) is recorded as its own category."""
+    embeddings._last_embedding_error = None
+
+    async def _no_key():
+        return None
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _no_key)
+    out = await embeddings.generate_embedding("hi")
+    assert out is None
+    assert embeddings.last_embedding_error()["category"] == "no_key"
+
+
+@pytest.mark.asyncio
+async def test_successful_embedding_clears_last_error(monkeypatch):
+    """After a recovery, a success clears the sticky error so /pipeline doesn't cry wolf forever."""
+    embeddings._last_embedding_error = {"category": "quota", "message": "old", "when": "x"}
+
+    async def _fake_key():
+        return "fake-key"
+
+    def _ok(*a, **k):
+        return [0.1, 0.2, 0.3]
+
+    monkeypatch.setattr(embeddings, "_resolve_embedding_key", _fake_key)
+    monkeypatch.setattr(embeddings, "_embed_sync", _ok)
+
+    out = await embeddings.generate_embedding("hi")
+    assert out == [0.1, 0.2, 0.3]
+    assert embeddings.last_embedding_error() is None


### PR DESCRIPTION
Fixes the deployed pipeline: **story details were empty because 0 articles ever embedded** — the free-tier Gemini quota was being blown. This PR diagnoses it *and* fixes the root cause.

## Root cause (confirmed from the Gemini dashboard)
- **429 TooManyRequests: 1,709 / 2,790 requests · 36.86% success.** That success count (~1,028) is exactly the free-tier **1,000 embeddings/day** cap.
- The old backfill made **one request per article** and retried failed rows every 5 min → torched the daily quota → `embedding_status` stuck all pending/failed → nothing clustered (`cluster_id` all `None`) → detail pages (which open a cluster) were empty. Silent, because `/health` stayed green.

## Fixes
**1. Root-cause fix — batch the backfill + circuit-breaker**
- `BatchEmbedContents` (`content=[list]`): **50 texts per request** (SDK max 100). 500 articles/day → **~10 requests** instead of 500 — two orders of magnitude under the cap. Order-aligned; `output_dimensionality` applied per item (verified against the SDK).
- On a 429, `QuotaExceeded` **parks the backfill for a cooldown** instead of re-firing a spent quota every cycle (that death-spiral was what produced 1,709 429s).
- Adversarial review (MEDIUM, fixed): a batch fails atomically, so a single poison text could starve the whole batch forever — so on a non-quota batch failure it **falls back to per-text embedding** to isolate the offender, with a short backoff if even that embeds nothing.

**2. Observability — so this is never silent again**
- **`GET /pipeline`** (unauthenticated, like `/health`): counts by `embedding_status`, cluster totals, freshness, and **`last_embedding_error.category`** (quota/auth/no_key). Would have shown "500 articles, 0 embedded, quota" instantly.

**3. Keep-alive**
- `keepalive.yml` pings `/health` every ~10 min so Render's free tier doesn't spin down and stop the in-process scheduler. Free on a public repo.

## Verification
- TDD: 13 new tests (batch=1 request, quota backoff+skip, poison isolation, systemic backoff, error classify/record/clear, `/pipeline` counts + error surfacing).
- Full backend suite **423 passed / 1 skipped**; ruff clean. No migration.

## Known residual (LOW, accepted)
The 429 backoff clock is in-memory, so a process restart re-probes a spent quota once — self-bounded to a single batched request per restart (not a storm). Persisting it to the DB wasn't worth it.

## After merge / deploy
`GET /pipeline` will show the live state. If it still shows `category: quota` after the batching deploys (i.e. genuine daily volume exceeds the cap), that's the point to consider the paid Gemini tier — but batching should keep you far under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
