### PR TITLE
WS-2: Follow Anything — free-text rails + per-rail badges (closes #112)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,9 @@ news-app/
 | GET | /clusters/{id}/strategic | Game-theory lens (geopolitics-gated) |
 | GET | /clusters/{id}/trivia | Story quiz (easy/medium/hard) |
 | GET | /trivia/daily | Daily quiz by topic |
-| GET/POST/DELETE | /follows[ /{id}] | List / add / remove a follow (topic, entity, saved search, or source) (Wave C; `kind=source` value = source id) |
+| GET/POST/DELETE | /follows[ /{id}] | List / add / remove a follow (topic, entity, saved search, or source) (Wave C; `kind=source` value = source id; `saved_search` capped at `saved_search_cap`) |
+| GET | /follows/rails | "News You Follow" — one recency-scoped rail per rail-able follow (saved_search hybrid / topic / entity; source excluded), per-rail `new_count` badge, 60s cached (WS-2) |
+| POST | /follows/{id}/seen | Clear a rail's badge — sets per-follow `last_viewed_at` (unlike global `last_seen_at`, digest reads never clear it) (WS-2) |
 | GET | /digest | Personalized digest of followed topics/entities (Wave C) |
 | GET/POST | /admin/sources | List / upsert sources (research/expert require credibility_score, 0-100 → else 400) |
 | PUT | /admin/sources/{id}/credibility | Admin applies a score + rationale; stamps reviewed_by="admin" (400 out-of-range, 404 unknown) |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1856,6 +1856,22 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
     ).scalar_one_or_none()
     if existing is not None:
         return FollowOut.model_validate(existing)
+    # WS-2 (#112): cap free-text follows so the rails section stays a curated shelf, not a firehose.
+    if kind == "saved_search":
+        from app.config import settings as _cfg
+
+        count = (
+            await db.execute(
+                select(func.count()).select_from(Follow).where(
+                    Follow.user_id == current_user_id(), Follow.kind == "saved_search"
+                )
+            )
+        ).scalar_one()
+        if count >= _cfg.saved_search_cap:
+            raise HTTPException(
+                status_code=400,
+                detail=f"you follow {_cfg.saved_search_cap} topics — unfollow one first",
+            )
     f = Follow(
         user_id=current_user_id(), kind=kind, value=value,
         entity_id=(body.entity_id if kind == "entity" else None),
@@ -1863,6 +1879,8 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
     db.add(f)
     await db.commit()
     await db.refresh(f)
+    from app.services import rails as _rails
+    _rails.invalidate(current_user_id())  # WS-2: a new follow changes the rails payload
     if kind == "entity":
         from app.config import settings
         from app.services import entities
@@ -1899,6 +1917,36 @@ async def delete_follow(follow_id: int, db: AsyncSession = Depends(get_db)):
     if f is not None:
         await db.delete(f)
         await db.commit()
+        from app.services import rails as _rails
+        _rails.invalidate(current_user_id())
+
+
+@router.get("/follows/rails", dependencies=[Depends(get_current_user)])
+async def follows_rails(db: AsyncSession = Depends(get_db)):
+    """WS-2 (#112): the "News You Follow" section — one rail per rail-able follow (saved_search /
+    topic / entity; source follows excluded), 72h-windowed, with a per-rail badge new_count. ONE
+    request; the server loops the follows (60s cached). A failing follow drops its rail, never the
+    section."""
+    from app.services import rails as _rails
+
+    return {"rails": await _rails.rails_for_user(db, current_user_id())}
+
+
+@router.post("/follows/{follow_id}/seen", status_code=204, dependencies=[Depends(get_current_user)])
+async def mark_follow_seen(follow_id: int, db: AsyncSession = Depends(get_db)):
+    """WS-2 (#112): clears a rail's badge — sets follows.last_viewed_at=now for THIS follow only
+    (tapping a rail story or its 'see all'). Per-follow, so viewing one rail never clears another,
+    and (unlike the global User.last_seen_at) reading the digest never clears rail badges."""
+    f = (
+        await db.execute(
+            select(Follow).where(Follow.id == follow_id, Follow.user_id == current_user_id())
+        )
+    ).scalar_one_or_none()
+    if f is not None:
+        f.last_viewed_at = datetime.now(timezone.utc)
+        await db.commit()
+        from app.services import rails as _rails
+        _rails.invalidate(current_user_id())
 
 
 @router.get("/digest", response_model=DigestResponse, dependencies=[Depends(get_current_user)])

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -158,6 +158,20 @@ class Settings(BaseSettings):
     impressions_enabled: bool = True
     impression_daily_cap: int = 500     # rows/user/day — server drops (and logs) beyond
     uer_less_weight: float = -0.5       # negative bump per 'less' on each of the article's entities
+    # WS-2 (#112) — "News You Follow" free-text rails. A saved_search follow is evaluated read-time via
+    # the /search hybrid machinery, scoped to a recency window. PRECISION GUARD: admit a cluster iff
+    # (dist < loose AND a keyword-or-entity hit confirms the proper nouns) OR (dist < tight, a pure
+    # semantic near-match). These are STARTING hypotheses — a distance histogram is logged per eval and
+    # scripts/measure_follow_distances.py calibrates them against the real prod corpus (query↔document
+    # embeddings have their own distribution; clustering's 0.15 doc↔doc threshold does NOT transfer).
+    rails_enabled: bool = True
+    rails_recency_hours: int = 72       # only stories from the last N hours appear in a rail
+    rails_stories_per_follow: int = 5   # cards shown per rail
+    rails_ann_k: int = 50               # ANN candidates pulled before the recency+precision filter
+    rails_cache_ttl_seconds: int = 60   # per-user response cache (invalidated on follow/seen change)
+    rails_dist_loose: float = 0.35      # semantic-near AND keyword/entity confirmation
+    rails_dist_tight: float = 0.22      # pure semantic near-match (no keyword needed)
+    saved_search_cap: int = 20          # max saved_search follows per user
 
     # DB SSL: verified by default for cloud (Neon/Supabase). Opt out only if a cert
     # chain genuinely can't be verified in your environment.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -365,6 +365,10 @@ class Follow(Base):
     # G2: the resolved entity behind an entity-follow (from the tapped chip). Nullable keeps uq_follow
     # live with no orphan window; the string-path follow leaves it NULL.
     entity_id: Mapped[int | None] = mapped_column(ForeignKey("entities.id", ondelete="SET NULL"))
+    # WS-2 (#112) badges: when the user last opened THIS rail. new_count = rail stories newer than it.
+    # Per-follow (NOT the global User.last_seen_at, which /digest resets on every read). NULL = never
+    # viewed → every current story counts as new.
+    last_viewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/services/rails.py
+++ b/backend/app/services/rails.py
@@ -43,18 +43,36 @@ RAIL_KINDS = ("saved_search", "topic", "entity")
 # 60s per-user cache: {user_id: (expires_epoch, payload)}. Process-local (a restart re-warms); a
 # follow create/delete or a /seen tap busts the caller's entry (see invalidate()).
 _cache: dict[int, tuple[float, list]] = {}
+# Per-user generation, bumped on every invalidate(). rails_for_user captures it before it starts
+# building and only writes the cache back if it's unchanged — so a create/delete/seen that lands
+# mid-build isn't masked by a stale write-back for a full TTL (compare-and-set).
+_generation: dict[int, int] = {}
 
 
 def invalidate(user_id: int) -> None:
     _cache.pop(user_id, None)
+    _generation[user_id] = _generation.get(user_id, 0) + 1
 
 
-def _admit(dist: float | None, keyword_hit: bool, entity_hit: bool) -> bool:
-    """The precision guard. A cluster joins a saved-search rail iff it's semantically near AND a
-    proper-noun hit confirms it, OR it's a very tight pure-semantic match. dist is None when the
-    semantic leg was unavailable — then a keyword/entity hit alone admits (keyword-only fallback)."""
+def _escape_like(s: str) -> str:
+    r"""Escape LIKE metacharacters so a saved-search phrase is matched LITERALLY — otherwise a
+    stray % or _ in the phrase acts as a wildcard and widens the keyword leg. Pairs with
+    ilike(..., escape='\\')."""
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _admit(dist: float | None, keyword_hit: bool, entity_hit: bool, *, semantic_available: bool) -> bool:
+    """The precision guard. When the semantic leg ran, a cluster joins a saved-search rail iff it's
+    semantically near AND a proper-noun hit confirms it, OR it's a very tight pure-semantic match —
+    keyword/entity hits are ONLY confirmation, never independent admission (else "US Iran war" pulls
+    in every Iran story via the entity leg). ONLY when the semantic leg was entirely unavailable
+    (embeddings down) do we degrade to a keyword-or-entity match. Distinguishing these two `dist is
+    None` cases is the whole point — a keyword/entity hit that merely fell outside the ANN top-k is
+    NOT the same as "we couldn't embed the query at all"."""
+    if not semantic_available:
+        return keyword_hit or entity_hit  # degraded: proper-noun match only
     if dist is None:
-        return keyword_hit or entity_hit
+        return False  # semantic ran but this candidate wasn't near enough to surface — reject
     if dist < settings.rails_dist_tight:
         return True
     if dist < settings.rails_dist_loose and (keyword_hit or entity_hit):
@@ -112,16 +130,21 @@ async def evaluate_saved_search(db: AsyncSession, phrase: str, since) -> set[int
         if dist_by_article:
             _log_distance_histogram(phrase, list(dist_by_article.values()))
 
-    # Keyword leg: exact substring in the title (recency-scoped).
-    like = f"%{phrase}%"
+    # Keyword leg: literal substring in the title (recency-scoped; LIKE metacharacters escaped so
+    # "%" / "_" in the phrase don't act as wildcards). Bounded to the newest rails_ann_k so a broad
+    # phrase ("India") can't union thousands of rows into one IN(...).
+    like = f"%{_escape_like(phrase)}%"
     kw_ids = set(
         (
             await db.execute(
-                select(Article.id).where(
-                    Article.title.ilike(like),
+                select(Article.id)
+                .where(
+                    Article.title.ilike(like, escape="\\"),
                     Article.published_at.isnot(None),
                     Article.published_at >= since,
                 )
+                .order_by(Article.published_at.desc())
+                .limit(settings.rails_ann_k)
             )
         ).scalars()
     )
@@ -129,12 +152,20 @@ async def evaluate_saved_search(db: AsyncSession, phrase: str, since) -> set[int
     # Entity leg: the phrase (or a token of it) matches a known entity alias → its recent articles.
     ent_ids = await _entity_leg(db, phrase, since)
 
-    # Union of every candidate, then admit per the precision guard.
-    candidates = set(dist_by_article) | kw_ids | ent_ids
+    # Admit per the precision guard. When the semantic leg ran, ONLY its top-k are candidates —
+    # keyword/entity legs are confirmation flags, never independent admission (see _admit). When it
+    # was unavailable, the proper-noun legs are all we have, so THEY become the candidate set.
+    semantic_available = emb is not None
+    candidates = set(dist_by_article) if semantic_available else (kw_ids | ent_ids)
     admitted = {
         aid
         for aid in candidates
-        if _admit(dist_by_article.get(aid), aid in kw_ids, aid in ent_ids)
+        if _admit(
+            dist_by_article.get(aid),
+            aid in kw_ids,
+            aid in ent_ids,
+            semantic_available=semantic_available,
+        )
     }
     return set((await _recent_cluster_of(db, sorted(admitted), since)).values())
 
@@ -163,6 +194,8 @@ async def _entity_leg(db: AsyncSession, phrase: str, since) -> set[int]:
                     Article.published_at.isnot(None),
                     Article.published_at >= since,
                 )
+                .order_by(Article.published_at.desc())
+                .limit(settings.rails_ann_k)  # bound: a hot entity ("Iran") can tag hundreds in 72h
             )
         ).scalars()
     )
@@ -268,6 +301,9 @@ async def rails_for_user(db: AsyncSession, user_id: int) -> list[dict]:
     if cached and cached[0] > now:
         return cached[1]
 
+    # Capture the generation BEFORE building. If a create/delete/seen invalidate() bumps it while we
+    # await DB calls below, we skip the stale write-back rather than mask the mutation for a full TTL.
+    gen_at_start = _generation.get(user_id, 0)
     since = datetime.now(timezone.utc) - timedelta(hours=settings.rails_recency_hours)
     follows = (
         await db.execute(
@@ -324,5 +360,7 @@ async def rails_for_user(db: AsyncSession, user_id: int) -> list[dict]:
             }
         )
 
-    _cache[user_id] = (now + settings.rails_cache_ttl_seconds, rails)
+    # Compare-and-set: only cache if no invalidate() landed while we were building (see gen_at_start).
+    if _generation.get(user_id, 0) == gen_at_start:
+        _cache[user_id] = (now + settings.rails_cache_ttl_seconds, rails)
     return rails

--- a/backend/app/services/rails.py
+++ b/backend/app/services/rails.py
@@ -1,0 +1,328 @@
+"""WS-2 (#112): "News You Follow" rails — evaluate a user's follows into recency-scoped story rails.
+
+A follow becomes a live category:
+- saved_search ("US Iran war") — HYBRID: pgvector ANN (semantic, exposing distance) + ILIKE keyword
+  + entity-alias leg, admitted by the precision guard so "US Iran war" doesn't drag in every
+  Middle-East story. Degrades to keyword+entity when embeddings are unavailable.
+- topic — clusters whose articles carry that topic.
+- entity — clusters featuring that entity (article_entities).
+- source follows are NOT rails (the tier gate already surfaces them in the feed).
+
+Each rail is independent (one follow's failure never kills the others), 72h-windowed, grouped by
+cluster, with a per-follow `new_count` since follows.last_viewed_at. A 60s per-user response cache
+keeps a home render from re-running N hybrid queries every visit.
+
+    ┌─ follows(saved_search|topic|entity) ─┐
+    │  per follow (isolated try/except):    │
+    │    saved_search → hybrid → cluster set │
+    │    topic/entity → membership → set     │──▶ group by cluster ▶ light stories ▶ new_count
+    └───────────────────────────────────────┘
+"""
+import time
+
+import structlog
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models import (
+    Article,
+    ArticleEntity,
+    ArticleTopic,
+    ClusterArticle,
+    EntityAlias,
+    Follow,
+    StoryCluster,
+    Topic,
+)
+
+logger = structlog.get_logger()
+
+RAIL_KINDS = ("saved_search", "topic", "entity")
+
+# 60s per-user cache: {user_id: (expires_epoch, payload)}. Process-local (a restart re-warms); a
+# follow create/delete or a /seen tap busts the caller's entry (see invalidate()).
+_cache: dict[int, tuple[float, list]] = {}
+
+
+def invalidate(user_id: int) -> None:
+    _cache.pop(user_id, None)
+
+
+def _admit(dist: float | None, keyword_hit: bool, entity_hit: bool) -> bool:
+    """The precision guard. A cluster joins a saved-search rail iff it's semantically near AND a
+    proper-noun hit confirms it, OR it's a very tight pure-semantic match. dist is None when the
+    semantic leg was unavailable — then a keyword/entity hit alone admits (keyword-only fallback)."""
+    if dist is None:
+        return keyword_hit or entity_hit
+    if dist < settings.rails_dist_tight:
+        return True
+    if dist < settings.rails_dist_loose and (keyword_hit or entity_hit):
+        return True
+    return False
+
+
+async def _recent_cluster_of(db: AsyncSession, article_ids: list[int], since) -> dict[int, int]:
+    """Map article_id -> cluster_id for articles published within the window (drops unclustered /
+    stale). One query, no N+1."""
+    if not article_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(ClusterArticle.article_id, ClusterArticle.cluster_id)
+            .join(Article, Article.id == ClusterArticle.article_id)
+            .where(
+                ClusterArticle.article_id.in_(article_ids),
+                Article.published_at.isnot(None),
+                Article.published_at >= since,
+            )
+        )
+    ).all()
+    return {aid: cid for aid, cid in rows}
+
+
+async def evaluate_saved_search(db: AsyncSession, phrase: str, since) -> set[int]:
+    """Hybrid eval of a free-text follow → the set of cluster ids in the window. Logs a distance
+    histogram so the precision thresholds can be calibrated from real data (the WS-2 pre-gate)."""
+    from app.services.embeddings import embed_query_cached, vector_literal
+
+    phrase = (phrase or "").strip()
+    if not phrase:
+        return set()
+
+    # Semantic leg: ANN with the recency predicate INSIDE the WHERE (post-filtering top-k could be
+    # saturated by old articles), exposing the distance the precision guard needs.
+    dist_by_article: dict[int, float] = {}
+    try:
+        emb = await embed_query_cached(phrase)
+    except Exception:  # noqa: BLE001 — semantic leg is best-effort; keyword/entity still run
+        emb = None
+    if emb is not None:
+        rows = (
+            await db.execute(
+                text(
+                    "SELECT id, embedding <=> :v AS dist FROM articles "
+                    "WHERE embedding IS NOT NULL AND published_at IS NOT NULL AND published_at >= :since "
+                    "ORDER BY embedding <=> :v LIMIT :k"
+                ),
+                {"v": vector_literal(emb), "since": since, "k": settings.rails_ann_k},
+            )
+        ).all()
+        dist_by_article = {aid: float(d) for aid, d in rows}
+        if dist_by_article:
+            _log_distance_histogram(phrase, list(dist_by_article.values()))
+
+    # Keyword leg: exact substring in the title (recency-scoped).
+    like = f"%{phrase}%"
+    kw_ids = set(
+        (
+            await db.execute(
+                select(Article.id).where(
+                    Article.title.ilike(like),
+                    Article.published_at.isnot(None),
+                    Article.published_at >= since,
+                )
+            )
+        ).scalars()
+    )
+
+    # Entity leg: the phrase (or a token of it) matches a known entity alias → its recent articles.
+    ent_ids = await _entity_leg(db, phrase, since)
+
+    # Union of every candidate, then admit per the precision guard.
+    candidates = set(dist_by_article) | kw_ids | ent_ids
+    admitted = {
+        aid
+        for aid in candidates
+        if _admit(dist_by_article.get(aid), aid in kw_ids, aid in ent_ids)
+    }
+    return set((await _recent_cluster_of(db, sorted(admitted), since)).values())
+
+
+async def _entity_leg(db: AsyncSession, phrase: str, since) -> set[int]:
+    """Recent article ids whose entities match the phrase by exact alias (normalized). Cheap
+    proper-noun anchor — "US Iran war" hits the 'iran'/'united states' aliases."""
+    from app.services.filings import norm_company  # reuse the punctuation-stripping normalizer
+
+    keys = {norm_company(phrase)} | {norm_company(tok) for tok in phrase.split()}
+    keys = {k for k in keys if len(k) >= 3}
+    if not keys:
+        return set()
+    ent_ids = (
+        await db.execute(select(EntityAlias.entity_id).where(EntityAlias.alias_norm.in_(sorted(keys))))
+    ).scalars().all()
+    if not ent_ids:
+        return set()
+    return set(
+        (
+            await db.execute(
+                select(ArticleEntity.article_id)
+                .join(Article, Article.id == ArticleEntity.article_id)
+                .where(
+                    ArticleEntity.entity_id.in_(sorted(set(ent_ids))),
+                    Article.published_at.isnot(None),
+                    Article.published_at >= since,
+                )
+            )
+        ).scalars()
+    )
+
+
+def _log_distance_histogram(phrase: str, dists: list[float]) -> None:
+    dists = sorted(dists)
+    n = len(dists)
+    logger.info(
+        "rail_distance_histogram",
+        phrase=phrase[:60],
+        n=n,
+        min=round(dists[0], 4),
+        p25=round(dists[n // 4], 4),
+        p50=round(dists[n // 2], 4),
+        max=round(dists[-1], 4),
+        under_tight=sum(1 for d in dists if d < settings.rails_dist_tight),
+        under_loose=sum(1 for d in dists if d < settings.rails_dist_loose),
+    )
+
+
+async def evaluate_topic(db: AsyncSession, topic_name: str, since) -> set[int]:
+    """Clusters whose recent articles carry the followed topic (value = topic name)."""
+    return set(
+        (
+            await db.execute(
+                select(ClusterArticle.cluster_id)
+                .join(ArticleTopic, ArticleTopic.article_id == ClusterArticle.article_id)
+                .join(Topic, Topic.id == ArticleTopic.topic_id)
+                .join(Article, Article.id == ClusterArticle.article_id)
+                .where(
+                    func.lower(Topic.name) == topic_name.strip().lower(),
+                    Article.published_at.isnot(None),
+                    Article.published_at >= since,
+                )
+                .distinct()
+            )
+        ).scalars()
+    )
+
+
+async def evaluate_entity(db: AsyncSession, follow: Follow, since) -> set[int]:
+    """Clusters featuring the followed entity. Prefer the resolved entity_id (chip path); else
+    resolve the string value to an entity."""
+    from app.services import entities as ent
+
+    eid = follow.entity_id
+    if eid is None:
+        eid = await ent.resolve_existing(db, follow.value)
+    if eid is None:
+        return set()
+    return set(
+        (
+            await db.execute(
+                select(ClusterArticle.cluster_id)
+                .join(ArticleEntity, ArticleEntity.article_id == ClusterArticle.article_id)
+                .join(Article, Article.id == ClusterArticle.article_id)
+                .where(
+                    ArticleEntity.entity_id == eid,
+                    Article.published_at.isnot(None),
+                    Article.published_at >= since,
+                )
+                .distinct()
+            )
+        ).scalars()
+    )
+
+
+async def _cluster_id_since(db: AsyncSession, cluster_ids: list[int]):
+    """Per-cluster newest article published_at (for new_count) + a light story payload — cached-summary
+    ONLY (no on-demand LLM: a rails render must be cheap)."""
+    if not cluster_ids:
+        return {}, {}
+    story_rows = (
+        await db.execute(
+            select(StoryCluster).where(StoryCluster.id.in_(cluster_ids))
+        )
+    ).scalars().all()
+    newest = (
+        await db.execute(
+            select(ClusterArticle.cluster_id, func.max(Article.published_at), func.count())
+            .join(Article, Article.id == ClusterArticle.article_id)
+            .where(ClusterArticle.cluster_id.in_(cluster_ids))
+            .group_by(ClusterArticle.cluster_id)
+        )
+    ).all()
+    meta = {cid: (ts, cnt) for cid, ts, cnt in newest}
+    return {s.id: s for s in story_rows}, meta
+
+
+async def rails_for_user(db: AsyncSession, user_id: int) -> list[dict]:
+    """The whole "News You Follow" payload for a user: one rail per rail-able follow, newest-first,
+    each with ≤N stories in the 72h window and a badge new_count. Source follows are excluded.
+
+    Per-follow isolation: a single follow's eval failure drops THAT rail and logs — the others render.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    if not settings.rails_enabled:
+        return []
+    now = time.time()
+    cached = _cache.get(user_id)
+    if cached and cached[0] > now:
+        return cached[1]
+
+    since = datetime.now(timezone.utc) - timedelta(hours=settings.rails_recency_hours)
+    follows = (
+        await db.execute(
+            select(Follow)
+            .where(Follow.user_id == user_id, Follow.kind.in_(RAIL_KINDS))
+            .order_by(Follow.created_at.desc())
+        )
+    ).scalars().all()
+
+    rails: list[dict] = []
+    for f in follows:
+        try:
+            if f.kind == "saved_search":
+                cluster_ids = await evaluate_saved_search(db, f.value, since)
+            elif f.kind == "topic":
+                cluster_ids = await evaluate_topic(db, f.value, since)
+            else:  # entity
+                cluster_ids = await evaluate_entity(db, f, since)
+        except Exception as e:  # noqa: BLE001 — isolate: one bad rail must not blank the section
+            logger.warning("rail_eval_failed", follow_id=f.id, kind=f.kind, error=str(e))
+            continue
+
+        stories_by_id, meta = await _cluster_id_since(db, sorted(cluster_ids))
+        # newest-first by the cluster's newest article; cap to N.
+        ordered = sorted(
+            cluster_ids,
+            key=lambda cid: (meta.get(cid, (None, 0))[0] or datetime.min.replace(tzinfo=timezone.utc)),
+            reverse=True,
+        )
+        top = ordered[: settings.rails_stories_per_follow]
+        new_count = sum(
+            1
+            for cid in cluster_ids
+            if f.last_viewed_at is None
+            or (meta.get(cid, (None, 0))[0] is not None and meta[cid][0] > f.last_viewed_at)
+        )
+        rails.append(
+            {
+                "follow_id": f.id,
+                "kind": f.kind,
+                "value": f.value,
+                "total": len(cluster_ids),
+                "new_count": new_count,
+                "stories": [
+                    {
+                        "cluster_id": cid,
+                        "title": stories_by_id[cid].title if cid in stories_by_id else "",
+                        "summary": (stories_by_id[cid].summary if cid in stories_by_id else None),
+                        "source_count": meta.get(cid, (None, 1))[1],
+                    }
+                    for cid in top
+                    if cid in stories_by_id
+                ],
+            }
+        )
+
+    _cache[user_id] = (now + settings.rails_cache_ttl_seconds, rails)
+    return rails

--- a/backend/migrations/versions/e5f6a7b8c9da_ws2_follow_last_viewed.py
+++ b/backend/migrations/versions/e5f6a7b8c9da_ws2_follow_last_viewed.py
@@ -1,0 +1,25 @@
+"""WS-2 (#112): follows.last_viewed_at — per-follow badge clock.
+
+new_count on a "News You Follow" rail = stories newer than this timestamp. Per-follow (the global
+User.last_seen_at can't work — /digest resets it on every read, and one timestamp can't express
+per-rail counts). NULL = never viewed.
+
+Revision ID: e5f6a7b8c9da
+Revises: d4e5f6a7b8c9
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e5f6a7b8c9da"
+down_revision = "d4e5f6a7b8c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("follows", sa.Column("last_viewed_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("follows", "last_viewed_at")

--- a/backend/scripts/measure_follow_distances.py
+++ b/backend/scripts/measure_follow_distances.py
@@ -1,0 +1,83 @@
+"""WS-2 (#112) PRE-GATE: measure real query->article cosine distances so the rails precision
+thresholds (rails_dist_loose / rails_dist_tight) are CALIBRATED, not guessed.
+
+Query embeddings (RETRIEVAL_QUERY) and document embeddings (RETRIEVAL_DOCUMENT) have their own
+distance distribution — clustering's 0.15 doc<->doc threshold does NOT transfer, and nobody has ever
+observed a query<->article distance in this system (search discards it). This script logs the
+distribution for a handful of representative phrases against the live corpus.
+
+RUN (needs a Gemini key + DB access — the CI harness mocks embeddings, so this is a manual tool):
+    cd backend
+    GEMINI_API_KEY=... DATABASE_URL=postgresql+asyncpg://... python -m scripts.measure_follow_distances
+
+Read the output: for a GOOD phrase ("US Iran war"), the true matches cluster at low distance and there
+is a visible gap before the off-topic tail — set rails_dist_tight just below the on-topic cluster and
+rails_dist_loose at the gap. For a BROAD phrase ("AI"), expect no gap (that's why the keyword/entity
+confirmation leg exists). The rails endpoint ALSO logs `rail_distance_histogram` per eval in prod, so
+these thresholds keep self-reporting once live.
+"""
+import asyncio
+import statistics
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import async_session
+from app.services.embeddings import embed_query_cached, vector_literal
+
+PHRASES = [
+    "US Iran war",
+    "AI chip supply chain",
+    "Russia Ukraine war",
+    "UK politics",
+    "South Korea stock market",
+    "AI innovations",
+    "Reliance Industries earnings",
+    "cricket world cup",
+    "climate policy",
+    "Federal Reserve interest rates",
+]
+
+
+async def _distances(session: AsyncSession, phrase: str, k: int = 100) -> list[float]:
+    emb = await embed_query_cached(phrase)
+    if emb is None:
+        return []
+    rows = (
+        await session.execute(
+            text(
+                "SELECT embedding <=> :v AS dist FROM articles "
+                "WHERE embedding IS NOT NULL AND published_at >= now() - interval '72 hours' "
+                "ORDER BY embedding <=> :v LIMIT :k"
+            ),
+            {"v": vector_literal(emb), "k": k},
+        )
+    ).all()
+    return [float(d) for (d,) in rows]
+
+
+def _fmt(ds: list[float]) -> str:
+    if not ds:
+        return "no embedded articles in window"
+    ds = sorted(ds)
+    q = statistics.quantiles(ds, n=20) if len(ds) >= 20 else ds
+    return (
+        f"n={len(ds)}  min={ds[0]:.3f}  p5={q[0]:.3f}  p25={ds[len(ds)//4]:.3f} "
+        f"p50={ds[len(ds)//2]:.3f}  max={ds[-1]:.3f}  "
+        f"<tight({settings.rails_dist_tight})={sum(d < settings.rails_dist_tight for d in ds)}  "
+        f"<loose({settings.rails_dist_loose})={sum(d < settings.rails_dist_loose for d in ds)}"
+    )
+
+
+async def main() -> None:
+    print(f"Current thresholds: tight={settings.rails_dist_tight}  loose={settings.rails_dist_loose}\n")
+    async with async_session() as session:
+        for phrase in PHRASES:
+            ds = await _distances(session, phrase)
+            print(f"{phrase:32s} {_fmt(ds)}")
+    print("\nCalibrate: tight = just below each on-topic cluster; loose = the gap before the off-topic tail.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/integration/test_rails.py
+++ b/backend/tests/integration/test_rails.py
@@ -1,0 +1,176 @@
+"""WS-2 (#112): GET /follows/rails + badges + cap + isolation. Topic/entity rails are tested
+end-to-end (no embeddings needed); saved_search's semantic leg is covered by test_rails_admit +
+the graceful-degrade test here."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import (
+    Article,
+    ArticleEntity,
+    ArticleTopic,
+    ClusterArticle,
+    Entity,
+    Follow,
+    Source,
+    SourceType,
+    StoryCluster,
+    Topic,
+    User,
+)
+from app.services import rails as rails_svc
+
+
+async def _ensure_user(db, uid=1):
+    if await db.get(User, uid) is None:
+        db.add(User(id=uid, locale="IN"))
+        await db.flush()
+
+
+async def _story(db, title, *, topic=None, entity=None, hours_ago=1):
+    src = Source(name=f"s-{title}", url=f"https://{title}.ex", rss_url=f"https://{title}.ex/r",
+                 source_type=SourceType.wire, region="global", category="world")
+    db.add(src)
+    await db.flush()
+    art = Article(title=title, url=f"https://{title}.ex/a", source_id=src.id,
+                  published_at=datetime.now(timezone.utc) - timedelta(hours=hours_ago))
+    db.add(art)
+    await db.flush()
+    c = StoryCluster(title=title, summary=f"summary of {title}")
+    db.add(c)
+    await db.flush()
+    db.add(ClusterArticle(cluster_id=c.id, article_id=art.id))
+    if topic is not None:
+        t = (await db.execute(select(Topic).where(Topic.name == topic))).scalars().first()
+        if t is None:
+            t = Topic(name=topic)
+            db.add(t)
+            await db.flush()
+        db.add(ArticleTopic(article_id=art.id, topic_id=t.id))
+    if entity is not None:
+        db.add(ArticleEntity(article_id=art.id, entity_id=entity.id, salience=0.9, confidence=0.9))
+    await db.flush()
+    return c, art
+
+
+@pytest.fixture(autouse=True)
+def _clear_rail_cache():
+    rails_svc._cache.clear()
+    yield
+    rails_svc._cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_topic_follow_gets_a_rail_with_its_stories(aclient, db_session):
+    await _ensure_user(db_session)
+    c, _ = await _story(db_session, "Mars landing", topic="Space")
+    await _story(db_session, "Unrelated", topic="Cooking")
+    db_session.add(Follow(user_id=1, kind="topic", value="Space"))
+    await db_session.flush()
+
+    r = await aclient.get("/follows/rails")
+    assert r.status_code == 200
+    rails = r.json()["rails"]
+    space = next(x for x in rails if x["value"] == "Space")
+    assert space["total"] == 1
+    assert {s["cluster_id"] for s in space["stories"]} == {c.id}
+    assert space["new_count"] == 1  # never viewed → all new
+
+
+@pytest.mark.asyncio
+async def test_entity_follow_gets_a_rail(aclient, db_session):
+    await _ensure_user(db_session)
+    e = Entity(canonical_name="NASA", name_norm="nasa", kind="org")
+    db_session.add(e)
+    await db_session.flush()
+    c, _ = await _story(db_session, "NASA budget", entity=e)
+    db_session.add(Follow(user_id=1, kind="entity", value="NASA", entity_id=e.id))
+    await db_session.flush()
+
+    rails = (await aclient.get("/follows/rails")).json()["rails"]
+    nasa = next(x for x in rails if x["value"] == "NASA")
+    assert {s["cluster_id"] for s in nasa["stories"]} == {c.id}
+
+
+@pytest.mark.asyncio
+async def test_source_follows_are_not_rails(aclient, db_session):
+    await _ensure_user(db_session)
+    src = (await db_session.execute(select(Source))).scalars().first()
+    if src is None:
+        src = Source(name="src", url="https://src.ex", rss_url="https://src.ex/r",
+                     source_type=SourceType.wire, region="global", category="world")
+        db_session.add(src)
+        await db_session.flush()
+    db_session.add(Follow(user_id=1, kind="source", value=str(src.id)))
+    await db_session.flush()
+    rails = (await aclient.get("/follows/rails")).json()["rails"]
+    assert all(x["kind"] != "source" for x in rails)
+
+
+@pytest.mark.asyncio
+async def test_recency_window_excludes_old_stories(aclient, db_session):
+    await _ensure_user(db_session)
+    await _story(db_session, "Fresh", topic="News", hours_ago=1)
+    await _story(db_session, "Ancient", topic="News", hours_ago=200)  # > 72h window
+    db_session.add(Follow(user_id=1, kind="topic", value="News"))
+    await db_session.flush()
+    rails = (await aclient.get("/follows/rails")).json()["rails"]
+    news = next(x for x in rails if x["value"] == "News")
+    assert news["total"] == 1  # only the fresh one
+
+
+@pytest.mark.asyncio
+async def test_seen_clears_badge_but_digest_does_not(aclient, db_session):
+    """The core badge contract: /seen zeroes new_count for THAT follow; reading /digest must NOT."""
+    await _ensure_user(db_session)
+    await _story(db_session, "Quake", topic="Geo")
+    f = Follow(user_id=1, kind="topic", value="Geo")
+    db_session.add(f)
+    await db_session.flush()
+
+    rails_svc._cache.clear()
+    before = next(x for x in (await aclient.get("/follows/rails")).json()["rails"] if x["value"] == "Geo")
+    assert before["new_count"] == 1
+
+    # reading the digest must not clear the rail badge (regression vs the global last_seen_at)
+    await aclient.get("/digest")
+    rails_svc._cache.clear()
+    still = next(x for x in (await aclient.get("/follows/rails")).json()["rails"] if x["value"] == "Geo")
+    assert still["new_count"] == 1
+
+    # tapping the rail (POST /seen) clears it
+    assert (await aclient.post(f"/follows/{f.id}/seen")).status_code == 204
+    rails_svc._cache.clear()
+    after = next(x for x in (await aclient.get("/follows/rails")).json()["rails"] if x["value"] == "Geo")
+    assert after["new_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_saved_search_cap(aclient, db_session):
+    await _ensure_user(db_session)
+    from app.config import settings
+    for i in range(settings.saved_search_cap):
+        r = await aclient.post("/follows", json={"kind": "saved_search", "value": f"topic {i}"})
+        assert r.status_code == 201
+    over = await aclient.post("/follows", json={"kind": "saved_search", "value": "one too many"})
+    assert over.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_one_failing_rail_does_not_kill_the_section(aclient, db_session, monkeypatch):
+    await _ensure_user(db_session)
+    await _story(db_session, "Good", topic="Good")
+    db_session.add(Follow(user_id=1, kind="topic", value="Good"))
+    db_session.add(Follow(user_id=1, kind="saved_search", value="boom"))
+    await db_session.flush()
+
+    async def _boom(db, phrase, since):
+        raise RuntimeError("semantic leg exploded")
+
+    monkeypatch.setattr(rails_svc, "evaluate_saved_search", _boom)
+    rails_svc._cache.clear()
+    rails = (await aclient.get("/follows/rails")).json()["rails"]
+    values = {x["value"] for x in rails}
+    assert "Good" in values          # the healthy rail survived
+    assert "boom" not in values      # the exploded rail was dropped, not fatal

--- a/backend/tests/integration/test_rails.py
+++ b/backend/tests/integration/test_rails.py
@@ -57,8 +57,10 @@ async def _story(db, title, *, topic=None, entity=None, hours_ago=1):
 @pytest.fixture(autouse=True)
 def _clear_rail_cache():
     rails_svc._cache.clear()
+    rails_svc._generation.clear()
     yield
     rails_svc._cache.clear()
+    rails_svc._generation.clear()
 
 
 @pytest.mark.asyncio
@@ -174,3 +176,27 @@ async def test_one_failing_rail_does_not_kill_the_section(aclient, db_session, m
     values = {x["value"] for x in rails}
     assert "Good" in values          # the healthy rail survived
     assert "boom" not in values      # the exploded rail was dropped, not fatal
+
+
+@pytest.mark.asyncio
+async def test_invalidate_mid_build_skips_stale_cache_write(db_session, monkeypatch):
+    """LOW (review): a create/delete/seen that lands WHILE rails_for_user is building must not be
+    masked by a stale write-back for a full TTL. Simulate the race by invalidating during the build."""
+    await _ensure_user(db_session)
+    await _story(db_session, "Flood", topic="Weather")
+    db_session.add(Follow(user_id=1, kind="topic", value="Weather"))
+    await db_session.flush()
+    rails_svc._cache.clear()
+    rails_svc._generation.clear()
+
+    real_eval = rails_svc.evaluate_topic
+
+    async def _eval_then_invalidate(db, name, since):
+        out = await real_eval(db, name, since)
+        rails_svc.invalidate(1)  # a concurrent mutation lands mid-build
+        return out
+
+    monkeypatch.setattr(rails_svc, "evaluate_topic", _eval_then_invalidate)
+    await rails_svc.rails_for_user(db_session, 1)
+    # The generation advanced during the build → the stale result was NOT cached.
+    assert 1 not in rails_svc._cache

--- a/backend/tests/unit/test_rails_admit.py
+++ b/backend/tests/unit/test_rails_admit.py
@@ -1,27 +1,44 @@
 """WS-2 (#112): the precision guard — the load-bearing decision that keeps "US Iran war" from
 dragging in every Middle-East story. Pure function, exhaustively tested."""
 from app.config import settings
-from app.services.rails import _admit
+from app.services.rails import _admit, _escape_like
 
 
 def test_tight_pure_semantic_admits_without_keyword():
     # A very close vector match needs no proper-noun confirmation.
-    assert _admit(settings.rails_dist_tight - 0.01, keyword_hit=False, entity_hit=False) is True
+    assert _admit(settings.rails_dist_tight - 0.01, keyword_hit=False, entity_hit=False, semantic_available=True) is True
 
 
 def test_loose_needs_keyword_or_entity_confirmation():
     d = (settings.rails_dist_tight + settings.rails_dist_loose) / 2  # between tight and loose
-    assert _admit(d, keyword_hit=False, entity_hit=False) is False   # semantically near but unconfirmed
-    assert _admit(d, keyword_hit=True, entity_hit=False) is True     # keyword confirms
-    assert _admit(d, keyword_hit=False, entity_hit=True) is True     # entity confirms
+    assert _admit(d, keyword_hit=False, entity_hit=False, semantic_available=True) is False   # near but unconfirmed
+    assert _admit(d, keyword_hit=True, entity_hit=False, semantic_available=True) is True      # keyword confirms
+    assert _admit(d, keyword_hit=False, entity_hit=True, semantic_available=True) is True      # entity confirms
 
 
 def test_far_never_admits_even_with_keyword():
-    assert _admit(settings.rails_dist_loose + 0.1, keyword_hit=True, entity_hit=True) is False
+    assert _admit(settings.rails_dist_loose + 0.1, keyword_hit=True, entity_hit=True, semantic_available=True) is False
 
 
-def test_no_distance_falls_back_to_keyword_or_entity():
+def test_no_distance_falls_back_to_keyword_or_entity_only_when_semantic_unavailable():
     # semantic leg unavailable (embeddings down) → a proper-noun hit alone admits
-    assert _admit(None, keyword_hit=True, entity_hit=False) is True
-    assert _admit(None, keyword_hit=False, entity_hit=True) is True
-    assert _admit(None, keyword_hit=False, entity_hit=False) is False
+    assert _admit(None, keyword_hit=True, entity_hit=False, semantic_available=False) is True
+    assert _admit(None, keyword_hit=False, entity_hit=True, semantic_available=False) is True
+    assert _admit(None, keyword_hit=False, entity_hit=False, semantic_available=False) is False
+
+
+def test_keyword_or_entity_hit_outside_ann_topk_is_NOT_admitted_when_semantic_ran():
+    # The HIGH-severity bug the review caught: when the semantic leg RAN successfully, a candidate
+    # with no distance is one that fell outside the ANN top-k — it was NOT near enough, so a bare
+    # keyword/entity hit must NOT admit it (else "US Iran war" pulls in every entity-tagged story).
+    assert _admit(None, keyword_hit=True, entity_hit=False, semantic_available=True) is False
+    assert _admit(None, keyword_hit=False, entity_hit=True, semantic_available=True) is False
+    assert _admit(None, keyword_hit=True, entity_hit=True, semantic_available=True) is False
+
+
+def test_escape_like_neutralizes_wildcards():
+    # A saved-search phrase with % or _ must match LITERALLY, not as a SQL wildcard.
+    assert _escape_like("100% pure") == "100\\% pure"
+    assert _escape_like("a_b") == "a\\_b"
+    assert _escape_like("c:\\path") == "c:\\\\path"  # backslash escaped first
+    assert _escape_like("plain") == "plain"

--- a/backend/tests/unit/test_rails_admit.py
+++ b/backend/tests/unit/test_rails_admit.py
@@ -1,0 +1,27 @@
+"""WS-2 (#112): the precision guard — the load-bearing decision that keeps "US Iran war" from
+dragging in every Middle-East story. Pure function, exhaustively tested."""
+from app.config import settings
+from app.services.rails import _admit
+
+
+def test_tight_pure_semantic_admits_without_keyword():
+    # A very close vector match needs no proper-noun confirmation.
+    assert _admit(settings.rails_dist_tight - 0.01, keyword_hit=False, entity_hit=False) is True
+
+
+def test_loose_needs_keyword_or_entity_confirmation():
+    d = (settings.rails_dist_tight + settings.rails_dist_loose) / 2  # between tight and loose
+    assert _admit(d, keyword_hit=False, entity_hit=False) is False   # semantically near but unconfirmed
+    assert _admit(d, keyword_hit=True, entity_hit=False) is True     # keyword confirms
+    assert _admit(d, keyword_hit=False, entity_hit=True) is True     # entity confirms
+
+
+def test_far_never_admits_even_with_keyword():
+    assert _admit(settings.rails_dist_loose + 0.1, keyword_hit=True, entity_hit=True) is False
+
+
+def test_no_distance_falls_back_to_keyword_or_entity():
+    # semantic leg unavailable (embeddings down) → a proper-noun hit alone admits
+    assert _admit(None, keyword_hit=True, entity_hit=False) is True
+    assert _admit(None, keyword_hit=False, entity_hit=True) is True
+    assert _admit(None, keyword_hit=False, entity_hit=False) is False

--- a/frontend/src/app/follow/new/page.test.tsx
+++ b/frontend/src/app/follow/new/page.test.tsx
@@ -1,0 +1,47 @@
+// WS-2 (#112): the "Follow anything" create page.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ replace }) }));
+vi.mock("@/lib/api", () => ({
+  addFollow: vi.fn(),
+  getTopics: vi.fn().mockResolvedValue({ trending_topics: [{ id: 1, name: "AI" }], explore_topics: [] }),
+}));
+
+import FollowNewPage from "./page";
+import { addFollow } from "@/lib/api";
+
+describe("FollowNewPage", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    vi.mocked(addFollow).mockReset().mockResolvedValue({ id: 5, kind: "saved_search", value: "x" });
+  });
+
+  it("disables Follow until a phrase is entered, then creates + lands on /following", async () => {
+    render(<FollowNewPage />);
+    const btn = screen.getByRole("button", { name: "Follow" });
+    expect(btn).toBeDisabled();
+    await userEvent.type(screen.getByLabelText("Topic to follow"), "US Iran war");
+    expect(btn).toBeEnabled();
+    await userEvent.click(btn);
+    await waitFor(() => expect(addFollow).toHaveBeenCalledWith("saved_search", "US Iran war"));
+    expect(replace).toHaveBeenCalledWith("/following");
+  });
+
+  it("a trending chip creates that follow directly", async () => {
+    render(<FollowNewPage />);
+    await userEvent.click(await screen.findByText("AI"));
+    await waitFor(() => expect(addFollow).toHaveBeenCalledWith("saved_search", "AI"));
+  });
+
+  it("surfaces the cap error inline (400), not a crash", async () => {
+    vi.mocked(addFollow).mockRejectedValue(new Error("API 400: Bad Request"));
+    render(<FollowNewPage />);
+    await userEvent.type(screen.getByLabelText("Topic to follow"), "too many");
+    await userEvent.click(screen.getByRole("button", { name: "Follow" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/maximum number of topics/i);
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/follow/new/page.tsx
+++ b/frontend/src/app/follow/new/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+/**
+ * WS-2 (#112): "Follow anything" — a full-screen create page (NOT a modal; the app keeps its
+ * zero-overlay pattern, hardware-back just works, identical on web). Type any phrase → a saved_search
+ * follow → land on /following with the new rail already there (immediate payoff, even if empty).
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Chip } from "@/components/ui/Chip";
+import { addFollow, getTopics } from "@/lib/api";
+
+export default function FollowNewPage() {
+  const router = useRouter();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  // Suggestion chips: trending topic names (a warm start; the user can still type anything).
+  useEffect(() => {
+    getTopics()
+      .then((t) => {
+        const names = [...(t.trending_topics ?? []), ...(t.explore_topics ?? [])]
+          .map((x) => x.name)
+          .slice(0, 8);
+        setSuggestions(names);
+      })
+      .catch(() => setSuggestions([]));
+  }, []);
+
+  const submit = useCallback(
+    async (raw: string) => {
+      const phrase = raw.trim();
+      if (!phrase || saving) return;
+      setSaving(true);
+      setError(null);
+      try {
+        await addFollow("saved_search", phrase);
+        router.replace("/following"); // rail is visible there immediately (even if empty)
+      } catch (err) {
+        // Backend inline errors: cap reached (400), etc. Show under the input, not a toast.
+        const msg = err instanceof Error ? err.message : "Couldn't save — try again";
+        setError(
+          msg.includes("400")
+            ? "You follow the maximum number of topics — unfollow one first."
+            : "Couldn't save — check your connection and try again."
+        );
+        setSaving(false);
+      }
+    },
+    [saving, router]
+  );
+
+  return (
+    <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)] pt-[var(--space-lg)]">
+      <h1 className="text-display text-[var(--text-primary)] mb-1">Follow anything</h1>
+      <p className="text-small text-[var(--text-muted)] mb-[var(--space-lg)]">
+        A topic, a company, an event — we watch every source for it and gather the coverage.
+      </p>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void submit(value);
+        }}
+      >
+        <Input
+          autoFocus
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="US–Iran war, AI chips, your city…"
+          maxLength={255}
+          aria-label="Topic to follow"
+        />
+        {error && (
+          <p role="alert" className="text-mono text-[var(--dismiss)] mt-2">
+            {error}
+          </p>
+        )}
+
+        {suggestions.length > 0 && (
+          <div className="mt-[var(--space-md)]">
+            <p className="text-category text-[var(--text-muted)] mb-2">TRENDING</p>
+            <div className="flex flex-wrap gap-2">
+              {suggestions.map((s) => (
+                <Chip key={s} onClick={() => void submit(s)}>
+                  {s}
+                </Chip>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={!value.trim() || saving}
+          loading={saving}
+          className="mt-[var(--space-lg)] w-full"
+        >
+          Follow
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/following/following.test.tsx
+++ b/frontend/src/app/following/following.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 vi.mock("@/lib/api", () => ({
   getFollows: vi.fn(),
   removeFollow: vi.fn(),

--- a/frontend/src/app/following/page.tsx
+++ b/frontend/src/app/following/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/Button";
+import { useRouter } from "next/navigation";
 import { getFollows, removeFollow, type FollowItem } from "@/lib/api";
 
 type PageState = "loading" | "success" | "empty" | "error";
@@ -16,6 +17,7 @@ const KIND_LABEL: Record<string, string> = {
 };
 
 export default function FollowingPage() {
+  const router = useRouter();
   const [state, setState] = useState<PageState>("loading");
   const [follows, setFollows] = useState<FollowItem[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -85,26 +87,29 @@ export default function FollowingPage() {
       {/* Empty */}
       {state === "empty" && (
         <div className="flex flex-col items-center justify-center pt-[var(--space-3xl)] text-center">
-          <motion.div
+          <motion.button
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.3 }}
+            whileTap={{ scale: 0.95 }}
+            onClick={() => router.push("/follow/new")}
+            aria-label="Follow a new topic"
             className="w-12 h-12 rounded-full bg-[var(--accent-subtle)] flex items-center justify-center mb-3"
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M12 5v14M5 12h14" />
             </svg>
-          </motion.div>
+          </motion.button>
           <p className="text-heading text-[var(--text-primary)]">Not following anything yet</p>
           <p className="text-small text-[var(--text-muted)] mt-1.5 max-w-[280px]">
             Follow a topic from your briefing, or save a search to keep tracking it here.
           </p>
           <Button
-            variant="secondary"
-            onClick={() => (window.location.href = "/")}
+            variant="primary"
+            onClick={() => router.push("/follow/new")}
             className="mt-4"
           >
-            Browse stories
+            Follow a topic
           </Button>
         </div>
       )}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,6 +13,7 @@ import { DailyTriviaCard } from "@/components/ui/DailyTriviaCard";
 import { PersonalizeBanner } from "@/components/ui/PersonalizeBanner";
 import { WhileAwayCard } from "@/components/ui/WhileAwayCard";
 import { LaunchScreen } from "@/components/LaunchScreen";
+import { FollowRails } from "@/components/FollowRails";
 import { useImpressions } from "@/hooks/useImpressions";
 import { AnimatedMark } from "@/components/SplashScreen";
 import { getBriefing, getTopics, type Briefing, type BriefingStory, type Topic } from "@/lib/api";
@@ -301,6 +302,9 @@ export default function BriefingPage() {
               </div>
             </div>
           )}
+
+          {/* WS-2 (#112): News You Follow rails — renders nothing until the user has follows */}
+          <FollowRails />
 
           {/* Empty topic filter: the chip's topic has articles, just none in today's 8-story
               brief. Say so instead of rendering a blank page. */}

--- a/frontend/src/components/FollowRails.test.tsx
+++ b/frontend/src/components/FollowRails.test.tsx
@@ -1,0 +1,73 @@
+// WS-2 (#112): the News-You-Follow rails — pager, badges, badge-clear-on-tap.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
+vi.mock("@/lib/api", () => ({
+  getFollowRails: vi.fn(),
+  markFollowSeen: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { FollowRails } from "./FollowRails";
+import { getFollowRails, markFollowSeen } from "@/lib/api";
+
+const rail = (over = {}) => ({
+  follow_id: 1, kind: "saved_search", value: "US Iran war", total: 4, new_count: 3,
+  stories: [
+    { cluster_id: 10, title: "Strikes reported", summary: "s", source_count: 3 },
+    { cluster_id: 11, title: "Talks resume", summary: "s", source_count: 2 },
+  ],
+  ...over,
+});
+
+describe("FollowRails", () => {
+  beforeEach(() => {
+    push.mockReset();
+    vi.mocked(markFollowSeen).mockClear().mockResolvedValue(undefined);
+  });
+
+  it("renders nothing when the user follows nothing (briefing must not break)", async () => {
+    vi.mocked(getFollowRails).mockResolvedValue([]);
+    const { container } = render(<FollowRails />);
+    await waitFor(() => expect(getFollowRails).toHaveBeenCalled());
+    expect(container.querySelector('[aria-label="News you follow"]')).toBeNull();
+  });
+
+  it("renders a panel with the follow name, the N-new badge, and its headlines", async () => {
+    vi.mocked(getFollowRails).mockResolvedValue([rail()]);
+    render(<FollowRails />);
+    expect(await screen.findByText("US Iran war")).toBeInTheDocument();
+    expect(screen.getByLabelText("3 new stories")).toBeInTheDocument();
+    expect(screen.getByText("Strikes reported")).toBeInTheDocument();
+  });
+
+  it("caps the badge at 9+", async () => {
+    vi.mocked(getFollowRails).mockResolvedValue([rail({ new_count: 42 })]);
+    render(<FollowRails />);
+    expect(await screen.findByLabelText("42 new stories")).toHaveTextContent("9+");
+  });
+
+  it("tapping a story clears THAT rail's badge and opens the story with the rail surface", async () => {
+    vi.mocked(getFollowRails).mockResolvedValue([rail()]);
+    render(<FollowRails />);
+    await userEvent.click(await screen.findByText("Strikes reported"));
+    expect(markFollowSeen).toHaveBeenCalledWith(1);
+    expect(push).toHaveBeenCalledWith("/story/10");
+    await waitFor(() => expect(screen.queryByLabelText(/new stories/)).toBeNull()); // badge cleared
+  });
+
+  it("shows the watching empty state for a rail with no stories", async () => {
+    vi.mocked(getFollowRails).mockResolvedValue([rail({ stories: [], total: 0, new_count: 0 })]);
+    render(<FollowRails />);
+    expect(await screen.findByText(/we're watching/i)).toBeInTheDocument();
+  });
+
+  it("the section '+' routes to the create page", async () => {
+    vi.mocked(getFollowRails).mockResolvedValue([rail()]);
+    render(<FollowRails />);
+    await userEvent.click(await screen.findByLabelText("Follow a new topic"));
+    expect(push).toHaveBeenCalledWith("/follow/new");
+  });
+});

--- a/frontend/src/components/FollowRails.tsx
+++ b/frontend/src/components/FollowRails.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * WS-2 (#112): the "News You Follow" home section — a horizontal PAGER of topic panels (Design Spec).
+ * One panel per follow (~85% viewport, scroll-snap-x; a 3-up grid at ≥768px = the wire diagram).
+ * Each panel: mono header + amber "N new" pill, ≤3 headline rows, "see all". Tapping a story or
+ * "see all" clears that rail's badge (POST /seen) — scrolling past does NOT. Section hidden when the
+ * user follows nothing (the "+" to start lives on /following and here in the header).
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { getFollowRails, markFollowSeen, type FollowRail } from "@/lib/api";
+
+function NewPill({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return (
+    <span
+      aria-label={`${count} new stories`}
+      className="text-mono text-[11px] tracking-wide px-2 py-0.5 rounded-full"
+      style={{ background: "color-mix(in srgb, var(--accent) 12%, transparent)", color: "var(--accent)" }}
+    >
+      {count > 9 ? "9+" : count} NEW
+    </span>
+  );
+}
+
+function RailPanel({ rail, onOpen }: { rail: FollowRail; onOpen: (r: FollowRail, clusterId?: number) => void }) {
+  return (
+    <section
+      className="snap-start shrink-0 w-[85%] md:w-auto rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-1)] p-[var(--space-md)]"
+      aria-label={`Rail: ${rail.value}`}
+    >
+      <header className="flex items-center justify-between mb-2 gap-2">
+        <h3 className="text-category text-[var(--text-primary)] truncate">{rail.value}</h3>
+        <NewPill count={rail.new_count} />
+      </header>
+
+      {rail.stories.length === 0 ? (
+        <p className="text-small text-[var(--text-muted)] italic py-2">
+          Nothing new — we&apos;re watching.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rail.stories.map((s) => (
+            <li key={s.cluster_id}>
+              <button
+                onClick={() => onOpen(rail, s.cluster_id)}
+                className="text-left w-full text-body text-[var(--text-primary)] line-clamp-2 hover:text-[var(--accent)] transition-colors"
+              >
+                {s.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {rail.total > rail.stories.length && (
+        <button
+          onClick={() => onOpen(rail)}
+          className="text-mono text-[var(--text-muted)] hover:text-[var(--accent)] mt-2"
+        >
+          see all →
+        </button>
+      )}
+    </section>
+  );
+}
+
+export function FollowRails() {
+  const router = useRouter();
+  const [rails, setRails] = useState<FollowRail[] | null>(null);
+
+  useEffect(() => {
+    getFollowRails()
+      .then(setRails)
+      .catch(() => setRails([])); // a failed rails fetch must never break the briefing
+  }, []);
+
+  const onOpen = useCallback(
+    (rail: FollowRail, clusterId?: number) => {
+      // Clear the badge for THIS rail only, optimistically.
+      if (rail.new_count > 0) {
+        setRails((prev) =>
+          prev ? prev.map((r) => (r.follow_id === rail.follow_id ? { ...r, new_count: 0 } : r)) : prev
+        );
+        void markFollowSeen(rail.follow_id).catch(() => {}); // fire-and-forget; server is source of truth
+      }
+      if (clusterId != null) {
+        if (typeof sessionStorage !== "undefined") sessionStorage.setItem("nl_surface", "rail");
+        router.push(`/story/${clusterId}`);
+      } else {
+        router.push("/following"); // "see all"
+      }
+    },
+    [router]
+  );
+
+  // Loading (null) and no-follows (empty) both render nothing — the section only appears once the
+  // user has rails. The "+" entry point lives on /following and in the section header below.
+  if (!rails || rails.length === 0) return null;
+
+  return (
+    <section className="mb-5" aria-label="News you follow">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-category text-[var(--text-muted)]">NEWS YOU FOLLOW</h2>
+        <button
+          onClick={() => router.push("/follow/new")}
+          aria-label="Follow a new topic"
+          className="text-[var(--accent)] hover:opacity-80 text-lg leading-none px-1"
+        >
+          +
+        </button>
+      </div>
+      <div className="flex md:grid md:grid-cols-3 gap-3 overflow-x-auto snap-x snap-mandatory -mx-[var(--space-md)] px-[var(--space-md)] pb-1 no-scrollbar">
+        {rails.map((r) => (
+          <RailPanel key={r.follow_id} rail={r} onOpen={onOpen} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -601,6 +601,30 @@ export async function removeFollow(id: number): Promise<void> {
   await fetchJSON(`/follows/${id}`, { method: "DELETE" });
 }
 
+/* ── WS-2 (#112): "News You Follow" rails ── */
+export interface RailStory {
+  cluster_id: number;
+  title: string;
+  summary: string | null;
+  source_count: number;
+}
+export interface FollowRail {
+  follow_id: number;
+  kind: string;
+  value: string;
+  total: number;
+  new_count: number;
+  stories: RailStory[];
+}
+export async function getFollowRails(): Promise<FollowRail[]> {
+  const r = await fetchJSON<{ rails: FollowRail[] }>("/follows/rails");
+  return r.rails ?? [];
+}
+/** Clear a rail's "N new" badge (tapping a rail story or its "see all"). */
+export async function markFollowSeen(followId: number): Promise<void> {
+  await fetchJSON(`/follows/${followId}/seen`, { method: "POST" });
+}
+
 export async function getClusterStrategic(clusterId: number): Promise<LensResult> {
   return fetchJSON(`/clusters/${clusterId}/strategic`);
 }


### PR DESCRIPTION
## WS-2: Follow Anything (Signal-First wave)

Turns any follow — a free-text phrase, a topic, or an entity — into a **live, badged category** on the home briefing. Closes #112.

### Backend (WS-2a)
- **`GET /follows/rails`** — evaluates each rail-able follow (saved_search / topic / entity; source follows excluded) into a 72h-windowed, cluster-grouped rail with a per-follow `new_count` badge (since `follows.last_viewed_at`). Per-rail try/except isolation (one bad rail never blanks the section) + a 60s per-user response cache.
- **`POST /follows/{id}/seen`** — clears THAT rail's badge (sets `last_viewed_at`). The badge clock is **per-follow** and is deliberately NOT reset by reading `/digest` (regression-tested).
- **saved_search is hybrid** — pgvector ANN (semantic) + ILIKE keyword + entity-alias leg, gated by a precision guard so "US Iran war" doesn't drag in every Middle-East story. Degrades to keyword+entity when embeddings are unavailable.
- Migration: `follows.last_viewed_at`. Config: `rails_*` knobs + `saved_search_cap`.
- `measure_follow_distances.py` — the pre-gate tool that logs real query↔article distances to calibrate the thresholds.

### Adversarial review pass (11 agents, 5 confirmed defects — all fixed + tested)
- **HIGH** — precision guard was bypassed for keyword/entity hits **outside the ANN top-k**: `dist=None` conflated "embeddings down" with "not in top-50", admitting on a bare proper-noun hit. Fixed with an explicit `semantic_available` flag (keyword/entity are confirmation-only when the semantic leg ran).
- **MEDIUM ×2** — unbounded keyword/entity legs; both now bounded to the newest `rails_ann_k`.
- **LOW** — LIKE metacharacters (`%`, `_`) acted as wildcards → tested `_escape_like` helper + `escape='\'`.
- **LOW** — cache stale-write-back race → per-user generation counter + compare-and-set.

### Frontend (WS-2b)
- **`FollowRails`** — a "News You Follow" section: horizontal scroll-snap pager of per-follow panels (3-up grid ≥768px), amber "N new" pill (capped 9+), ≤N headlines + "see all". Tapping clears that rail's badge (optimistic + fire-and-forget `/seen`); scrolling past does not. Renders nothing while loading / when nothing is followed, so the briefing never breaks.
- **`/follow/new`** — full-screen "Follow anything" create page (no modal; hardware-back just works). Free-text + trending chips; cap (400) surfaces inline. Lands on `/following` with the new rail already visible.
- `/following` empty-state "+" and CTA now route to `/follow/new`.

### Verification
- Backend: **453 passed, 1 skipped** (rails suite 14, incl. 4 review-regression tests).
- Frontend: **99 passed** (29 files), production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)