### PR TITLE
WS-5: entity co-occurrence graph + one-hop expansion + unified scorer + CTR (closes #115)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ news-app/
 │   │   ├── main.py                   # FastAPI app, lifespan, scheduler setup
 │   │   ├── config.py                 # Pydantic settings (env vars)
 │   │   ├── database.py               # SQLAlchemy async engine + session
-│   │   ├── models.py                 # SQLAlchemy ORM models (16 tables) + RLS DDL events
+│   │   ├── models.py                 # SQLAlchemy ORM models (17 tables) + RLS DDL events
 │   │   │                             #   incl. entities, entity_aliases, article_entities (G1),
 │   │   │                             #   user_entity_relevance (G2), follows (C), cluster_edges (D2)
 │   │   ├── schemas.py                # Pydantic request/response schemas
@@ -161,7 +161,7 @@ news-app/
 | POST | /settings/test-key | Validate OpenAI API key |
 | GET | /saved | User's saved articles list |
 | DELETE | /saved/{article_id} | Remove a saved article |
-| GET | /stats | Reading stats (articles read, saved, topics explored) |
+| GET | /stats | Reading stats (articles read, saved, topics explored) + per-surface impressions & CTR (`surfaces[]`, opens=read+interesting / impressions; WS-5) |
 | GET/PUT | /profile | Persona: profession, locale, interests, watchlist, depth_pref, region |
 | PUT | /settings/gemini-key | Save/remove per-user Gemini key (Fernet) |
 | POST | /settings/test-gemini-key | Validate Gemini key |
@@ -200,6 +200,7 @@ news-app/
 6. **Credibility Review** (monthly, 03:00 on the 1st) → propose-only LLM pass over gated rows unreviewed >90d → writes `credibility_meta.proposed_score` + `reviewed_by="llm-proposed"`; never touches the live score, preserves the admin lock, no-ops without a platform LLM key
 7. **PubMed Ingest** (weekly, Mon 04:00; gated by `PUBMED_ENABLED`) → NCBI E-utilities → recent abstracts for each medical profession as gated research articles (`audience=["medicine"]`), deduped by PMID, ≤3 req/s
 8. **arXiv Generate** (weekly, Mon 04:30) → maps subscribed-topic interests to arXiv categories and idempotently ensures those research sources
+9. **Entity Edge Aggregation** (nightly, 02:00; gated by `ENTITY_EDGE_ENABLED`) → rebuilds `entity_edges` from scratch: co-occurrence weight = Σ over shared clusters of `exp(-ln2·cluster_age/half_life)`, top-K per source, both directions. Full recompute ⇒ idempotent + skip-tolerant. Feeds one-hop interest expansion (WS-5)
 
 ## Key Patterns
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -50,6 +50,7 @@ from app.schemas import (
     SavedListResponse,
     SourceOut,
     StatsResponse,
+    SurfaceCTR,
     SwipeRequest,
     TopicOut,
     TopicListResponse,
@@ -291,31 +292,18 @@ async def get_feed(
         pub_ts = {a.id: (a.published_at.timestamp() if a.published_at else None) for a in articles}
         present = [t for t in pub_ts.values() if t is not None]
         lo, hi = (min(present), max(present)) if present else (0.0, 0.0)
-        span = (hi - lo) or 1.0
         ratio = app_settings.uer_feed_blend_ratio
-
-        def _cred_mult(a: Article) -> float:
-            # #79: bounded ×[0.9, 1.1] credibility nudge. NULL (news) → neutral → ×1.0. Clamp to
-            # [0,100] so a bad stored score can never break the bound and drown fresher news —
-            # defense at the point of use, independent of the write-side validation.
-            score = a.source.credibility_score if (a.source and a.source.credibility_score is not None) \
-                else app_settings.credibility_rank_neutral
-            score = min(100, max(0, score))
-            return 0.9 + 0.2 * score / 100
-
-        def _specialty_mult(a: Article) -> float:
-            # #94: a bounded lift when the article's source specialty matches the user's own specialty.
-            # No specialty (non-medical / general) → ×1.0, so ordinary feeds are unchanged.
-            if not _user_specialty or not a.source:
-                return 1.0
-            meta = a.source.credibility_meta or {}
-            return app_settings.specialty_rank_boost if meta.get("specialty") == _user_specialty else 1.0
+        from app.services import ranking  # WS-5 (#115): the extracted, parity-tested feed blend
 
         def _blend(a: Article) -> float:
-            t = pub_ts[a.id]
-            recency = 0.0 if t is None else (1.0 if hi == lo else (t - lo) / span)
-            rel = min(1.0, scores.get(art_to_cluster.get(a.id), 0.0))
-            return ((1 - ratio) * recency + ratio * rel) * _cred_mult(a) * _specialty_mult(a)
+            src_specialty = (a.source.credibility_meta or {}).get("specialty") if a.source else None
+            return ranking.blend_score(
+                ranking.recency_norm(pub_ts[a.id], lo, hi),
+                scores.get(art_to_cluster.get(a.id), 0.0),
+                ranking.credibility_mult(a.source.credibility_score if a.source else None),
+                ranking.specialty_mult(src_specialty, _user_specialty),
+                ratio,
+            )
 
         blends = {a.id: _blend(a) for a in articles}
         articles.sort(
@@ -1504,10 +1492,42 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
     )
     topics_explored = topics_result.scalar_one() or 0
 
+    # WS-5 (#115): impressions + CTR per surface. Denominator = surface-tagged impressions (WS-1);
+    # numerator = opens (read + interesting) on that surface. RLS-scoped like the counts above.
+    imp_rows = (
+        await db.execute(
+            select(Impression.surface, func.count())
+            .where(Impression.user_id == current_user_id())
+            .group_by(Impression.surface)
+        )
+    ).all()
+    click_rows = (
+        await db.execute(
+            select(UserFeedback.surface, func.count())
+            .where(
+                UserFeedback.user_id == current_user_id(),
+                UserFeedback.surface.isnot(None),
+                UserFeedback.feedback_type.in_([FeedbackType.read, FeedbackType.interesting]),
+            )
+            .group_by(UserFeedback.surface)
+        )
+    ).all()
+    clicks_by = {s: n for s, n in click_rows}
+    surfaces = [
+        SurfaceCTR(
+            surface=s,
+            impressions=n,
+            clicks=clicks_by.get(s, 0),
+            ctr=(clicks_by.get(s, 0) / n) if n else 0.0,
+        )
+        for s, n in sorted(imp_rows)
+    ]
+
     return StatsResponse(
         articles_read=articles_read,
         stories_saved=stories_saved,
         topics_explored=topics_explored,
+        surfaces=surfaces,
     )
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1492,18 +1492,24 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
     )
     topics_explored = topics_result.scalar_one() or 0
 
-    # WS-5 (#115): impressions + CTR per surface. Denominator = surface-tagged impressions (WS-1);
-    # numerator = opens (read + interesting) on that surface. RLS-scoped like the counts above.
+    # WS-5 (#115): impressions + CTR per surface — a bounded LIFETIME aggregate (not a session rate).
+    # Both sides count DISTINCT stories per surface so the ratio can't be distorted by the per-DAY
+    # impression dedup, a lifetime-pinned `read` row, or un-deduped `interesting` taps (review): a
+    # story shown across N days or tapped N times still counts once. clamped to [0,1] as a belt-and-
+    # braces against the cluster/article key mismatch. RLS-scoped like the counts above.
     imp_rows = (
         await db.execute(
-            select(Impression.surface, func.count())
+            select(
+                Impression.surface,
+                func.count(func.distinct(func.coalesce(Impression.cluster_id, Impression.article_id))),
+            )
             .where(Impression.user_id == current_user_id())
             .group_by(Impression.surface)
         )
     ).all()
     click_rows = (
         await db.execute(
-            select(UserFeedback.surface, func.count())
+            select(UserFeedback.surface, func.count(func.distinct(UserFeedback.article_id)))
             .where(
                 UserFeedback.user_id == current_user_id(),
                 UserFeedback.surface.isnot(None),
@@ -1512,15 +1518,18 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
             .group_by(UserFeedback.surface)
         )
     ).all()
+    imp_by = {s: n for s, n in imp_rows}
     clicks_by = {s: n for s, n in click_rows}
+    # UNION of surfaces so a surface with opens but no logged impressions (e.g. a rail deep-link) is
+    # still shown (impressions=0, ctr=0.0) instead of silently dropped.
     surfaces = [
         SurfaceCTR(
             surface=s,
-            impressions=n,
+            impressions=imp_by.get(s, 0),
             clicks=clicks_by.get(s, 0),
-            ctr=(clicks_by.get(s, 0) / n) if n else 0.0,
+            ctr=min(1.0, clicks_by.get(s, 0) / imp_by[s]) if imp_by.get(s) else 0.0,
         )
-        for s, n in sorted(imp_rows)
+        for s in sorted(set(imp_by) | set(clicks_by))
     ]
 
     return StatsResponse(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -110,6 +110,15 @@ class Settings(BaseSettings):
     uer_briefing_blend_weight: float = 0.2  # additive scaler on cluster relevance into story_weights
     uer_search_rerank_boost: float = 10.0   # max within-tier rank improvement (must stay < the 100 gap)
     uer_search_relevance_threshold: float = 0.3  # min relevance before any search boost applies
+    # WS-5 (#115) entity co-occurrence graph + one-hop interest expansion. The nightly job aggregates
+    # entities that shared a cluster into decayed edges (top-K per source). Expansion adds a small
+    # bounded "adjacent interests" term into the cluster relevance score — a NO-OP for a user with no
+    # affinity signal (no seed entities → no expansion), so the G2 invariant holds.
+    entity_edge_enabled: bool = True          # nightly co-occurrence aggregation job on/off
+    entity_edge_top_k: int = 50               # max edges kept per source entity (by weight)
+    entity_edge_half_life_days: float = 30.0  # exponential decay applied to prior edge weight nightly
+    expansion_enabled: bool = True            # one-hop expansion term in score_clusters_relevance
+    expansion_weight: float = 0.1             # bounded additive scaler on the adjacent-interest term
 
     # Phase 1 source expansion — credibility floors for the gated tiers (research/expert). A gated
     # source below the feed floor is discover/search-only; below the briefing floor it never enters

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -155,6 +155,7 @@ async def start_scheduler():
     from app.services.pubmed import ingest_pubmed
     from app.services.arxiv_gen import generate_arxiv_sources
     from app.services.lenses import backfill_tension_lines
+    from app.services.graph import aggregate_entity_edges
 
     scheduler = AsyncIOScheduler()
     # One-shot: seed topic embeddings 10s after startup (non-blocking)
@@ -280,6 +281,18 @@ async def start_scheduler():
         max_instances=1,
         coalesce=True,
         misfire_grace_time=300,
+    )
+    # WS-5 · #115: nightly entity co-occurrence graph rebuild (02:00). Full recompute → idempotent +
+    # skip-tolerant; no-op when entity_edge_enabled=false. Feeds one-hop interest expansion.
+    scheduler.add_job(
+        aggregate_entity_edges,
+        "cron",
+        hour=2,
+        id="entity_edge_aggregation",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=3600,
     )
     scheduler.start()
     logger.info("scheduler_started", jobs=len(scheduler.get_jobs()))

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -486,6 +486,28 @@ class UserEntityRelevance(Base):
     # (user_id, score) index if/when score is materialized for a global-ranking query.
 
 
+class EntityEdge(Base):
+    """WS-5 (#115): a co-occurrence edge — two entities that shared a story cluster — carrying an
+    exponentially-decayed weight. GLOBAL (content-scoped, like entities/clusters — NOT in _RLS_TABLES).
+    The nightly job upserts BOTH directions (a→b and b→a) and keeps the top-50 by weight per source,
+    so a one-hop read is `WHERE src_entity_id IN (the user's affinity entities)`. That read is served
+    by the composite PK's leftmost column, so — like UserEntityRelevance — there is deliberately NO
+    extra b-tree index (keeps Alembic autogenerate parity + avoids write-side dead weight)."""
+
+    __tablename__ = "entity_edges"
+
+    src_entity_id: Mapped[int] = mapped_column(
+        ForeignKey("entities.id", ondelete="CASCADE"), primary_key=True
+    )
+    dst_entity_id: Mapped[int] = mapped_column(
+        ForeignKey("entities.id", ondelete="CASCADE"), primary_key=True
+    )
+    weight: Mapped[float] = mapped_column(Float, server_default="0", nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
 # ── Row-Level Security (Wave D Phase A) ──────────────────────────────────────────────
 # Per-user tables are isolated by the `app.user_id` GUC, which get_current_user sets per request
 # (SET LOCAL). "Enforce-when-set": when the GUC is unset — background jobs reading the owner's API

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -330,9 +330,9 @@ class SavedListResponse(BaseModel):
 # --- Stats ---
 class SurfaceCTR(BaseModel):
     surface: str
-    impressions: int
-    clicks: int
-    ctr: float  # clicks / impressions (opens = read + interesting), 0.0 when no impressions
+    impressions: int  # DISTINCT stories impressed on this surface (lifetime)
+    clicks: int       # DISTINCT stories opened (read + interesting) on this surface (lifetime)
+    ctr: float        # clicks / impressions, bounded to [0,1]; a lifetime aggregate, not a session rate
 
 
 class StatsResponse(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -328,10 +328,19 @@ class SavedListResponse(BaseModel):
 
 
 # --- Stats ---
+class SurfaceCTR(BaseModel):
+    surface: str
+    impressions: int
+    clicks: int
+    ctr: float  # clicks / impressions (opens = read + interesting), 0.0 when no impressions
+
+
 class StatsResponse(BaseModel):
     articles_read: int
     stories_saved: int
     topics_explored: int
+    # WS-5 (#115): per-surface impressions + click-through rate (consumes WS-1's surface-tagged log).
+    surfaces: list[SurfaceCTR] = []
 
 
 # --- Impact engine v2 (Wave A) ---

--- a/backend/app/services/entities.py
+++ b/backend/app/services/entities.py
@@ -148,6 +148,26 @@ async def bump_relevance_for_article(db: AsyncSession, user_id: int, article_id:
 # ── Surface personalization (G2 S5): one shared per-cluster relevance score ──────────
 
 
+async def _seed_affinities(db: AsyncSession, user_id: int) -> dict[int, float]:
+    """WS-5 (#115): the user's POSITIVE-affinity entities with their decayed weight — the SEEDS for
+    one-hop interest expansion. Same half-life decay as the scorer. Empty for a zero-signal user, so
+    expansion collapses to a no-op (only positive affinity seeds; a disliked entity never expands)."""
+    age_days = func.greatest(
+        0.0, func.extract("epoch", func.now() - UserEntityRelevance.last_event_at) / 86400.0
+    )
+    decayed = UserEntityRelevance.engagement_raw * func.exp(
+        -_LN2 * age_days / settings.uer_half_life_days
+    )
+    rows = (
+        await db.execute(
+            select(UserEntityRelevance.entity_id, decayed.label("aff")).where(
+                UserEntityRelevance.user_id == user_id
+            )
+        )
+    ).all()
+    return {int(eid): float(aff) for eid, aff in rows if aff and aff > 0}
+
+
 async def score_clusters_relevance(
     db: AsyncSession, cluster_ids: list[int], user_id: int | None
 ) -> dict[int, float]:
@@ -183,7 +203,39 @@ async def score_clusters_relevance(
     )
     q = select(per_entity.c.cid, func.avg(per_entity.c.decayed)).group_by(per_entity.c.cid)
     rows = (await db.execute(q)).all()
-    return {cid: float(score) for cid, score in rows if score is not None}
+    base = {cid: float(score) for cid, score in rows if score is not None}
+
+    # WS-5 (#115): one-hop interest expansion — a small additive "adjacent interests" nudge. Gated,
+    # and short-circuited when the user has no positive-affinity seeds, so a zero-signal user takes
+    # the EXACT base path (no extra queries, byte-identical) — the G2 no-op invariant holds.
+    if not settings.expansion_enabled:
+        return base
+    seeds = await _seed_affinities(db, user_id)
+    if not seeds:
+        return base
+    from app.services import graph
+    candidates = await graph.one_hop_candidates(db, seeds)
+    if not candidates:
+        return base
+    cent = (
+        await db.execute(
+            select(ClusterArticle.cluster_id, ArticleEntity.entity_id)
+            .join(ArticleEntity, ArticleEntity.article_id == ClusterArticle.article_id)
+            .where(ClusterArticle.cluster_id.in_(cluster_ids))
+            .distinct()
+        )
+    ).all()
+    by_cluster: dict[int, list[int]] = {}
+    for cid, eid in cent:
+        by_cluster.setdefault(cid, []).append(eid)
+    out = dict(base)
+    for cid, eids in by_cluster.items():
+        # AVG adjacency over the cluster's entities, CLAMPED to 1.0 so the term is at most
+        # expansion_weight (a bounded nudge that can't drown the recency/base-relevance signal).
+        adj = min(1.0, sum(candidates.get(e, 0.0) for e in eids) / len(eids))
+        if adj:
+            out[cid] = out.get(cid, 0.0) + settings.expansion_weight * adj
+    return out
 
 
 async def score_cluster_relevance(db: AsyncSession, cluster_id: int, user_id: int | None) -> float:

--- a/backend/app/services/graph.py
+++ b/backend/app/services/graph.py
@@ -1,0 +1,125 @@
+"""WS-5 (#115): the entity co-occurrence graph — a nightly, decayed aggregation of which entities
+share story clusters, and the one-hop candidate lookup that feeds interest expansion.
+
+The nightly job REBUILDS `entity_edges` from scratch each run (a derived cache): edge weight =
+Σ over the clusters two entities share of exp(-ln2·cluster_age/half_life). Because the weight is a
+pure function of the current article_entities + cluster state, the job is idempotent AND skip-tolerant
+— a missed night just means staler weights, and the next run recomputes correctly. Only the top-K
+edges per source (by weight) are kept.
+
+    article_entities × cluster_article ─▶ (cluster, entity) ─▶ self-join on cluster ─▶ decayed pair sum
+                                                                        │
+                                                        top-K per src ─▶ replace entity_edges (txn)
+"""
+import structlog
+from sqlalchemy import delete, func, insert, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import async_session
+from app.models import Article, ArticleEntity, ClusterArticle, EntityEdge
+
+logger = structlog.get_logger()
+
+_LN2 = 0.6931471805599453
+
+
+def _rank_edges(pairs: list[tuple[int, int, float]], k: int) -> dict[tuple[int, int], float]:
+    """Pure: expand unordered (src<dst) weighted pairs into BOTH directions and keep the top-K
+    neighbours per source by weight. Deterministic tie-break by (weight, dst) so repeated runs and
+    the idempotency test are stable."""
+    by_src: dict[int, list[tuple[int, float]]] = {}
+    for src, dst, w in pairs:
+        by_src.setdefault(src, []).append((dst, w))
+        by_src.setdefault(dst, []).append((src, w))
+    edges: dict[tuple[int, int], float] = {}
+    for src, neighbours in by_src.items():
+        for dst, w in sorted(neighbours, key=lambda x: (x[1], x[0]), reverse=True)[:k]:
+            edges[(src, dst)] = w
+    return edges
+
+
+async def _cooccurrence_weights(db: AsyncSession) -> list[tuple[int, int, float]]:
+    """Unordered entity pairs (src<dst) with Σ of per-shared-cluster exponential decay. Cluster age =
+    now − the cluster's newest article published_at (clusters with no dated article are skipped)."""
+    ts = (
+        select(ClusterArticle.cluster_id.label("cid"), func.max(Article.published_at).label("ts"))
+        .join(Article, Article.id == ClusterArticle.article_id)
+        .where(Article.published_at.isnot(None))
+        .group_by(ClusterArticle.cluster_id)
+        .subquery()
+    )
+    ce = (
+        select(ClusterArticle.cluster_id.label("cid"), ArticleEntity.entity_id.label("eid"))
+        .join(ArticleEntity, ArticleEntity.article_id == ClusterArticle.article_id)
+        .distinct()
+        .subquery()
+    )
+    ce1, ce2 = ce.alias("ce1"), ce.alias("ce2")
+    age_days = func.greatest(0.0, func.extract("epoch", func.now() - ts.c.ts) / 86400.0)
+    decay = func.exp(-_LN2 * age_days / settings.entity_edge_half_life_days)
+    q = (
+        select(ce1.c.eid.label("src"), ce2.c.eid.label("dst"), func.sum(decay).label("weight"))
+        .select_from(ce1)
+        .join(ce2, ce1.c.cid == ce2.c.cid)
+        .join(ts, ts.c.cid == ce1.c.cid)
+        .where(ce1.c.eid < ce2.c.eid)
+        .group_by(ce1.c.eid, ce2.c.eid)
+    )
+    return [(int(s), int(d), float(w)) for s, d, w in (await db.execute(q)).all()]
+
+
+async def _replace_edges(db: AsyncSession, edges: dict[tuple[int, int], float]) -> None:
+    """Atomically swap the whole derived table: delete all, then bulk-insert. Transactional, so a
+    concurrent reader sees the old set or the new set, never an empty table — and the result is
+    identical for identical input (idempotent)."""
+    await db.execute(delete(EntityEdge))
+    if edges:
+        await db.execute(
+            insert(EntityEdge),
+            [{"src_entity_id": s, "dst_entity_id": d, "weight": w} for (s, d), w in edges.items()],
+        )
+
+
+async def _rebuild(db: AsyncSession) -> dict[str, int]:
+    pairs = await _cooccurrence_weights(db)
+    edges = _rank_edges(pairs, settings.entity_edge_top_k)
+    await _replace_edges(db, edges)
+    return {"pairs": len(pairs), "edges": len(edges)}
+
+
+async def aggregate_entity_edges(db: AsyncSession | None = None) -> None:
+    """APScheduler nightly job: rebuild entity_edges from the current co-occurrence state. No-op when
+    disabled. Idempotent + skip-tolerant (full recompute), so a missed night never corrupts weights.
+    Opens its own session + commits when called by the scheduler (db=None); accepts an injected
+    session (tests) whose transaction the caller owns."""
+    if not settings.entity_edge_enabled:
+        return
+    if db is None:
+        async with async_session() as own:
+            stats = await _rebuild(own)
+            await own.commit()
+    else:
+        stats = await _rebuild(db)  # caller owns the transaction
+    logger.info("entity_edges_aggregated", **stats)
+
+
+async def one_hop_candidates(
+    db: AsyncSession, seed_weights: dict[int, float]
+) -> dict[int, float]:
+    """Adjacent-interest scores: for the user's seed entities (entity_id → affinity), sum
+    edge_weight × affinity over their graph neighbours. Returns {neighbour_entity_id: score}. Empty
+    when there are no seeds — the no-op path for a zero-signal user."""
+    if not seed_weights:
+        return {}
+    rows = (
+        await db.execute(
+            select(EntityEdge.src_entity_id, EntityEdge.dst_entity_id, EntityEdge.weight).where(
+                EntityEdge.src_entity_id.in_(sorted(seed_weights))
+            )
+        )
+    ).all()
+    out: dict[int, float] = {}
+    for src, dst, w in rows:
+        out[dst] = out.get(dst, 0.0) + float(w) * seed_weights[src]
+    return out

--- a/backend/app/services/ranking.py
+++ b/backend/app/services/ranking.py
@@ -1,0 +1,45 @@
+"""WS-5 (#115): the single home for the FEED ranking blend — recency + entity relevance, nudged by
+credibility and specialty. Extracted from routes.get_feed so the formula lives in one tunable,
+unit-testable place (a parity test pins it to the original inline behavior).
+
+Scope note: the other surfaces keep their by-design ordering and do NOT consume this blend —
+- rails ("News You Follow") are recency-only: the user asked for the latest on a follow, not an
+  affinity re-rank;
+- the discover deck is randomly sampled (discovery, not ranking);
+- the briefing uses its own additive story-weight (topic pref + affinity + field bonus).
+So this module is deliberately the feed's blend, ready to be adopted elsewhere in a future A/B.
+"""
+from app.config import settings
+
+
+def recency_norm(ts: float | None, lo: float, hi: float) -> float:
+    """Publish time normalized to [0,1] over the pool's [lo,hi] range. None → 0.0; a flat pool
+    (hi == lo) → 1.0 (matches the original inline guard)."""
+    if ts is None:
+        return 0.0
+    return 1.0 if hi == lo else (ts - lo) / (hi - lo)
+
+
+def credibility_mult(score: float | None) -> float:
+    """#79 bounded ×[0.9, 1.1] nudge. NULL (news) → the neutral default. Clamped to [0,100] at the
+    apply point so a bad stored score can never break the bound and drown fresher news."""
+    s = settings.credibility_rank_neutral if score is None else score
+    s = min(100, max(0, s))
+    return 0.9 + 0.2 * s / 100
+
+
+def specialty_mult(source_specialty: str | None, user_specialty: str | None) -> float:
+    """#94 bounded lift when the source's specialty matches the user's own. No specialty on either
+    side → ×1.0, so ordinary feeds are unchanged."""
+    if not user_specialty or not source_specialty:
+        return 1.0
+    return settings.specialty_rank_boost if source_specialty == user_specialty else 1.0
+
+
+def blend_score(
+    recency: float, relevance: float, cred: float, specialty: float, ratio: float | None = None
+) -> float:
+    """The feed blend: (recency vs relevance, mixed by `ratio`) × credibility × specialty. Relevance
+    is clamped to [0,1] here (score_clusters_relevance can exceed 1 once expansion is added)."""
+    r = settings.uer_feed_blend_ratio if ratio is None else ratio
+    return ((1 - r) * recency + r * min(1.0, relevance)) * cred * specialty

--- a/backend/migrations/versions/f6a7b8c9dae5_ws5_entity_edges.py
+++ b/backend/migrations/versions/f6a7b8c9dae5_ws5_entity_edges.py
@@ -1,0 +1,35 @@
+"""WS-5 (#115): entity_edges — global co-occurrence graph.
+
+Two entities that shared a story cluster get a decayed-weight edge (both directions). The nightly job
+upserts and keeps the top-K per source; one-hop interest expansion reads `WHERE src_entity_id IN
+(...)`, served by the composite PK's leftmost column (no extra index — mirrors user_entity_relevance).
+Global / content-scoped: NOT RLS.
+
+Revision ID: f6a7b8c9dae5
+Revises: e5f6a7b8c9da
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "f6a7b8c9dae5"
+down_revision = "e5f6a7b8c9da"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "entity_edges",
+        sa.Column("src_entity_id", sa.Integer(), nullable=False),
+        sa.Column("dst_entity_id", sa.Integer(), nullable=False),
+        sa.Column("weight", sa.Float(), server_default="0", nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["src_entity_id"], ["entities.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["dst_entity_id"], ["entities.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("src_entity_id", "dst_entity_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("entity_edges")

--- a/backend/tests/integration/test_feed.py
+++ b/backend/tests/integration/test_feed.py
@@ -99,9 +99,10 @@ async def test_feed_no_n_plus_one(aclient, db_session, engine):
     assert resp.status_code == 200
     assert len(resp.json()["articles"]) == 25
     # Endpoint issues a bounded set of queries: count, page, source selectin,
-    # cluster-membership, per-cluster count, summary set, recent feedback.
+    # cluster-membership, per-cluster count, summary set, recent feedback, and WS-5's one-hop seed
+    # probe (a single O(1) UER lookup — 0 rows for this zero-signal user, then expansion short-circuits).
     # Far fewer than 1-per-article (which would be 25+). Allow generous headroom.
-    assert counter["n"] <= 12, f"feed issued {counter['n']} SELECTs (possible N+1)"
+    assert counter["n"] <= 13, f"feed issued {counter['n']} SELECTs (possible N+1)"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_feed_personalized.py
+++ b/backend/tests/integration/test_feed_personalized.py
@@ -143,7 +143,9 @@ async def test_feed_on_zero_uer_identical_to_off(aclient, db_session, monkeypatc
 
 @pytest.mark.asyncio
 async def test_feed_on_no_n_plus_one(aclient, db_session, engine, monkeypatch):
-    """The on-path adds only the one score aggregate — query count stays bounded (no per-article N+1)."""
+    """The on-path adds only bounded aggregates — query count stays constant in the article count (no
+    per-article N+1). WS-5 adds one-hop expansion: a couple more single IN-clause queries (seed
+    affinities + graph neighbours), still O(1) in the pool size."""
     from app.config import settings as s
     monkeypatch.setattr(s, "uer_enabled", True)
     await _ensure_user1(db_session)
@@ -171,4 +173,4 @@ async def test_feed_on_no_n_plus_one(aclient, db_session, engine, monkeypatch):
 
     assert resp.status_code == 200
     assert len(resp.json()["articles"]) == 25
-    assert counter["n"] <= 13, f"feed (personalized) issued {counter['n']} SELECTs (possible N+1)"
+    assert counter["n"] <= 15, f"feed (personalized) issued {counter['n']} SELECTs (possible N+1)"

--- a/backend/tests/integration/test_graph_edges.py
+++ b/backend/tests/integration/test_graph_edges.py
@@ -1,0 +1,133 @@
+"""WS-5 (#115): the nightly entity co-occurrence graph — decayed pair weights, top-K bound, both
+directions, idempotency, skip-tolerance."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import Article, ArticleEntity, ClusterArticle, Entity, EntityEdge, Source, SourceType, StoryCluster
+from app.services import graph
+
+UTC = timezone.utc
+_n = 0
+
+
+async def _entity(db, name):
+    global _n
+    _n += 1
+    e = Entity(canonical_name=f"{name}{_n}", name_norm=f"{name}{_n}".lower(), kind="org")
+    db.add(e)
+    await db.flush()
+    return e
+
+
+async def _cluster(db, entities, when):
+    global _n
+    _n += 1
+    src = Source(name="S", url=f"https://g/{_n}", source_type=SourceType.wire)
+    db.add(src)
+    await db.flush()
+    art = Article(title=f"a{_n}", url=f"https://g/{_n}/a", source_id=src.id, published_at=when)
+    db.add(art)
+    await db.flush()
+    c = StoryCluster(title=f"c{_n}")
+    db.add(c)
+    await db.flush()
+    db.add(ClusterArticle(cluster_id=c.id, article_id=art.id))
+    for e in entities:
+        db.add(ArticleEntity(article_id=art.id, entity_id=e.id, salience=0.5))
+    await db.flush()
+    return c
+
+
+async def _edge_map(db):
+    rows = (await db.execute(select(EntityEdge.src_entity_id, EntityEdge.dst_entity_id, EntityEdge.weight))).all()
+    return {(s, d): float(w) for s, d, w in rows}
+
+
+# ── pure _rank_edges ──────────────────────────────────────────────────────────────────
+def test_rank_edges_bounds_per_source_and_stores_both_directions():
+    pairs = [(1, 2, 5.0), (1, 3, 3.0), (1, 4, 1.0)]  # entity 1 has three neighbours
+    edges = graph._rank_edges(pairs, k=2)
+    assert (1, 2) in edges and (1, 3) in edges          # entity 1 keeps its top-2
+    assert (1, 4) not in edges                           # and drops its weakest
+    assert (2, 1) in edges and (3, 1) in edges           # reverse direction stored
+    assert edges[(1, 2)] == 5.0
+
+
+def test_rank_edges_is_idempotent():
+    pairs = [(1, 2, 5.0), (2, 3, 2.0), (1, 3, 4.0)]
+    assert graph._rank_edges(pairs, 50) == graph._rank_edges(pairs, 50)
+
+
+# ── the job (uses the injected test session) ───────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_aggregate_builds_both_direction_edges_from_a_shared_cluster(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "entity_edge_enabled", True)
+    a, b, c = await _entity(db_session, "A"), await _entity(db_session, "B"), await _entity(db_session, "C")
+    await _cluster(db_session, [a, b, c], datetime.now(UTC))
+
+    await graph.aggregate_entity_edges(db_session)
+
+    edges = await _edge_map(db_session)
+    for x, y in [(a.id, b.id), (a.id, c.id), (b.id, c.id)]:
+        assert (x, y) in edges and (y, x) in edges  # every co-occurring pair, both directions
+
+
+@pytest.mark.asyncio
+async def test_aggregate_is_idempotent_and_skip_tolerant(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "entity_edge_enabled", True)
+    a, b = await _entity(db_session, "A"), await _entity(db_session, "B")
+    await _cluster(db_session, [a, b], datetime.now(UTC))
+
+    await graph.aggregate_entity_edges(db_session)
+    first = await _edge_map(db_session)
+    # a "skipped night" then a re-run recomputes the SAME table from scratch (no drift, no double-count)
+    await graph.aggregate_entity_edges(db_session)
+    assert await _edge_map(db_session) == first
+
+
+@pytest.mark.asyncio
+async def test_recent_cooccurrence_outweighs_old(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "entity_edge_enabled", True)
+    monkeypatch.setattr(s, "entity_edge_half_life_days", 30.0)
+    a, b = await _entity(db_session, "A"), await _entity(db_session, "B")
+    c, d = await _entity(db_session, "C"), await _entity(db_session, "D")
+    now = datetime.now(UTC)
+    await _cluster(db_session, [a, b], now)                       # fresh co-occurrence
+    await _cluster(db_session, [c, d], now - timedelta(days=120))  # old co-occurrence
+
+    await graph.aggregate_entity_edges(db_session)
+    edges = await _edge_map(db_session)
+    assert edges[(a.id, b.id)] > edges[(c.id, d.id)]  # decay makes the fresh pair heavier
+
+
+@pytest.mark.asyncio
+async def test_top_k_bounds_edges_per_source(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "entity_edge_enabled", True)
+    monkeypatch.setattr(s, "entity_edge_top_k", 2)
+    hub = await _entity(db_session, "HUB")
+    others = [await _entity(db_session, f"N{i}") for i in range(4)]
+    now = datetime.now(UTC)
+    # hub co-occurs with 4 others across clusters of increasing recency (so weights differ)
+    for i, o in enumerate(others):
+        await _cluster(db_session, [hub, o], now - timedelta(days=i))
+
+    await graph.aggregate_entity_edges(db_session)
+    edges = await _edge_map(db_session)
+    hub_edges = [d for (srcid, d) in edges if srcid == hub.id]
+    assert len(hub_edges) == 2  # bounded to top_k
+
+
+@pytest.mark.asyncio
+async def test_disabled_is_a_noop(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "entity_edge_enabled", False)
+    a, b = await _entity(db_session, "A"), await _entity(db_session, "B")
+    await _cluster(db_session, [a, b], datetime.now(UTC))
+    await graph.aggregate_entity_edges(db_session)
+    assert await _edge_map(db_session) == {}

--- a/backend/tests/integration/test_graph_expansion.py
+++ b/backend/tests/integration/test_graph_expansion.py
@@ -1,0 +1,102 @@
+"""WS-5 (#115): one-hop interest expansion in score_clusters_relevance — a bounded adjacency nudge
+that is a strict no-op for a zero-signal user (the G2 invariant) and when the flag is off."""
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models import (
+    Article, ArticleEntity, ClusterArticle, Entity, EntityEdge, Source, SourceType, StoryCluster,
+    User, UserEntityRelevance,
+)
+from app.services import entities
+
+UTC = timezone.utc
+_n = 0
+
+
+async def _ensure_user(db, uid=1):
+    if await db.get(User, uid) is None:
+        db.add(User(id=uid, locale="IN"))
+        await db.flush()
+
+
+async def _entity(db, name):
+    global _n
+    _n += 1
+    e = Entity(canonical_name=f"{name}{_n}", name_norm=f"{name}{_n}".lower(), kind="org")
+    db.add(e)
+    await db.flush()
+    return e
+
+
+async def _cluster_with(db, ents):
+    global _n
+    _n += 1
+    src = Source(name="S", url=f"https://x/{_n}", source_type=SourceType.wire)
+    db.add(src)
+    await db.flush()
+    art = Article(title=f"a{_n}", url=f"https://x/{_n}/a", source_id=src.id, published_at=datetime.now(UTC))
+    db.add(art)
+    await db.flush()
+    c = StoryCluster(title=f"c{_n}")
+    db.add(c)
+    await db.flush()
+    db.add(ClusterArticle(cluster_id=c.id, article_id=art.id))
+    for e in ents:
+        db.add(ArticleEntity(article_id=art.id, entity_id=e.id, salience=0.5))
+    await db.flush()
+    return c
+
+
+async def _follow(db, uid, entity, raw=1.0):
+    db.add(UserEntityRelevance(user_id=uid, entity_id=entity.id, source="follow",
+                               engagement_raw=raw, last_event_at=datetime.now(UTC)))
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_expansion_boosts_an_adjacent_cluster(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    monkeypatch.setattr(s, "expansion_enabled", True)
+    await _ensure_user(db_session)
+    a, b = await _entity(db_session, "A"), await _entity(db_session, "B")
+    await _follow(db_session, 1, a)                                   # user has affinity for A only
+    db_session.add(EntityEdge(src_entity_id=a.id, dst_entity_id=b.id, weight=1.0))  # A—B adjacency
+    await db_session.flush()
+    cl = await _cluster_with(db_session, [b])                          # a cluster of ONLY B
+
+    scores = await entities.score_clusters_relevance(db_session, [cl.id], 1)
+    assert scores.get(cl.id, 0.0) > 0.0                               # adjacency lifted a no-direct-signal cluster
+    assert scores[cl.id] <= s.expansion_weight + 1e-9                 # bounded to at most expansion_weight
+
+
+@pytest.mark.asyncio
+async def test_expansion_off_leaves_adjacent_cluster_at_zero(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    monkeypatch.setattr(s, "expansion_enabled", False)
+    await _ensure_user(db_session)
+    a, b = await _entity(db_session, "A"), await _entity(db_session, "B")
+    await _follow(db_session, 1, a)
+    db_session.add(EntityEdge(src_entity_id=a.id, dst_entity_id=b.id, weight=1.0))
+    await db_session.flush()
+    cl = await _cluster_with(db_session, [b])
+
+    scores = await entities.score_clusters_relevance(db_session, [cl.id], 1)
+    assert scores.get(cl.id, 0.0) == 0.0  # no direct affinity for B + expansion off → base 0.0
+
+
+@pytest.mark.asyncio
+async def test_expansion_is_noop_for_zero_signal_user(db_session, monkeypatch):
+    from app.config import settings as s
+    monkeypatch.setattr(s, "uer_enabled", True)
+    monkeypatch.setattr(s, "expansion_enabled", True)
+    await _ensure_user(db_session)
+    a, b = await _entity(db_session, "A"), await _entity(db_session, "B")
+    db_session.add(EntityEdge(src_entity_id=a.id, dst_entity_id=b.id, weight=1.0))
+    await db_session.flush()
+    cl = await _cluster_with(db_session, [b])  # user has NO UER → no seeds → no expansion
+
+    scores = await entities.score_clusters_relevance(db_session, [cl.id], 1)
+    assert scores.get(cl.id, 0.0) == 0.0  # zero-signal user unaffected by the graph

--- a/backend/tests/integration/test_stats_ctr.py
+++ b/backend/tests/integration/test_stats_ctr.py
@@ -1,0 +1,58 @@
+"""WS-5 (#115): /stats gains impressions + CTR per surface (opens = read + interesting over the
+surface-tagged impression log)."""
+import pytest
+
+from app.models import Article, FeedbackType, Impression, Source, SourceType, User, UserFeedback
+
+_n = 0
+
+
+async def _ensure_user(db, uid=1):
+    if await db.get(User, uid) is None:
+        db.add(User(id=uid, locale="IN"))
+        await db.flush()
+
+
+async def _article(db):
+    global _n
+    _n += 1
+    src = Source(name="S", url=f"https://st/{_n}", source_type=SourceType.wire)
+    db.add(src)
+    await db.flush()
+    a = Article(title=f"a{_n}", url=f"https://st/{_n}/a", source_id=src.id)
+    db.add(a)
+    await db.flush()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_stats_reports_impressions_and_ctr_per_surface(aclient, db_session):
+    await _ensure_user(db_session)
+    arts = [await _article(db_session) for _ in range(3)]
+    # 3 feed impressions (distinct articles → not deduped), 1 rail impression
+    for a in arts:
+        db_session.add(Impression(user_id=1, article_id=a.id, surface="feed"))
+    db_session.add(Impression(user_id=1, article_id=arts[0].id, surface="rail"))
+    # 2 feed OPENS (read + interesting) + 1 feed save (NOT an open)
+    db_session.add(UserFeedback(user_id=1, article_id=arts[0].id, feedback_type=FeedbackType.read, surface="feed"))
+    db_session.add(UserFeedback(user_id=1, article_id=arts[1].id, feedback_type=FeedbackType.interesting, surface="feed"))
+    db_session.add(UserFeedback(user_id=1, article_id=arts[2].id, feedback_type=FeedbackType.save, surface="feed"))
+    await db_session.flush()
+
+    body = (await aclient.get("/stats")).json()
+    surfaces = {s["surface"]: s for s in body["surfaces"]}
+
+    assert surfaces["feed"]["impressions"] == 3
+    assert surfaces["feed"]["clicks"] == 2                 # read + interesting; save excluded
+    assert abs(surfaces["feed"]["ctr"] - 2 / 3) < 1e-6
+    assert surfaces["rail"]["impressions"] == 1
+    assert surfaces["rail"]["clicks"] == 0
+    assert surfaces["rail"]["ctr"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_stats_surfaces_empty_without_impressions(aclient, db_session):
+    await _ensure_user(db_session)
+    body = (await aclient.get("/stats")).json()
+    assert body["surfaces"] == []  # backward-compatible: no impressions → empty list, scalars intact
+    assert "articles_read" in body

--- a/backend/tests/integration/test_stats_ctr.py
+++ b/backend/tests/integration/test_stats_ctr.py
@@ -1,5 +1,7 @@
 """WS-5 (#115): /stats gains impressions + CTR per surface (opens = read + interesting over the
-surface-tagged impression log)."""
+surface-tagged impression log). CTR is a bounded lifetime aggregate over DISTINCT stories."""
+from datetime import date, timedelta
+
 import pytest
 
 from app.models import Article, FeedbackType, Impression, Source, SourceType, User, UserFeedback
@@ -51,8 +53,44 @@ async def test_stats_reports_impressions_and_ctr_per_surface(aclient, db_session
 
 
 @pytest.mark.asyncio
+async def test_ctr_stays_bounded_across_multi_day_impressions_and_repeat_feedback(aclient, db_session):
+    """Review regression: distinct-story counting collapses the per-day impression dedup and repeated
+    'interesting' taps, so CTR can't drift below the real rate or exceed 1.0."""
+    await _ensure_user(db_session)
+    a = await _article(db_session)
+    today = date.today()
+    db_session.add(Impression(user_id=1, article_id=a.id, surface="feed", day=today))
+    db_session.add(Impression(user_id=1, article_id=a.id, surface="feed", day=today - timedelta(days=1)))
+    db_session.add(UserFeedback(user_id=1, article_id=a.id, feedback_type=FeedbackType.interesting, surface="feed"))
+    db_session.add(UserFeedback(user_id=1, article_id=a.id, feedback_type=FeedbackType.interesting, surface="feed"))
+    db_session.add(UserFeedback(user_id=1, article_id=a.id, feedback_type=FeedbackType.read, surface="feed"))
+    await db_session.flush()
+
+    feed = next(s for s in (await aclient.get("/stats")).json()["surfaces"] if s["surface"] == "feed")
+    assert feed["impressions"] == 1   # one distinct story, not two day-rows
+    assert feed["clicks"] == 1        # one distinct opened story, not three feedback rows
+    assert feed["ctr"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_surface_with_clicks_but_no_impressions_is_visible(aclient, db_session):
+    """Review regression: a surface with opens but no logged impressions (e.g. a rail deep-link) must
+    appear (impressions=0), not silently vanish."""
+    await _ensure_user(db_session)
+    a = await _article(db_session)
+    db_session.add(UserFeedback(user_id=1, article_id=a.id, feedback_type=FeedbackType.read, surface="rail"))
+    await db_session.flush()
+
+    surfaces = {s["surface"]: s for s in (await aclient.get("/stats")).json()["surfaces"]}
+    assert "rail" in surfaces
+    assert surfaces["rail"]["impressions"] == 0
+    assert surfaces["rail"]["clicks"] == 1
+    assert surfaces["rail"]["ctr"] == 0.0
+
+
+@pytest.mark.asyncio
 async def test_stats_surfaces_empty_without_impressions(aclient, db_session):
     await _ensure_user(db_session)
     body = (await aclient.get("/stats")).json()
-    assert body["surfaces"] == []  # backward-compatible: no impressions → empty list, scalars intact
+    assert body["surfaces"] == []  # backward-compatible: no impressions/clicks → empty list, scalars intact
     assert "articles_read" in body

--- a/backend/tests/unit/test_ranking_parity.py
+++ b/backend/tests/unit/test_ranking_parity.py
@@ -1,0 +1,59 @@
+"""WS-5 (#115): the unified-scorer PARITY guard — the extracted services/ranking.py must reproduce
+the ORIGINAL inline feed blend exactly (extracted == inline). Pure functions, no DB."""
+import pytest
+
+from app.config import settings
+from app.services import ranking
+
+
+# The formulas exactly as they were inline in routes.get_feed before extraction.
+def _inline_cred(score, neutral):
+    s = neutral if score is None else score
+    s = min(100, max(0, s))
+    return 0.9 + 0.2 * s / 100
+
+
+def _inline_specialty(src, user, boost):
+    if not user or not src:
+        return 1.0
+    return boost if src == user else 1.0
+
+
+def _inline_recency(ts, lo, hi, span):
+    return 0.0 if ts is None else (1.0 if hi == lo else (ts - lo) / span)
+
+
+def _inline_blend(recency, rel, cred, spec, ratio):
+    return ((1 - ratio) * recency + ratio * min(1.0, rel)) * cred * spec
+
+
+@pytest.mark.parametrize("score", [None, 0, 50, 75, 100, -5, 120])
+def test_credibility_mult_parity_and_bounds(score):
+    got = ranking.credibility_mult(score)
+    assert got == _inline_cred(score, settings.credibility_rank_neutral)
+    assert 0.9 <= got <= 1.1  # #79 bound holds even for out-of-range stored scores
+
+
+@pytest.mark.parametrize(
+    "src,user", [(None, None), ("med", None), (None, "med"), ("med", "med"), ("med", "law")]
+)
+def test_specialty_mult_parity(src, user):
+    assert ranking.specialty_mult(src, user) == _inline_specialty(src, user, settings.specialty_rank_boost)
+
+
+@pytest.mark.parametrize("ts,lo,hi", [(None, 0.0, 10.0), (5.0, 0.0, 10.0), (10.0, 10.0, 10.0), (0.0, 0.0, 10.0)])
+def test_recency_norm_parity(ts, lo, hi):
+    span = (hi - lo) or 1.0
+    assert ranking.recency_norm(ts, lo, hi) == _inline_recency(ts, lo, hi, span)
+
+
+@pytest.mark.parametrize(
+    "recency,rel,cred,spec,ratio",
+    [(0.5, 0.2, 1.0, 1.0, 0.3), (1.0, 1.5, 1.1, 1.25, 0.3), (0.0, 0.0, 0.9, 1.0, 0.5), (0.7, 1.0, 1.05, 1.0, 0.9)],
+)
+def test_blend_score_parity(recency, rel, cred, spec, ratio):
+    assert ranking.blend_score(recency, rel, cred, spec, ratio) == _inline_blend(recency, rel, cred, spec, ratio)
+
+
+def test_blend_default_ratio_matches_config():
+    assert ranking.blend_score(0.5, 0.5, 1.0, 1.0) == _inline_blend(0.5, 0.5, 1.0, 1.0, settings.uer_feed_blend_ratio)


### PR DESCRIPTION
## WS-5: signal-first graph + unified scorer + CTR — closes #115

The "honest G3 for recs": a global entity graph and a bounded adjacent-interest nudge, both strict no-ops until a user has real affinity signal — plus a centralized feed scorer and per-surface CTR.

### Entity co-occurrence graph
- **`entity_edges`** (src,dst composite PK, weight, updated_at) — global/content-scoped (not RLS). No extra index: the PK's leftmost column serves the one-hop read (mirrors `user_entity_relevance`). + migration.
- **Nightly job** (`services/graph.py`, 02:00, `max_instances=1`) **rebuilds from scratch**: edge weight = Σ over shared clusters of `exp(-ln2·cluster_age/half_life)`, top-K per source, both directions. Full recompute ⇒ **idempotent + skip-tolerant** (a missed night never corrupts weights).

### One-hop interest expansion
- A bounded additive term in `score_clusters_relevance`: seeds = the user's **positive**-affinity entities → their graph neighbours scored by edge×affinity → `expansion_weight=0.1`, clamped so it can't drown recency.
- **Zero-signal user has no seeds → early return → byte-identical base path**, so the G2 no-op invariant holds across feed / briefing / search (verified). Gated by `EXPANSION_ENABLED` / `ENTITY_EDGE_ENABLED`.

### Unified scorer
- Feed blend (recency + relevance × credibility × specialty) extracted to **`services/ranking.py`**; the feed consumes it and a **parity test pins it to the original inline formulas** (`extracted == inline`). Rails (recency-only — a follow surface) and the discover deck (random discovery) keep their by-design ordering.

### CTR
- **`/stats` gains impressions + CTR per surface** — DISTINCT stories opened (read+interesting) / DISTINCT stories impressed, clamped [0,1], RLS-scoped. A bounded lifetime aggregate.

### Adversarial review (8 agents · 2 confirmed MEDIUM · rest rejected)
- **Fixed:** CTR used incomparable count bases (per-day impressions vs lifetime/undeduped feedback) → could exceed 1.0 or drift; and clicks-only surfaces were dropped. Now distinct-story counts + clamp + union-of-surfaces. Regression tests added. (Graph, expansion, no-op invariant, and parity all survived review.)

### Verification
- Backend **494 passed / 1 skipped**; Alembic baseline parity green; N+1 guards updated for the bounded expansion queries (all O(1), not per-article).

🤖 Generated with [Claude Code](https://claude.com/claude-code)