### PR TITLE
WS-3: home infinite scroll + stable as_of pagination (closes #113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ news-app/
 |--------|------|---------|
 | GET | /health | Health check (DB status) |
 | GET | /pipeline | Pipeline health: article counts by `embedding_status`, cluster counts, freshness, and `last_embedding_error` (quota/auth/no_key) — diagnoses a stalled embed→cluster stage without the log stream |
-| GET | /feed | Paginated feed with explore/exploit mix |
+| GET | /feed | Paginated feed with explore/exploit mix; optional `as_of` cursor pins the pool (`fetched_at <= as_of`) for stable infinite scroll on BOTH paths — first response echoes `as_of=now`, a stale cursor recovers with a fresh one (WS-3) |
 | GET | /feed?topic={id} | Topic-filtered feed |
 | GET | /feed?source_type={news\|research\|expert} | Source-tier-filtered feed (invalid → 400; chip UI deferred) |
 | GET | /clusters/{id} | Story cluster with all source articles (free first) |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -147,6 +147,7 @@ async def get_feed(
     source_type: str | None = None,
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
+    as_of: datetime | None = Query(None),
     db: AsyncSession = Depends(get_db),
 ):
     offset = (page - 1) * per_page
@@ -219,6 +220,18 @@ async def get_feed(
         else:
             raise HTTPException(status_code=400, detail="invalid source_type")
         query = query.where(Article.source_id.in_(select(Source.id).where(type_cond)))
+
+    # WS-3 (#113): the as_of pagination cursor. When the client threads a cursor (page ≥ 2), pin the
+    # pool to fetched_at <= as_of so new ingest mid-scroll can't shift page boundaries (duplicate/drop
+    # rows) — on BOTH the personalized and legacy paths (they share the identical top-shift bug).
+    # Omitting as_of (the first page) leaves the query UNFILTERED — byte-identical legacy behavior, and
+    # avoids clock skew excluding a just-ingested row — while we still hand back as_of=now to pin later
+    # pages. A stale cursor whose window is empty recovers with a fresh now() (see response_as_of below).
+    now = datetime.now(timezone.utc)
+    if as_of is not None:
+        if as_of.tzinfo is None:
+            as_of = as_of.replace(tzinfo=timezone.utc)
+        query = query.where(Article.fetched_at <= as_of)
 
     # G2: when personalizing, fetch a bounded recent pool and rerank it (recency + entity relevance)
     # BEFORE paginating, so a high-affinity story can cross page boundaries within the horizon. When
@@ -348,12 +361,21 @@ async def get_feed(
     else:
         explore_ratio = app_settings.default_explore_ratio
 
+    # WS-3 (#113): the cursor echoed to the client. Normally the pinned as_of (or now() on the first
+    # page). But a client-supplied cursor whose window is now empty (predates all data / pruned) is
+    # stale — hand back a FRESH now() so the client restarts pagination instead of looping on an empty
+    # page. (Distinct from "caught up": there total > 0 and only the page slice is empty.)
+    response_as_of = as_of if as_of is not None else now
+    if as_of is not None and total == 0:
+        response_as_of = now
+
     return FeedResponse(
         articles=article_outs,
         total=total,
         page=page,
         per_page=per_page,
         explore_ratio=explore_ratio,
+        as_of=response_as_of,
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -48,6 +48,10 @@ class FeedResponse(BaseModel):
     page: int
     per_page: int
     explore_ratio: float
+    # WS-3 (#113): the pagination cursor. First response echoes now(); the client threads it back on
+    # subsequent pages to pin the pool (fetched_at <= as_of) so new ingest can't shift page boundaries.
+    # A stale cursor (empty window) comes back refreshed to now() so the client can restart.
+    as_of: datetime
 
 
 # --- Cluster / Deep Dive ---

--- a/backend/tests/integration/test_feed_cursor.py
+++ b/backend/tests/integration/test_feed_cursor.py
@@ -1,0 +1,148 @@
+"""WS-3 (#113): the as_of pagination cursor. Pins the feed pool to fetched_at <= as_of so new
+ingest mid-scroll can't duplicate/drop rows across a page boundary — on BOTH the personalized and
+legacy paths. First response echoes as_of=now; a stale cursor (empty window) recovers with a fresh
+cursor + empty items."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import Article, EmbeddingStatus, Source, SourceType, User
+
+UTC = timezone.utc
+_seq = 0
+
+
+async def _ensure_user1(db):
+    if (await db.execute(select(User).where(User.id == 1))).scalar_one_or_none() is None:
+        db.add(User(id=1, locale="IN"))
+        await db.flush()
+
+
+async def _src(db):
+    global _seq
+    _seq += 1
+    s = Source(name="S", url=f"https://cur/{_seq}", source_type=SourceType.wire)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _article_at(db, src, *, published, fetched, title):
+    """Seed an article with EXPLICIT fetched_at (the cursor axis) and published_at (the sort axis)."""
+    global _seq
+    _seq += 1
+    a = Article(title=title, url=f"https://cur/{_seq}/a", source_id=src.id,
+                embedding_status=EmbeddingStatus.complete, published_at=published, fetched_at=fetched)
+    db.add(a)
+    await db.flush()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_first_response_echoes_as_of_now(aclient, db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", False)
+    src = await _src(db_session)
+    now = datetime.now(UTC)
+    await _article_at(db_session, src, published=now, fetched=now, title="A")
+    await db_session.flush()
+
+    body = (await aclient.get("/feed?per_page=50")).json()
+    assert "as_of" in body, "feed response must carry the pagination cursor"
+    returned = datetime.fromisoformat(body["as_of"])
+    assert abs((datetime.now(UTC) - returned).total_seconds()) < 60  # ≈ now
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("uer", [False, True])
+async def test_as_of_pins_window_excludes_newer_fetch(aclient, db_session, monkeypatch, uer):
+    """The core stability fix, on BOTH paths: a row fetched AFTER the cursor is excluded."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", uer)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    t0 = datetime.now(UTC) - timedelta(days=3)
+    await _article_at(db_session, src, published=t0, fetched=t0, title="Old")
+    cursor = t0 + timedelta(hours=1)
+    later = t0 + timedelta(days=2)
+    await _article_at(db_session, src, published=later, fetched=later, title="NewerFetch")
+    await db_session.flush()
+
+    body = (await aclient.get("/feed", params={"per_page": 50, "as_of": cursor.isoformat()})).json()
+    titles = [it["title"] for it in body["articles"]]
+    assert "Old" in titles
+    assert "NewerFetch" not in titles          # fetched after the cursor → pinned out
+    # a valid cursor is echoed (same instant; server serializes UTC as "…Z", client sent "+00:00")
+    assert datetime.fromisoformat(body["as_of"]) == cursor
+
+
+@pytest.mark.asyncio
+async def test_omitting_as_of_is_unfiltered_legacy(aclient, db_session, monkeypatch):
+    """Regression: no as_of → NO fetched_at filter → byte-identical legacy behavior (all rows)."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", False)
+    src = await _src(db_session)
+    now = datetime.now(UTC)
+    await _article_at(db_session, src, published=now, fetched=now, title="Fresh")
+    await _article_at(db_session, src, published=now - timedelta(days=1), fetched=now, title="Older")
+    await db_session.flush()
+
+    body = (await aclient.get("/feed?per_page=50")).json()
+    assert {it["title"] for it in body["articles"]} == {"Fresh", "Older"}
+    assert body["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_same_cursor_stable_across_new_ingest(aclient, db_session, monkeypatch):
+    """Page 1 (no cursor) pins as_of; a BREAKING story ingested before page 2 must NOT appear on
+    page 2 nor duplicate/drop any page-1 row (personalized path)."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    await _ensure_user1(db_session)
+    src = await _src(db_session)
+    now = datetime.now(UTC)
+    for i in range(6):
+        t = now - timedelta(hours=6 - i)  # A0 oldest … A5 newest, all in the past
+        await _article_at(db_session, src, published=t, fetched=t, title=f"A{i}")
+    await db_session.flush()
+
+    p1 = (await aclient.get("/feed?per_page=3&page=1")).json()
+    cursor = p1["as_of"]
+    page1_ids = [it["id"] for it in p1["articles"]]
+    assert len(page1_ids) == 3
+
+    # New ingest lands AFTER the pinned cursor.
+    cursor_dt = datetime.fromisoformat(cursor)
+    await _article_at(db_session, src, published=now + timedelta(hours=1),
+                      fetched=cursor_dt + timedelta(seconds=1), title="BREAKING")
+    await db_session.flush()
+
+    p2 = (await aclient.get("/feed", params={"per_page": 3, "page": 2, "as_of": cursor})).json()
+    page2_titles = [it["title"] for it in p2["articles"]]
+    page2_ids = [it["id"] for it in p2["articles"]]
+    assert "BREAKING" not in page2_titles                 # pinned out by the cursor
+    assert set(page1_ids).isdisjoint(page2_ids)           # no duplicate across the boundary
+    assert len(set(page1_ids) | set(page2_ids)) == 6      # all 6 originals covered, none dropped
+
+
+@pytest.mark.asyncio
+async def test_stale_cursor_recovers_with_fresh_cursor(aclient, db_session, monkeypatch):
+    """A cursor whose window is empty (predates all data) → items=[] + a FRESH cursor to restart."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", False)
+    src = await _src(db_session)
+    now = datetime.now(UTC)
+    await _article_at(db_session, src, published=now, fetched=now, title="Only")
+    await db_session.flush()
+
+    stale = datetime(2000, 1, 1, tzinfo=UTC)
+    body = (await aclient.get("/feed", params={"as_of": stale.isoformat()})).json()
+    assert body["articles"] == []
+    fresh = datetime.fromisoformat(body["as_of"])
+    assert fresh > stale
+    assert abs((now - fresh).total_seconds()) < 60       # server issued a fresh ≈now cursor
+
+    # Recovery: the fresh cursor returns the live article.
+    body2 = (await aclient.get("/feed", params={"as_of": body["as_of"]})).json()
+    assert [it["title"] for it in body2["articles"]] == ["Only"]

--- a/frontend/src/app/feed/page.tsx
+++ b/frontend/src/app/feed/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { Chip } from "@/components/ui/Chip";
-import { Button } from "@/components/ui/Button";
-import { FeedArticleCard } from "@/components/FeedArticleCard";
-import { getFeed, type Article } from "@/lib/api";
-import { useImpressions } from "@/hooks/useImpressions";
+import { InfiniteFeed } from "@/components/InfiniteFeed";
 
 type SourceType = "all" | "news" | "research" | "expert" | "official" | "filing";
 const CHIPS: { label: string; value: SourceType }[] = [
@@ -18,31 +15,11 @@ const CHIPS: { label: string; value: SourceType }[] = [
   // watchlist a company — the intended, honest behaviour, not a bug.
   { label: "Filings", value: "filing" },
 ];
-type State = "loading" | "success" | "empty" | "error";
 
-/** #82 — the source-type-filtered feed screen. The backend GET /feed?source_type= + getFeed(sourceType)
- *  already exist; this is the surface that renders them. */
+/** #82 / WS-3 (#113) — the source-type-filtered feed screen, now infinite-scrolling via the shared
+ *  InfiniteFeed (cursor pagination + prefetch + dedupe). Switching a chip remounts the feed. */
 export default function FeedPage() {
   const [active, setActive] = useState<SourceType>("all");
-  const { observe } = useImpressions("feed");
-  const [articles, setArticles] = useState<Article[]>([]);
-  const [state, setState] = useState<State>("loading");
-
-  const load = useCallback(async (type: SourceType) => {
-    setState("loading");
-    try {
-      const res = await getFeed(1, 20, undefined, type === "all" ? undefined : type);
-      setArticles(res.articles);
-      setState(res.articles.length ? "success" : "empty");
-    } catch {
-      setState("error");
-    }
-  }, []);
-
-  useEffect(() => {
-    void load(active);
-  }, [active, load]);
-
   return (
     <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)] pt-2">
       <h1 className="text-hero text-[var(--text-primary)] mb-3">Feed</h1>
@@ -54,36 +31,12 @@ export default function FeedPage() {
         ))}
       </div>
 
-      {state === "loading" && <p className="text-small text-[var(--text-muted)] pt-6">Loading…</p>}
-
-      {state === "error" && (
-        <div className="pt-6">
-          <p className="text-small text-[var(--dismiss)]">Couldn&apos;t load the feed.</p>
-          <Button variant="secondary" onClick={() => load(active)} className="mt-3">
-            Try again
-          </Button>
-        </div>
-      )}
-
-      {state === "empty" && (
-        <p className="text-small text-[var(--text-muted)] pt-6">Nothing here yet — check back soon.</p>
-      )}
-
-      {state === "success" && (
-        <div className="flex flex-col" key={active}>
-          {articles.map((a) => (
-            <div
-              key={a.id}
-              ref={observe}
-              data-impression-cluster={a.cluster_id ?? undefined}
-              data-impression-article={a.cluster_id ? undefined : a.id}
-              onClickCapture={() => sessionStorage.setItem("nl_surface", "feed")}
-            >
-              <FeedArticleCard article={a} />
-            </div>
-          ))}
-        </div>
-      )}
+      <InfiniteFeed
+        key={active}
+        surface="feed"
+        sourceType={active === "all" ? undefined : active}
+        emptyLabel="Nothing here yet — check back soon."
+      />
     </div>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { StoryCard } from "@/components/StoryCard";
@@ -14,6 +14,7 @@ import { PersonalizeBanner } from "@/components/ui/PersonalizeBanner";
 import { WhileAwayCard } from "@/components/ui/WhileAwayCard";
 import { LaunchScreen } from "@/components/LaunchScreen";
 import { FollowRails } from "@/components/FollowRails";
+import { InfiniteFeed } from "@/components/InfiniteFeed";
 import { useImpressions } from "@/hooks/useImpressions";
 import { AnimatedMark } from "@/components/SplashScreen";
 import { getBriefing, getTopics, type Briefing, type BriefingStory, type Topic } from "@/lib/api";
@@ -50,6 +51,11 @@ export default function BriefingPage() {
   const [activeCategory, setActiveCategory] = useState<string>("All");
   const [rechecking, setRechecking] = useState(false);
   const [userTopics, setUserTopics] = useState<Topic[]>([]);
+  // WS-3 (#113): cross-section dedupe — cluster ids the rails render, lifted up so the "All stories"
+  // feed can filter them out (precedence hero > rails > categories > feed). And a key that pull-to-
+  // refresh bumps to remount the feed with a fresh as_of cursor.
+  const [railClusterIds, setRailClusterIds] = useState<number[]>([]);
+  const [feedKey, setFeedKey] = useState(0);
   const router = useRouter();
   // WS-1: log which briefing stories were actually SEEN (>=50% for >=1s); tag taps with the surface.
   const { observe } = useImpressions("briefing");
@@ -73,6 +79,7 @@ export default function BriefingPage() {
     try {
       setState(isRefresh ? "refreshing" : "loading");
       setError(null);
+      if (isRefresh) setFeedKey((k) => k + 1); // pull-to-refresh resets the feed's as_of cursor
       const data = await getBriefing();
 
       if (!data.stories || data.stories.length === 0) {
@@ -143,6 +150,19 @@ export default function BriefingPage() {
   // Hero story is the first one (highest source count / importance)
   const heroStory = filteredStories[0];
   const remainingStories = filteredStories.slice(1);
+
+  // WS-3: cluster ids already shown above the feed (briefing stories + rails) → the feed dedupes them.
+  const handleRailIds = useCallback((ids: number[]) => setRailClusterIds(ids), []);
+  const seenClusterIds = useMemo(() => {
+    const s = new Set<number>();
+    (briefing?.stories ?? []).forEach((st) => {
+      if (st.cluster_id != null) s.add(st.cluster_id);
+    });
+    railClusterIds.forEach((id) => {
+      if (id != null) s.add(id);
+    });
+    return s;
+  }, [briefing, railClusterIds]);
 
   // Group remaining by category
   const grouped = remainingStories.reduce<Record<string, BriefingStory[]>>(
@@ -304,7 +324,7 @@ export default function BriefingPage() {
           )}
 
           {/* WS-2 (#112): News You Follow rails — renders nothing until the user has follows */}
-          <FollowRails />
+          <FollowRails onClusterIdsRendered={handleRailIds} />
 
           {/* Empty topic filter: the chip's topic has articles, just none in today's 8-story
               brief. Say so instead of rendering a blank page. */}
@@ -358,6 +378,18 @@ export default function BriefingPage() {
               Refresh briefing
             </Button>
           </div>
+
+          {/* WS-3 (#113): ALL STORIES — the infinite "everything, newest first" feed. Only in the
+              unfiltered "All" view (a category chip is a filtered briefing, not the full firehose).
+              Cross-section dedupe removes stories already shown above. key resets on pull-to-refresh. */}
+          {activeCategory === "All" && (
+            <InfiniteFeed
+              key={feedKey}
+              surface="feed"
+              excludeClusterIds={seenClusterIds}
+              showHeader
+            />
+          )}
         </motion.div>
       )}
     </div>

--- a/frontend/src/components/FollowRails.test.tsx
+++ b/frontend/src/components/FollowRails.test.tsx
@@ -70,4 +70,11 @@ describe("FollowRails", () => {
     await userEvent.click(await screen.findByLabelText("Follow a new topic"));
     expect(push).toHaveBeenCalledWith("/follow/new");
   });
+
+  it("reports its rendered cluster ids for cross-section dedupe (WS-3)", async () => {
+    const onIds = vi.fn();
+    vi.mocked(getFollowRails).mockResolvedValue([rail()]);
+    render(<FollowRails onClusterIdsRendered={onIds} />);
+    await waitFor(() => expect(onIds).toHaveBeenCalledWith([10, 11]));
+  });
 });

--- a/frontend/src/components/FollowRails.tsx
+++ b/frontend/src/components/FollowRails.tsx
@@ -7,7 +7,7 @@
  * "see all" clears that rail's badge (POST /seen) — scrolling past does NOT. Section hidden when the
  * user follows nothing (the "+" to start lives on /following and here in the header).
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { getFollowRails, markFollowSeen, type FollowRail } from "@/lib/api";
@@ -67,13 +67,25 @@ function RailPanel({ rail, onOpen }: { rail: FollowRail; onOpen: (r: FollowRail,
   );
 }
 
-export function FollowRails() {
+export function FollowRails({
+  onClusterIdsRendered,
+}: {
+  /** WS-3 (#113): report the cluster ids these rails render so the home feed can dedupe them out
+   *  (cross-section precedence hero > rails > categories > feed). */
+  onClusterIdsRendered?: (ids: number[]) => void;
+} = {}) {
   const router = useRouter();
   const [rails, setRails] = useState<FollowRail[] | null>(null);
+  // Ref so the single-fetch mount effect always calls the latest callback without re-fetching.
+  const onIdsRef = useRef(onClusterIdsRendered);
+  onIdsRef.current = onClusterIdsRendered;
 
   useEffect(() => {
     getFollowRails()
-      .then(setRails)
+      .then((rs) => {
+        setRails(rs);
+        onIdsRef.current?.(rs.flatMap((r) => r.stories.map((s) => s.cluster_id)));
+      })
       .catch(() => setRails([])); // a failed rails fetch must never break the briefing
   }, []);
 

--- a/frontend/src/components/InfiniteFeed.test.tsx
+++ b/frontend/src/components/InfiniteFeed.test.tsx
@@ -1,0 +1,67 @@
+// WS-3 (#113): the InfiniteFeed component — render, cross-section dedupe, caught-up, retry, skeletons.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/api", () => ({ getFeed: vi.fn(), postImpressions: vi.fn().mockResolvedValue(undefined) }));
+
+import { getFeed } from "@/lib/api";
+import { InfiniteFeed } from "./InfiniteFeed";
+
+const art = (id: number) => ({
+  id, title: `S${id}`, url: `https://ex/${id}`, snippet: "snip", ai_summary: null,
+  published_at: "2026-07-04T00:00:00Z", fetched_at: "2026-07-04T00:00:00Z",
+  source: { id, name: "Src", url: "https://ex", is_paywalled: false }, topics: [], cluster_id: id,
+});
+const pageResp = (ids: number[], total = ids.length) => ({
+  articles: ids.map(art), total, page: 1, per_page: 20, as_of: "T0",
+});
+
+beforeEach(() => vi.mocked(getFeed).mockReset());
+
+describe("InfiniteFeed", () => {
+  it("renders feed rows and the caught-up terminal when the window fits one page", async () => {
+    vi.mocked(getFeed).mockResolvedValue(pageResp([1, 2]));
+    render(<InfiniteFeed />);
+    expect(await screen.findByText("S1")).toBeInTheDocument();
+    expect(screen.getByText("S2")).toBeInTheDocument();
+    expect(await screen.findByText(/all caught up/i)).toBeInTheDocument();
+  });
+
+  it("filters out cluster ids already shown above (cross-section dedupe)", async () => {
+    vi.mocked(getFeed).mockResolvedValue(pageResp([1, 2, 3]));
+    render(<InfiniteFeed excludeClusterIds={new Set([2])} />);
+    expect(await screen.findByText("S1")).toBeInTheDocument();
+    expect(screen.getByText("S3")).toBeInTheDocument();
+    expect(screen.queryByText("S2")).not.toBeInTheDocument(); // deduped away
+  });
+
+  it("shows the ALL STORIES chapter break when asked", async () => {
+    vi.mocked(getFeed).mockResolvedValue(pageResp([1]));
+    render(<InfiniteFeed showHeader />);
+    expect(await screen.findByText("S1")).toBeInTheDocument(); // let the feed settle first
+    expect(screen.getByText("ALL STORIES")).toBeInTheDocument();
+    expect(screen.getByText(/everything, newest first/i)).toBeInTheDocument();
+  });
+
+  it("shows a retry on initial failure and recovers on click", async () => {
+    vi.mocked(getFeed)
+      .mockRejectedValueOnce(new Error("API 500"))
+      .mockResolvedValue(pageResp([1, 2]));
+    render(<InfiniteFeed />);
+    expect(await screen.findByText(/couldn't load more stories/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(await screen.findByText("S1")).toBeInTheDocument();
+  });
+
+  it("shows skeletons during the initial load", async () => {
+    let resolve!: (v: unknown) => void;
+    vi.mocked(getFeed).mockReturnValue(new Promise((r) => { resolve = r; }) as never);
+    render(<InfiniteFeed />);
+    expect(screen.getByLabelText("Loading stories")).toBeInTheDocument();
+    resolve(pageResp([1]));
+    await waitFor(() => expect(screen.getByText("S1")).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/InfiniteFeed.tsx
+++ b/frontend/src/components/InfiniteFeed.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * WS-3 (#113): the "All stories" infinite feed. Wraps useInfiniteFeed and renders FeedArticleCard
+ * rows with impression logging, a scroll sentinel, three loading skeletons, an inline retry, and a
+ * "You're all caught up" terminal. Reused on the home briefing and the /feed screen.
+ *
+ * Cross-section dedupe (home): `excludeClusterIds` filters out any story already shown above (hero >
+ * rails > categories), so one story renders once. The filter runs at render, so ids that arrive late
+ * (rails self-fetch) still de-dup on the next paint.
+ */
+import { useMemo } from "react";
+
+import { FeedArticleCard } from "@/components/FeedArticleCard";
+import { Button } from "@/components/ui/Button";
+import { useInfiniteFeed } from "@/hooks/useInfiniteFeed";
+import { useImpressions } from "@/hooks/useImpressions";
+import type { ImpressionItem } from "@/lib/api";
+
+interface InfiniteFeedProps {
+  surface?: ImpressionItem["surface"];
+  sourceType?: string;
+  topicId?: number;
+  perPage?: number;
+  /** Cluster ids already rendered above on the same screen — filtered out (cross-section dedupe). */
+  excludeClusterIds?: Set<number>;
+  /** Render the "ALL STORIES" chapter break above the feed (home). */
+  showHeader?: boolean;
+  /** Shown when the feed is genuinely empty. Home omits it (stay silent); /feed passes a message. */
+  emptyLabel?: string;
+}
+
+function FeedRowSkeleton() {
+  return (
+    <div className="py-4 border-b border-[var(--border-subtle)]">
+      <div className="h-5 w-3/4 skeleton mb-2" />
+      <div className="h-4 w-full skeleton mb-1" />
+      <div className="h-3 w-24 skeleton" />
+    </div>
+  );
+}
+
+function AllStoriesHeader() {
+  return (
+    <div className="mt-6 mb-3">
+      <div className="flex items-center gap-3">
+        <h2 className="text-category text-[var(--text-muted)] whitespace-nowrap">ALL STORIES</h2>
+        <span className="flex-1 h-px bg-[var(--border-subtle)]" aria-hidden />
+      </div>
+      <p className="text-small text-[var(--text-ghost)] mt-1">Everything, newest first</p>
+    </div>
+  );
+}
+
+export function InfiniteFeed({
+  surface = "feed",
+  sourceType,
+  topicId,
+  perPage = 20,
+  excludeClusterIds,
+  showHeader = false,
+  emptyLabel,
+}: InfiniteFeedProps) {
+  const { items, status, sentinelRef, retry } = useInfiniteFeed({ perPage, topicId, sourceType });
+  const { observe } = useImpressions(surface);
+
+  const visible = useMemo(
+    () =>
+      excludeClusterIds
+        ? items.filter((a) => a.cluster_id == null || !excludeClusterIds.has(a.cluster_id))
+        : items,
+    [items, excludeClusterIds]
+  );
+
+  // Initial load (no items yet): three skeletons.
+  if (status === "loading" && items.length === 0) {
+    return (
+      <div aria-label="Loading stories" aria-busy>
+        {showHeader && <AllStoriesHeader />}
+        {[0, 1, 2].map((i) => (
+          <FeedRowSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  // Initial load failed (no items): retry, don't blank the briefing.
+  if (status === "error" && items.length === 0) {
+    return (
+      <div className="py-6 text-center">
+        <p className="text-small text-[var(--dismiss)]">Couldn&apos;t load more stories.</p>
+        <Button variant="secondary" size="sm" onClick={retry} className="mt-3">
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  // Nothing to show. On a dedicated feed screen, say so (emptyLabel); on home, stay silent (the feed
+  // just added nothing the sections above didn't already show).
+  if (status === "done" && visible.length === 0) {
+    return emptyLabel ? (
+      <p className="text-small text-[var(--text-muted)] pt-6">{emptyLabel}</p>
+    ) : null;
+  }
+
+  return (
+    <section aria-label="All stories">
+      {showHeader && <AllStoriesHeader />}
+      <div className="flex flex-col">
+        {visible.map((a) => (
+          <div
+            key={a.id}
+            ref={observe}
+            data-impression-cluster={a.cluster_id ?? undefined}
+            data-impression-article={a.cluster_id ? undefined : a.id}
+            onClickCapture={() => sessionStorage.setItem("nl_surface", surface)}
+          >
+            <FeedArticleCard article={a} />
+          </div>
+        ))}
+      </div>
+
+      {status === "paging" && (
+        <p className="text-mono text-[var(--text-muted)] text-center py-4">Loading more…</p>
+      )}
+      {status === "error" && items.length > 0 && (
+        <div className="py-4 text-center">
+          <Button variant="ghost" size="sm" onClick={retry}>
+            Retry
+          </Button>
+        </div>
+      )}
+      {status === "done" && (
+        <p className="text-mono text-[var(--text-ghost)] text-center py-6">You&apos;re all caught up</p>
+      )}
+      {/* The sentinel: present only while more can load. */}
+      {(status === "idle" || status === "paging") && (
+        <div ref={sentinelRef} aria-hidden className="h-1 w-full" />
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useInfiniteFeed.test.tsx
+++ b/frontend/src/hooks/useInfiniteFeed.test.tsx
@@ -89,6 +89,29 @@ describe("useInfiniteFeed", () => {
     expect(result.current.status).toBe("done"); // total 2 == one page → caught up
   });
 
+  it("recovers when a mid-scroll page (a prefetch) fails and retry is tapped", async () => {
+    // Regression (WS-3 review, HIGH): a rejected prefetch must not wedge retry by re-awaiting the
+    // same dead promise. Page 1 succeeds + prefetches page 2; page 2 fails once, then recovers.
+    let page2 = 0;
+    vi.mocked(getFeed).mockImplementation(async (p) => {
+      if (p === 1) return pageResp([1, 2], { total: 100 });
+      if (p === 2) {
+        page2 += 1;
+        if (page2 === 1) throw new Error("API 500: prefetch blip");
+        return pageResp([3, 4], { total: 100 });
+      }
+      return pageResp([5, 6], { total: 100 });
+    });
+    const { result } = renderHook(() => useInfiniteFeed({ perPage: 2 }));
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2]));
+
+    await act(async () => { await result.current.loadMore(); }); // consumes the rejected prefetch
+    await waitFor(() => expect(result.current.status).toBe("error"));
+
+    await act(async () => { result.current.retry(); }); // must issue a FRESH page-2 fetch
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2, 3, 4]));
+  });
+
   it("fires exactly one loadMore per sentinel intersection (single-fire guard)", async () => {
     let cb: (entries: { isIntersecting: boolean }[]) => void = () => {};
     const observe = vi.fn();

--- a/frontend/src/hooks/useInfiniteFeed.test.tsx
+++ b/frontend/src/hooks/useInfiniteFeed.test.tsx
@@ -1,0 +1,111 @@
+// WS-3 (#113): the infinite-feed hook — cursor threading, prefetch, dedupe, stale recovery, terminal.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/api", () => ({ getFeed: vi.fn() }));
+
+import { getFeed } from "@/lib/api";
+import { useInfiniteFeed } from "./useInfiniteFeed";
+
+const art = (id: number) => ({
+  id, title: `S${id}`, url: `https://ex/${id}`, snippet: "s", ai_summary: null,
+  published_at: "2026-07-04T00:00:00Z", fetched_at: "2026-07-04T00:00:00Z",
+  source: { id, name: "Src", url: "https://ex", is_paywalled: false }, topics: [], cluster_id: id,
+});
+const pageResp = (ids: number[], opts: { total?: number; as_of?: string } = {}) => ({
+  articles: ids.map(art), total: opts.total ?? 100, page: 1, per_page: 2, as_of: opts.as_of ?? "T0",
+});
+const ids = (r: { items: { id: number }[] }) => r.items.map((i) => i.id);
+
+beforeEach(() => vi.mocked(getFeed).mockReset());
+afterEach(() => vi.unstubAllGlobals());
+
+describe("useInfiniteFeed", () => {
+  it("loads page 1 on mount, pins the cursor, and prefetches page 2", async () => {
+    vi.mocked(getFeed).mockImplementation(async (p) => pageResp(p === 1 ? [1, 2] : [3, 4]));
+    const { result } = renderHook(() => useInfiniteFeed({ perPage: 2 }));
+
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2]));
+    expect(result.current.status).toBe("idle");
+    // page 2 prefetched WITHOUT any loadMore, and carrying the pinned cursor
+    await waitFor(() => expect(vi.mocked(getFeed).mock.calls.some((c) => c[0] === 2)).toBe(true));
+    const p2call = vi.mocked(getFeed).mock.calls.find((c) => c[0] === 2)!;
+    expect(p2call[4]).toBe("T0"); // as_of threaded
+  });
+
+  it("appends the next page, dedupes overlapping ids, and prefetches ahead", async () => {
+    vi.mocked(getFeed).mockImplementation(async (p) => {
+      if (p === 1) return pageResp([1, 2]);
+      if (p === 2) return pageResp([2, 3]); // id 2 overlaps page 1
+      return pageResp([4, 5]);
+    });
+    const { result } = renderHook(() => useInfiniteFeed({ perPage: 2 }));
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2]));
+
+    await act(async () => { await result.current.loadMore(); });
+
+    expect(ids(result.current)).toEqual([1, 2, 3]); // 2 deduped away
+    await waitFor(() => expect(vi.mocked(getFeed).mock.calls.some((c) => c[0] === 3)).toBe(true));
+  });
+
+  it("reaches the 'done' terminal when the window is exhausted", async () => {
+    vi.mocked(getFeed).mockImplementation(async (p) =>
+      p === 1 ? pageResp([1, 2], { total: 3 }) : pageResp([3], { total: 3 })
+    );
+    const { result } = renderHook(() => useInfiniteFeed({ perPage: 2 }));
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2]));
+
+    await act(async () => { await result.current.loadMore(); });
+
+    expect(ids(result.current)).toEqual([1, 2, 3]);
+    expect(result.current.status).toBe("done");
+  });
+
+  it("recovers from a stale cursor by restarting with the fresh one", async () => {
+    vi.mocked(getFeed).mockImplementation(async (_p, _pp, _t, _st, asOf) => {
+      if (!asOf) return pageResp([1, 2], { as_of: "T0" });                 // page 1, pins T0
+      if (asOf === "T0") return { articles: [], total: 0, page: 2, per_page: 2, as_of: "T1" }; // STALE
+      return pageResp([10, 11], { as_of: "T1" });                          // recovered under T1
+    });
+    const { result } = renderHook(() => useInfiniteFeed({ perPage: 2 }));
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2]));
+
+    await act(async () => { await result.current.loadMore(); });
+
+    // stale detected → items reset → refetched under the fresh cursor
+    await waitFor(() => expect(ids(result.current)).toEqual([10, 11]));
+  });
+
+  it("surfaces an error and retries the failed load", async () => {
+    vi.mocked(getFeed)
+      .mockRejectedValueOnce(new Error("API 500: err"))
+      .mockImplementation(async () => pageResp([1, 2], { total: 2 }));
+    const { result } = renderHook(() => useInfiniteFeed({ perPage: 2 }));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+
+    await act(async () => { result.current.retry(); });
+
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2]));
+    expect(result.current.status).toBe("done"); // total 2 == one page → caught up
+  });
+
+  it("fires exactly one loadMore per sentinel intersection (single-fire guard)", async () => {
+    let cb: (entries: { isIntersecting: boolean }[]) => void = () => {};
+    const observe = vi.fn();
+    vi.stubGlobal(
+      "IntersectionObserver",
+      vi.fn((c: typeof cb) => { cb = c; return { observe, disconnect: vi.fn(), unobserve: vi.fn() }; })
+    );
+    vi.mocked(getFeed).mockImplementation(async (p) => pageResp(p === 1 ? [1, 2] : [3, 4]));
+    const { result } = renderHook(() => useInfiniteFeed({ perPage: 2 }));
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2]));
+
+    act(() => result.current.sentinelRef(document.createElement("div")));
+    expect(observe).toHaveBeenCalled();
+
+    // two intersections back-to-back must page in only ONCE
+    await act(async () => { cb([{ isIntersecting: true }]); cb([{ isIntersecting: true }]); });
+    await waitFor(() => expect(ids(result.current)).toEqual([1, 2, 3, 4]));
+    expect(vi.mocked(getFeed).mock.calls.filter((c) => c[0] === 2).length).toBe(1);
+  });
+});

--- a/frontend/src/hooks/useInfiniteFeed.ts
+++ b/frontend/src/hooks/useInfiniteFeed.ts
@@ -1,0 +1,175 @@
+"use client";
+
+/**
+ * WS-3 (#113): infinite feed pagination. The ONE shared hook for the home "All stories" feed and the
+ * /feed screen — never copy this logic into a component.
+ *
+ * - Threads the server's `as_of` cursor: the first page pins it, later pages send it back so new
+ *   ingest mid-scroll can't shift page boundaries (duplicate/drop). See GET /feed.
+ * - Prefetches page N+1 as page N renders, so the next batch is usually already in hand on scroll.
+ * - Appends with dedupe-by-id (belt-and-braces against any residual re-rank drift).
+ * - Stale cursor: if the server hands back a FRESH cursor (its window went empty), reset and restart
+ *   from page 1 with the new cursor.
+ * - Terminal "done" once the window is exhausted; "error" is retryable.
+ *
+ *   mount ─▶ loadFirst(page1, no cursor) ─▶ pin as_of ─▶ prefetch(2)
+ *   scroll ─▶ loadMore ─▶ await prefetch|fetch ─▶ [stale? reset+restart] ─▶ append ─▶ prefetch(N+1)
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getFeed, type Article, type FeedResponse } from "@/lib/api";
+
+export type FeedStatus = "loading" | "idle" | "paging" | "done" | "error";
+
+interface Options {
+  perPage?: number;
+  topicId?: number;
+  sourceType?: string;
+}
+
+export function useInfiniteFeed({ perPage = 20, topicId, sourceType }: Options = {}) {
+  const [items, setItems] = useState<Article[]>([]);
+  const [status, setStatusState] = useState<FeedStatus>("loading");
+  const [total, setTotalState] = useState(0);
+
+  const pageRef = useRef(0);                         // last successfully loaded page (0 = none yet)
+  const asOfRef = useRef<string | null>(null);       // the pinned cursor
+  const idsRef = useRef<Set<number>>(new Set());     // loaded article ids (dedupe)
+  const prefetchRef = useRef<Promise<FeedResponse> | null>(null);  // page pageRef+1, in flight
+  const statusRef = useRef<FeedStatus>("loading");   // synchronous guard (state is async)
+  const mountedRef = useRef(true);
+  const optsRef = useRef({ perPage, topicId, sourceType });
+  optsRef.current = { perPage, topicId, sourceType };
+
+  const setStatus = (s: FeedStatus) => {
+    statusRef.current = s;
+    if (mountedRef.current) setStatusState(s);
+  };
+  const setTotal = (t: number) => {
+    if (mountedRef.current) setTotalState(t);
+  };
+
+  const fetchPage = useCallback((page: number): Promise<FeedResponse> => {
+    const { perPage, topicId, sourceType } = optsRef.current;
+    return getFeed(page, perPage, topicId, sourceType, asOfRef.current ?? undefined);
+  }, []);
+
+  // Kick off a prefetch and pre-attach a no-op catch so a page the user never scrolls to can't raise
+  // an unhandledrejection — loadMore's own await still receives the rejection.
+  const prefetch = useCallback((page: number): void => {
+    const p = fetchPage(page);
+    p.catch(() => {});
+    prefetchRef.current = p;
+  }, [fetchPage]);
+
+  const hasMore = useCallback((resp: FeedResponse, page: number): boolean => {
+    return resp.articles.length > 0 && page * optsRef.current.perPage < resp.total;
+  }, []);
+
+  const append = useCallback((arts: Article[]): void => {
+    const fresh = arts.filter((a) => !idsRef.current.has(a.id));
+    fresh.forEach((a) => idsRef.current.add(a.id));
+    if (fresh.length && mountedRef.current) setItems((prev) => [...prev, ...fresh]);
+  }, []);
+
+  const loadFirst = useCallback(async (): Promise<void> => {
+    setStatus("loading");
+    try {
+      const { perPage, topicId, sourceType } = optsRef.current;
+      const resp = await getFeed(1, perPage, topicId, sourceType);  // first page: NO cursor (unfiltered)
+      asOfRef.current = resp.as_of ?? null;
+      pageRef.current = 1;
+      append(resp.articles);
+      setTotal(resp.total);
+      if (hasMore(resp, 1)) {
+        prefetch(2);
+        setStatus("idle");
+      } else {
+        setStatus("done");
+      }
+    } catch {
+      setStatus("error");
+    }
+  }, [append, hasMore, prefetch]);
+
+  const loadMore = useCallback(async function loadMore(): Promise<void> {
+    if (statusRef.current !== "idle") return;  // only page from a settled, has-more state (single-fire)
+    setStatus("paging");
+    const nextPage = pageRef.current + 1;
+    let resp: FeedResponse;
+    try {
+      resp = await (prefetchRef.current ?? fetchPage(nextPage));
+      prefetchRef.current = null;
+    } catch {
+      setStatus("error");
+      return;
+    }
+
+    // Stale-cursor recovery: the server handed back a FRESH cursor (its pinned window went empty) →
+    // drop what we have and restart pagination from page 1 with the new cursor.
+    if (asOfRef.current && resp.as_of && resp.as_of !== asOfRef.current) {
+      asOfRef.current = resp.as_of;
+      pageRef.current = 0;
+      idsRef.current.clear();
+      prefetchRef.current = null;
+      if (mountedRef.current) setItems([]);
+      setStatus("idle");
+      return loadMore();
+    }
+
+    pageRef.current = nextPage;
+    append(resp.articles);
+    setTotal(resp.total);
+    if (hasMore(resp, nextPage)) {
+      prefetch(nextPage + 1);
+      setStatus("idle");
+    } else {
+      setStatus("done");
+    }
+  }, [append, fetchPage, hasMore, prefetch]);
+
+  const loadMoreRef = useRef(loadMore);
+  loadMoreRef.current = loadMore;
+
+  const retry = useCallback((): void => {
+    if (statusRef.current !== "error") return;
+    if (pageRef.current === 0) void loadFirst();  // the first load failed
+    else {
+      setStatus("idle");
+      void loadMore();  // a subsequent page failed
+    }
+  }, [loadFirst, loadMore]);
+
+  // (Re)load on mount and whenever the query changes — full reset.
+  useEffect(() => {
+    mountedRef.current = true;
+    pageRef.current = 0;
+    asOfRef.current = null;
+    idsRef.current = new Set();
+    prefetchRef.current = null;
+    setItems([]);
+    void loadFirst();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [perPage, topicId, sourceType, loadFirst]);
+
+  // The sentinel: when it scrolls into view (600px early), page in the next batch. The status guard in
+  // loadMore makes repeated intersections while paging a no-op (single-fire).
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const sentinelRef = useCallback((el: HTMLElement | null) => {
+    observerRef.current?.disconnect();
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) void loadMoreRef.current();
+      },
+      { rootMargin: "600px" }
+    );
+    observerRef.current.observe(el);
+  }, []);
+
+  useEffect(() => () => observerRef.current?.disconnect(), []);
+
+  return { items, status, total, sentinelRef, loadMore, retry };
+}

--- a/frontend/src/hooks/useInfiniteFeed.ts
+++ b/frontend/src/hooks/useInfiniteFeed.ts
@@ -101,6 +101,10 @@ export function useInfiniteFeed({ perPage = 20, topicId, sourceType }: Options =
       resp = await (prefetchRef.current ?? fetchPage(nextPage));
       prefetchRef.current = null;
     } catch {
+      // Drop the poisoned prefetch — otherwise retry() would re-await this same already-rejected
+      // promise (awaiting a settled rejection re-throws) and the feed would be wedged in "error"
+      // forever. Clearing it makes the next loadMore issue a fresh fetchPage(nextPage).
+      prefetchRef.current = null;
       setStatus("error");
       return;
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -169,6 +169,9 @@ export interface FeedResponse {
   total: number;
   page: number;
   per_page: number;
+  // WS-3 (#113): the pagination cursor. First response = now(); thread it back on later pages to pin
+  // the pool (fetched_at <= as_of). A stale cursor comes back refreshed so the client can restart.
+  as_of: string;
 }
 
 export interface TopicsResponse {
@@ -197,7 +200,9 @@ export async function getFeed(
   perPage = 20,
   topicId?: number,
   // Phase 2 · #82 — source-type filter: "news" | "research" | "expert" (omit/"all" = every tier).
-  sourceType?: string
+  sourceType?: string,
+  // WS-3 (#113) — pagination cursor. URLSearchParams encodes the "+00:00"/"Z" offset safely.
+  asOf?: string
 ): Promise<FeedResponse> {
   const params = new URLSearchParams({
     page: String(page),
@@ -205,6 +210,7 @@ export async function getFeed(
   });
   if (topicId) params.set("topic", String(topicId));
   if (sourceType && sourceType !== "all") params.set("source_type", sourceType);
+  if (asOf) params.set("as_of", asOf);
   return fetchJSON(`/feed?${params}`);
 }
 


### PR DESCRIPTION
## WS-3: Home infinite scroll (stable pagination) — closes #113

Turns the home briefing into an endless, stable feed and hardens `/feed` pagination.

### Backend — the `as_of` cursor
- `GET /feed` gains an optional `as_of` cursor that pins the pool to `fetched_at <= as_of` on **both** the personalized (UER) and legacy paths — the identical top-shift duplicate/drop bug lived in both. First page is unfiltered and echoes `as_of=now` (byte-identical legacy + no clock-skew exclusion of a just-ingested row); the client threads the cursor on page ≥2.
- **Stale-cursor recovery:** a cursor whose window went empty returns `items=[]` + a fresh cursor so the client restarts (distinct from "caught up", where `total > 0` and only the page slice is empty).
- 6 cursor tests (echo, pin on UER on/off, unfiltered-legacy, same-cursor lossless across a BREAKING ingest, stale recovery). Backend **459 passed**.

### Frontend — infinite feed
- **`useInfiniteFeed`** — shared hook: threads the cursor, **prefetches page N+1** as page N renders, appends with **dedupe-by-id**, recovers from a stale cursor, IntersectionObserver sentinel (status-guarded single-fire), retryable error, "done" terminal.
- **`InfiniteFeed`** — FeedArticleCard rows + impression logging, 3 skeletons, inline retry, "You're all caught up", the **ALL STORIES** chapter break, and `excludeClusterIds` cross-section dedupe (filters at render, so late rail ids still de-dup).
- **Home:** briefing (top 8, unchanged) + rails + ALL STORIES infinite feed (only in the "All" view). One story renders once — precedence **hero > rails > categories > feed** (briefing ∪ rail ids excluded; FollowRails now reports its rendered cluster ids up). Pull-to-refresh remounts the feed (fresh cursor).
- **`/feed`** reuses the same InfiniteFeed (its `getFeed` call arity is unchanged, so its tests hold).

### Adversarial review (9 agents · 1 confirmed HIGH · 4 rejected)
- **HIGH (fixed):** a rejected *prefetch* left a poisoned promise in `prefetchRef`, so tapping Retry re-awaited the same dead promise and wedged the feed forever. Now cleared in the catch; regression test added.

### Verification
- Backend **459 passed / 1 skipped**; frontend **112 passed** (31 files); prod build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)