### PR TITLE
WS-6: multi-user key/provider fix + settings consolidation (closes #116)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1371,6 +1371,7 @@ async def test_api_key(db: AsyncSession = Depends(get_db)):
         setting.openai_key_verified = True
         setting.openai_key_verified_at = datetime.now(timezone.utc)
         await db.commit()
+        _invalidate_llm_caches(current_user_id())  # WS-6: verified→live now (not after ≤60s TTL)
 
         logger.info("settings_key_test_success", models=model_count)
         return KeyTestResult(success=True, models_available=model_count)
@@ -1707,6 +1708,7 @@ async def test_gemini_key(db: AsyncSession = Depends(get_db)):
         setting.gemini_key_verified = True
         setting.gemini_key_verified_at = datetime.now(timezone.utc)
         await db.commit()
+        _invalidate_llm_caches(current_user_id())  # WS-6: verified→live now
         return KeyTestResult(success=True, models_available=len(models))
     except Exception as e:  # noqa: BLE001
         return KeyTestResult(success=False, error=str(e)[:200])
@@ -1762,6 +1764,7 @@ async def test_anthropic_key(db: AsyncSession = Depends(get_db)):
         setting.anthropic_key_verified = True
         setting.anthropic_key_verified_at = datetime.now(timezone.utc)
         await db.commit()
+        _invalidate_llm_caches(current_user_id())  # WS-6: verified→live now
         return KeyTestResult(success=True, models_available=1)
     except Exception as e:  # noqa: BLE001
         # REDACT: Anthropic exception text can echo the key / request metadata — never return str(e).

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1341,6 +1341,7 @@ async def update_settings(
 
     await db.commit()
     await db.refresh(setting)
+    _invalidate_llm_caches(current_user_id())  # WS-6: provider/model/key change live at once
     return _settings_out(setting)
 
 
@@ -1650,6 +1651,14 @@ async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)
 
 
 # ── E1: per-user Gemini key ──
+def _invalidate_llm_caches(uid: int) -> None:
+    """WS-6 (#116): drop this user's cached key/provider so a settings write takes effect at once."""
+    from app.services import embeddings as _emb
+    from app.services import llm as _llm
+    _llm.invalidate_user(uid)
+    _emb.invalidate_user(uid)
+
+
 @router.put("/settings/gemini-key", dependencies=[Depends(get_current_user)])
 async def set_gemini_key(body: GeminiKeyUpdate, db: AsyncSession = Depends(get_db)):
     from app.services.encryption import encrypt_value
@@ -1676,6 +1685,7 @@ async def set_gemini_key(body: GeminiKeyUpdate, db: AsyncSession = Depends(get_d
         setting.gemini_api_key_encrypted = None
         setting.gemini_key_verified = False
     await db.commit()
+    _invalidate_llm_caches(current_user_id())  # WS-6: saved key live at once (with the 60s TTL)
     return {"has_gemini_key": bool(setting.gemini_api_key_encrypted)}
 
 
@@ -1726,6 +1736,7 @@ async def set_anthropic_key(body: AnthropicKeyUpdate, db: AsyncSession = Depends
         setting.anthropic_api_key_encrypted = None
         setting.anthropic_key_verified = False
     await db.commit()
+    _invalidate_llm_caches(current_user_id())  # WS-6
     return {"has_anthropic_key": bool(setting.anthropic_api_key_encrypted)}
 
 

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -19,47 +19,55 @@ from app.models import Article, EmbeddingStatus
 logger = structlog.get_logger()
 
 
-_cached_user_key: str | None = None
-_cached_user_key_ts: float = 0
-_USER_KEY_TTL = 300  # 5 minutes cache
+# WS-6 (#116): per-user cache {user_id: (key|None, ts)} — was a single global slot that returned
+# user #1's key to every caller. TTL 60s so a freshly-saved key takes effect within a minute.
+_user_key_cache: dict[int, tuple[str | None, float]] = {}
+_USER_KEY_TTL = 60
 
 
-async def _get_user_api_key() -> str | None:
-    """Check DB for per-user OpenAI key. Cached for 5 minutes."""
+def invalidate_user(user_id: int) -> None:
+    """Drop a user's cached OpenAI key so a just-saved key takes effect at once (with the 60s TTL)."""
+    _user_key_cache.pop(user_id, None)
+
+
+async def _get_user_api_key(user_id: int | None = None) -> str | None:
+    """The per-user OpenAI key (verified), cached 60s. Resolves for the CURRENT request's user
+    (current_user_id() — an async-task-local set by get_current_user) unless an explicit user_id is
+    passed. Multi-user correct: user #2's request no longer resolves user #1's key."""
     import time
 
-    global _cached_user_key, _cached_user_key_ts
+    from app.services.auth import current_user_id
 
+    uid = user_id if user_id is not None else current_user_id()
     now = time.time()
-    if _cached_user_key is not None and (now - _cached_user_key_ts) < _USER_KEY_TTL:
-        return _cached_user_key
+    hit = _user_key_cache.get(uid)
+    if hit is not None and (now - hit[1]) < _USER_KEY_TTL:
+        return hit[0]
 
+    key: str | None = None
     try:
         from sqlalchemy import select as sa_select
         from app.models import UserSetting
 
         async with async_session() as session:
-            result = await session.execute(
-                sa_select(UserSetting).where(
-                    UserSetting.user_id == 1,
-                    UserSetting.openai_api_key_encrypted.isnot(None),
-                    UserSetting.openai_key_verified.is_(True),
+            setting = (
+                await session.execute(
+                    sa_select(UserSetting).where(
+                        UserSetting.user_id == uid,
+                        UserSetting.openai_api_key_encrypted.isnot(None),
+                        UserSetting.openai_key_verified.is_(True),
+                    )
                 )
-            )
-            setting = result.scalar_one_or_none()
-
+            ).scalar_one_or_none()
             if setting and setting.openai_api_key_encrypted:
                 from app.services.encryption import decrypt_value
 
-                _cached_user_key = decrypt_value(setting.openai_api_key_encrypted)
-                _cached_user_key_ts = now
-                return _cached_user_key
+                key = decrypt_value(setting.openai_api_key_encrypted)
     except Exception as e:
         logger.debug("user_key_lookup_failed", error=str(e))
 
-    _cached_user_key = None
-    _cached_user_key_ts = now
-    return None
+    _user_key_cache[uid] = (key, now)
+    return key
 
 
 def _get_client() -> AsyncOpenAI | None:
@@ -76,9 +84,9 @@ def _get_client_platform() -> AsyncOpenAI | None:
     return _get_client()
 
 
-async def _get_client_async() -> AsyncOpenAI | None:
-    """Get OpenAI client: per-user DB key first, env var fallback."""
-    user_key = await _get_user_api_key()
+async def _get_client_async(user_id: int | None = None) -> AsyncOpenAI | None:
+    """Get OpenAI client: per-user DB key first (current request's user), env var fallback."""
+    user_key = await _get_user_api_key(user_id)
     if user_key:
         return AsyncOpenAI(api_key=user_key)
     if settings.openai_api_key:
@@ -86,12 +94,12 @@ async def _get_client_async() -> AsyncOpenAI | None:
     return None
 
 
-async def _resolve_embedding_key() -> str | None:
+async def _resolve_embedding_key(user_id: int | None = None) -> str | None:
     """Gemini key for embeddings: the owner's verified per-user key, else the platform env key.
     Reuses the generation-side resolver (lazy import avoids a circular import with llm)."""
     from app.services.llm import _resolve_gemini_key
 
-    return await _resolve_gemini_key()
+    return await _resolve_gemini_key(user_id)
 
 
 def vector_literal(embedding) -> str:

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -55,19 +55,36 @@ def extract_json(text):
     raise ValueError("could not parse JSON from model output")
 
 
-# ── Per-user Gemini key resolver (separate cache slot from the OpenAI one) ──
-# NOTE: per-user DB key (user_settings.gemini_api_key_encrypted) lands with the E1
-# migration; until then this resolves the env key. Kept as a seam so callers don't change.
-_gem_key_cache: str | None = None
-_gem_key_ts: float = 0.0
-_GEM_TTL = 300
+# WS-6 (#116): all per-user resolution keys off the CURRENT request's user (current_user_id() — an
+# async-task-local set by get_current_user), with an optional explicit user_id override, and PER-USER
+# caches (were single global slots that leaked user #1's config to every caller). TTL 60s so a saved
+# key/provider takes effect within a minute. Background jobs (force_platform_key) never hit these.
+_GEM_TTL = 60
 
 
-async def _resolve_gemini_key() -> str | None:
-    global _gem_key_cache, _gem_key_ts
+def _uid(user_id: int | None) -> int:
+    from app.services.auth import current_user_id
+    return user_id if user_id is not None else current_user_id()
+
+
+def invalidate_user(user_id: int) -> None:
+    """Drop a user's cached key/provider entries so a just-saved key/provider takes effect at once
+    (belt-and-braces on top of the 60s TTL). Called by the settings write endpoints."""
+    _gem_key_cache.pop(user_id, None)
+    _anth_key_cache.pop(user_id, None)
+    _active_cache.pop(user_id, None)
+
+
+# ── Per-user Gemini key resolver ──
+_gem_key_cache: dict[int, tuple[str | None, float]] = {}
+
+
+async def _resolve_gemini_key(user_id: int | None = None) -> str | None:
+    uid = _uid(user_id)
     now = time.time()
-    if _gem_key_cache is not None and (now - _gem_key_ts) < _GEM_TTL:
-        return _gem_key_cache
+    hit = _gem_key_cache.get(uid)
+    if hit is not None and (now - hit[1]) < _GEM_TTL:
+        return hit[0]
     key = None
     try:
         from sqlalchemy import select
@@ -79,7 +96,7 @@ async def _resolve_gemini_key() -> str | None:
             row = (
                 await s.execute(
                     select(UserSetting).where(
-                        UserSetting.user_id == 1,
+                        UserSetting.user_id == uid,
                         UserSetting.gemini_api_key_encrypted.isnot(None),
                         UserSetting.gemini_key_verified.is_(True),
                     )
@@ -91,20 +108,20 @@ async def _resolve_gemini_key() -> str | None:
         logger.debug("gemini_key_lookup_failed", error=str(e))
     if not key:
         key = settings.gemini_api_key or None
-    _gem_key_cache, _gem_key_ts = key, now
+    _gem_key_cache[uid] = (key, now)
     return key
 
 
-# ── Per-user Anthropic key resolver (own cache slot, mirrors gemini) ──
-_anth_key_cache: str | None = None
-_anth_key_ts: float = 0.0
+# ── Per-user Anthropic key resolver ──
+_anth_key_cache: dict[int, tuple[str | None, float]] = {}
 
 
-async def _resolve_anthropic_key() -> str | None:
-    global _anth_key_cache, _anth_key_ts
+async def _resolve_anthropic_key(user_id: int | None = None) -> str | None:
+    uid = _uid(user_id)
     now = time.time()
-    if _anth_key_cache is not None and (now - _anth_key_ts) < _GEM_TTL:
-        return _anth_key_cache
+    hit = _anth_key_cache.get(uid)
+    if hit is not None and (now - hit[1]) < _GEM_TTL:
+        return hit[0]
     key = None
     try:
         from sqlalchemy import select
@@ -116,7 +133,7 @@ async def _resolve_anthropic_key() -> str | None:
             row = (
                 await s.execute(
                     select(UserSetting).where(
-                        UserSetting.user_id == 1,
+                        UserSetting.user_id == uid,
                         UserSetting.anthropic_api_key_encrypted.isnot(None),
                         UserSetting.anthropic_key_verified.is_(True),
                     )
@@ -128,22 +145,22 @@ async def _resolve_anthropic_key() -> str | None:
         logger.debug("anthropic_key_lookup_failed", error=str(e))
     if not key:
         key = settings.anthropic_api_key or None
-    _anth_key_cache, _anth_key_ts = key, now
+    _anth_key_cache[uid] = (key, now)
     return key
 
 
-# ── Active provider + per-provider model overrides (own cache slot) ──
-_active_cache: tuple[str, dict] | None = None
-_active_ts: float = 0.0
+# ── Active provider + per-provider model overrides ──
+_active_cache: dict[int, tuple[tuple[str, dict], float]] = {}
 
 
-async def _active_settings() -> tuple[str, dict]:
-    """(active_provider, model_prefs) for the owner (user 1), cached 300s. Falls back to the env
-    generation_provider when no per-user choice is stored. Independent of the key caches."""
-    global _active_cache, _active_ts
+async def _active_settings(user_id: int | None = None) -> tuple[str, dict]:
+    """(active_provider, model_prefs) for the CURRENT request's user (or an explicit user_id), cached
+    60s. Falls back to the env generation_provider when no per-user choice is stored."""
+    uid = _uid(user_id)
     now = time.time()
-    if _active_cache is not None and (now - _active_ts) < _GEM_TTL:
-        return _active_cache
+    hit = _active_cache.get(uid)
+    if hit is not None and (now - hit[1]) < _GEM_TTL:
+        return hit[0]
     provider = (settings.generation_provider or "openai").lower()
     prefs: dict = {}
     try:
@@ -153,7 +170,7 @@ async def _active_settings() -> tuple[str, dict]:
 
         async with async_session() as s:
             row = (
-                await s.execute(select(UserSetting).where(UserSetting.user_id == 1))
+                await s.execute(select(UserSetting).where(UserSetting.user_id == uid))
             ).scalar_one_or_none()
             if row:
                 if row.active_provider:
@@ -161,8 +178,8 @@ async def _active_settings() -> tuple[str, dict]:
                 prefs = row.model_prefs or {}
     except Exception as e:  # noqa: BLE001
         logger.debug("active_provider_lookup_failed", error=str(e))
-    _active_cache, _active_ts = (provider, prefs), now
-    return _active_cache
+    _active_cache[uid] = ((provider, prefs), now)
+    return _active_cache[uid][0]
 
 
 def _model_default(provider: str) -> str:
@@ -176,7 +193,7 @@ def _model_default(provider: str) -> str:
 async def _generate_openai(prompt: str, *, system: str | None = None,
                            schema=None, model: str | None = None,
                            max_tokens: int | None = None,
-                           force_platform_key: bool = False):
+                           force_platform_key: bool = False, user_id: int | None = None):
     # Module ref (not a bound import) so tests can patch embeddings._get_client_async.
     from app.services import embeddings
     # force_platform_key: background jobs (graph extraction) bill the platform/env key, never the
@@ -184,7 +201,7 @@ async def _generate_openai(prompt: str, *, system: str | None = None,
     client = (
         embeddings._get_client_platform()
         if force_platform_key
-        else await embeddings._get_client_async()
+        else await embeddings._get_client_async(user_id)
     )
     if client is None:
         raise LLMUnavailable("no OpenAI key configured")
@@ -208,8 +225,8 @@ async def _generate_openai(prompt: str, *, system: str | None = None,
 async def _generate_gemini(prompt: str, *, system: str | None = None,
                            schema=None, model: str | None = None,
                            max_tokens: int | None = None,
-                           force_platform_key: bool = False):
-    key = settings.gemini_api_key if force_platform_key else await _resolve_gemini_key()
+                           force_platform_key: bool = False, user_id: int | None = None):
+    key = settings.gemini_api_key if force_platform_key else await _resolve_gemini_key(user_id)
     if not key:
         raise LLMUnavailable("no Gemini key configured")
     import google.generativeai as genai  # lazy import — only needed on the gemini path
@@ -231,8 +248,8 @@ async def _generate_gemini(prompt: str, *, system: str | None = None,
 async def _generate_anthropic(prompt: str, *, system: str | None = None,
                               schema=None, model: str | None = None,
                               max_tokens: int | None = None,
-                              force_platform_key: bool = False):
-    key = settings.anthropic_api_key if force_platform_key else await _resolve_anthropic_key()
+                              force_platform_key: bool = False, user_id: int | None = None):
+    key = settings.anthropic_api_key if force_platform_key else await _resolve_anthropic_key(user_id)
     if not key:
         raise LLMUnavailable("no Anthropic key configured")
     import anthropic  # lazy — only on the real anthropic path
@@ -262,26 +279,28 @@ async def _generate_anthropic(prompt: str, *, system: str | None = None,
 async def generate(prompt: str, *, system: str | None = None,
                    schema=None, model: str | None = None,
                    max_tokens: int | None = None,
-                   force_platform_key: bool = False):
-    """Generate text (or parsed JSON when ``schema`` is given) via the owner's chosen provider+model.
+                   force_platform_key: bool = False, user_id: int | None = None):
+    """Generate text (or parsed JSON when ``schema`` is given) via the chosen provider+model.
 
-    Provider = per-user active_provider (else env generation_provider). Model = explicit arg →
-    per-user model_prefs[provider] → provider config default. ``force_platform_key`` routes to the
-    platform/env key (background jobs), never a per-user key. Raises ``LLMUnavailable`` when no key.
+    Provider/model/key resolve for the CURRENT request's user (current_user_id(), an async-task-local
+    set by get_current_user) unless an explicit ``user_id`` is passed. Provider = per-user
+    active_provider (else env generation_provider). Model = explicit arg → per-user model_prefs[provider]
+    → provider config default. ``force_platform_key`` routes to the platform/env key (background jobs),
+    never a per-user key. Raises ``LLMUnavailable`` when no key.
     """
-    provider, prefs = await _active_settings()
+    provider, prefs = await _active_settings(user_id)
     resolved_model = model or prefs.get(provider) or _model_default(provider)
     if provider == "gemini":
         return await _generate_gemini(
             prompt, system=system, schema=schema, model=resolved_model, max_tokens=max_tokens,
-            force_platform_key=force_platform_key,
+            force_platform_key=force_platform_key, user_id=user_id,
         )
     if provider == "anthropic":
         return await _generate_anthropic(
             prompt, system=system, schema=schema, model=resolved_model, max_tokens=max_tokens,
-            force_platform_key=force_platform_key,
+            force_platform_key=force_platform_key, user_id=user_id,
         )
     return await _generate_openai(
         prompt, system=system, schema=schema, model=resolved_model, max_tokens=max_tokens,
-        force_platform_key=force_platform_key,
+        force_platform_key=force_platform_key, user_id=user_id,
     )

--- a/backend/tests/integration/test_multiuser_keys.py
+++ b/backend/tests/integration/test_multiuser_keys.py
@@ -1,0 +1,101 @@
+"""WS-6 (#116): the multi-user key/provider fix — every per-user resolver keys off the CURRENT
+request's user (current_user_id() contextvar), not a hardcoded user #1. Background jobs
+(force_platform_key) still use the env key, byte-identical."""
+import contextlib
+
+import pytest
+
+from app.models import User, UserSetting
+from app.services import embeddings, llm
+from app.services.auth import _req_user_id
+from app.services.encryption import encrypt_value
+
+
+def _route_sessions_to_test(monkeypatch, db_session):
+    """Make the resolvers' own async_session() yield the test's (uncommitted) session. llm imports it
+    lazily from app.database; embeddings holds a module-level ref — patch both."""
+    import app.database
+
+    @contextlib.asynccontextmanager
+    async def _fake():
+        yield db_session
+
+    monkeypatch.setattr(app.database, "async_session", _fake)
+    monkeypatch.setattr(embeddings, "async_session", _fake)
+
+
+async def _seed(db, uid, *, gem, anth, oai, provider):
+    if await db.get(User, uid) is None:
+        db.add(User(id=uid, locale="IN"))
+        await db.flush()
+    db.add(
+        UserSetting(
+            user_id=uid,
+            gemini_api_key_encrypted=encrypt_value(gem), gemini_key_verified=True,
+            anthropic_api_key_encrypted=encrypt_value(anth), anthropic_key_verified=True,
+            openai_api_key_encrypted=encrypt_value(oai), openai_key_verified=True,
+            active_provider=provider, model_prefs={provider: f"model-{uid}"},
+        )
+    )
+    await db.flush()
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    for c in (llm._gem_key_cache, llm._anth_key_cache, llm._active_cache, embeddings._user_key_cache):
+        c.clear()
+    yield
+    for c in (llm._gem_key_cache, llm._anth_key_cache, llm._active_cache, embeddings._user_key_cache):
+        c.clear()
+
+
+@pytest.mark.asyncio
+async def test_current_user_resolves_own_keys_and_provider_across_all_four_sites(db_session, monkeypatch):
+    _route_sessions_to_test(monkeypatch, db_session)
+    await _seed(db_session, 1, gem="g1", anth="a1", oai="o1", provider="openai")
+    await _seed(db_session, 2, gem="g2", anth="a2", oai="o2", provider="anthropic")
+
+    tok = _req_user_id.set(2)  # simulate user #2's request context
+    try:
+        assert await llm._resolve_gemini_key() == "g2"          # site 1
+        assert await llm._resolve_anthropic_key() == "a2"        # site 2
+        assert await embeddings._get_user_api_key() == "o2"      # site 3 (OpenAI)
+        provider, prefs = await llm._active_settings()           # site 4 (provider/model)
+        assert provider == "anthropic"
+        assert prefs.get("anthropic") == "model-2"
+    finally:
+        _req_user_id.reset(tok)
+
+    # Isolation: user #1's config is unaffected (explicit override, distinct cache slot).
+    assert await llm._resolve_gemini_key(user_id=1) == "g1"
+    assert (await llm._active_settings(user_id=1))[0] == "openai"
+
+
+@pytest.mark.asyncio
+async def test_background_force_platform_uses_env_key_and_never_the_user_resolver(monkeypatch):
+    """Regression: background jobs (force_platform_key) resolve the ENV key and never touch the
+    per-user resolver — byte-identical to before the multi-user fix."""
+    from app.config import settings as s
+    monkeypatch.setattr(s, "gemini_api_key", "ENV-GEMINI")
+
+    async def _boom(*a, **k):
+        raise AssertionError("per-user resolver must NOT run for force_platform_key")
+
+    monkeypatch.setattr(llm, "_resolve_gemini_key", _boom)
+
+    captured = {}
+    import google.generativeai as genai
+
+    class _Model:
+        def __init__(self, *a, **k):
+            pass
+
+        async def generate_content_async(self, prompt):
+            return type("R", (), {"text": "ok"})()
+
+    monkeypatch.setattr(genai, "configure", lambda api_key=None: captured.__setitem__("key", api_key))
+    monkeypatch.setattr(genai, "GenerativeModel", _Model)
+
+    out = await llm._generate_gemini("hi", force_platform_key=True)
+    assert out == "ok"
+    assert captured["key"] == "ENV-GEMINI"  # env platform key, not any per-user key

--- a/backend/tests/integration/test_multiuser_keys.py
+++ b/backend/tests/integration/test_multiuser_keys.py
@@ -99,3 +99,23 @@ async def test_background_force_platform_uses_env_key_and_never_the_user_resolve
     out = await llm._generate_gemini("hi", force_platform_key=True)
     assert out == "ok"
     assert captured["key"] == "ENV-GEMINI"  # env platform key, not any per-user key
+
+
+@pytest.mark.asyncio
+async def test_test_key_endpoint_busts_the_resolver_cache(aclient, db_session, monkeypatch):
+    """Review regression: verifying a key (test-*-key flips verified→True) must bust the per-user
+    resolver cache, so the freshly-verified key is used at once instead of after the 60s TTL."""
+    if await db_session.get(User, 1) is None:
+        db_session.add(User(id=1, locale="IN"))
+        await db_session.flush()
+    db_session.add(UserSetting(user_id=1, gemini_api_key_encrypted=encrypt_value("gk"), gemini_key_verified=False))
+    await db_session.flush()
+
+    llm._gem_key_cache[1] = (None, 9e9)  # poison: as if a prior resolve saw no verified key
+    import google.generativeai as genai
+    monkeypatch.setattr(genai, "configure", lambda api_key=None: None)
+    monkeypatch.setattr(genai, "list_models", lambda: [object()])
+
+    r = await aclient.post("/settings/test-gemini-key")
+    assert r.json()["success"] is True
+    assert 1 not in llm._gem_key_cache  # busted → the next resolve re-reads the now-verified row

--- a/backend/tests/unit/test_generate_anthropic.py
+++ b/backend/tests/unit/test_generate_anthropic.py
@@ -60,7 +60,7 @@ async def test_text_path_joins_blocks_and_top_level_system(monkeypatch):
 async def test_no_key_raises(monkeypatch):
     monkeypatch.setattr(llm.settings, "anthropic_api_key", "")
 
-    async def _no_key():
+    async def _no_key(user_id=None):
         return None
 
     monkeypatch.setattr(llm, "_resolve_anthropic_key", _no_key)

--- a/backend/tests/unit/test_graph_extraction_provider.py
+++ b/backend/tests/unit/test_graph_extraction_provider.py
@@ -13,7 +13,7 @@ class _Cluster:
 
 @pytest.mark.asyncio
 async def test_extraction_uses_active_provider_model_not_hardcoded_gpt(monkeypatch):
-    async def _active():
+    async def _active(user_id=None):
         return ("anthropic", {})
     monkeypatch.setattr(llm, "_active_settings", _active)
     monkeypatch.setattr(llm.settings, "anthropic_model", "claude-haiku-4-5")

--- a/backend/tests/unit/test_llm.py
+++ b/backend/tests/unit/test_llm.py
@@ -34,7 +34,7 @@ class TestGenerateRouting:
         # directly (no cache, no DB) — active-settings resolution is covered by its own tests.
         from app.config import settings as _s
 
-        async def _fake():
+        async def _fake(user_id=None):
             return ((_s.generation_provider or "openai").lower(), {})
 
         monkeypatch.setattr(llm, "_active_settings", _fake)
@@ -78,7 +78,7 @@ class TestGenerateRouting:
         monkeypatch.setattr(settings, "openai_api_key", "")
         import app.services.embeddings as emb
 
-        async def none_client():
+        async def none_client(user_id=None):
             return None
 
         monkeypatch.setattr(emb, "_get_client_async", none_client)
@@ -122,7 +122,7 @@ async def test_generate_no_key_returns_unavailable(monkeypatch):
     monkeypatch.setattr(settings, "generation_provider", "gemini")
     monkeypatch.setattr(settings, "gemini_api_key", "")
 
-    async def no_gem_key():
+    async def no_gem_key(user_id=None):
         return None
 
     monkeypatch.setattr(llm, "_resolve_gemini_key", no_gem_key)
@@ -148,15 +148,15 @@ async def test_gemini_key_cache_slot_separate_from_openai(monkeypatch):
     # OpenAI key set to a different value to prove the slots don't cross-contaminate.
     monkeypatch.setattr(settings, "openai_api_key", "sk-openai-key")
 
-    # Reset the Gemini cache slot so the fallback path runs deterministically.
-    monkeypatch.setattr(llm, "_gem_key_cache", None)
-    monkeypatch.setattr(llm, "_gem_key_ts", 0.0)
+    # Reset the Gemini cache (WS-6: now a per-user dict) so the fallback path runs deterministically.
+    llm._gem_key_cache.clear()
 
+    from app.services.auth import current_user_id
     key = await llm._resolve_gemini_key()
     assert key == "gem-env-key"
-    # The dedicated Gemini cache slot now holds the Gemini key, not the OpenAI one.
-    assert llm._gem_key_cache == "gem-env-key"
-    assert llm._gem_key_cache != settings.openai_api_key
+    # The dedicated Gemini cache holds the Gemini key for the default user, not the OpenAI one.
+    assert llm._gem_key_cache[current_user_id()][0] == "gem-env-key"
+    assert llm._gem_key_cache[current_user_id()][0] != settings.openai_api_key
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_llm_dispatch.py
+++ b/backend/tests/unit/test_llm_dispatch.py
@@ -5,7 +5,7 @@ from app.services import llm
 
 
 def _patch_active(monkeypatch, provider, prefs):
-    async def _fake():
+    async def _fake(user_id=None):
         return (provider, prefs)
     monkeypatch.setattr(llm, "_active_settings", _fake)
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -13,14 +13,9 @@ import { ProfileFields } from "@/components/ProfileFields";
 import { ModelProviderCard } from "@/components/ModelProviderCard";
 import { AccountCard } from "@/components/AccountCard";
 import {
-  getSettings,
   getStats,
   getTopics,
-  updateSettings,
   updateProfile,
-  testApiKey,
-  type UserSettings,
-  type KeyTestResult,
   type StatsResponse,
   type Topic,
 } from "@/lib/api";
@@ -59,11 +54,6 @@ const fadeUp = {
 
 export default function ProfilePage() {
   const [state, setState] = useState<PageState>("loading");
-  const [settings, setSettings] = useState<UserSettings | null>(null);
-  const [keyInput, setKeyInput] = useState("");
-  const [showKey, setShowKey] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [testResult, setTestResult] = useState<KeyTestResult | null>(null);
 
   // Local preferences (persisted to localStorage)
   const [selectedTopics, setSelectedTopics] = useState<Set<string>>(() => {
@@ -82,17 +72,14 @@ export default function ProfilePage() {
   const fetchSettings = useCallback(async () => {
     try {
       setState("loading");
-      const [settingsData, statsData, topicsData] = await Promise.all([
-        getSettings(),
+      const [statsData, topicsData] = await Promise.all([
         getStats().catch(() => null),
         getTopics().catch(() => null),
       ]);
-      setSettings(settingsData);
       if (statsData) setStats(statsData);
       if (topicsData) setTopics(topicsData.your_topics);
       setState("idle");
     } catch {
-      setError("Failed to load settings");
       setState("idle");
     }
   }, []);
@@ -120,65 +107,12 @@ export default function ProfilePage() {
     });
   };
 
-  const handleSave = async () => {
-    if (!keyInput.trim()) return;
-    try {
-      setState("saving");
-      setError(null);
-      setTestResult(null);
-      const data = await updateSettings({ openai_api_key: keyInput.trim() });
-      setSettings(data);
-      setKeyInput("");
-      setShowKey(false);
-      setState("idle");
-    } catch {
-      setError("Failed to save API key");
-      setState("editing");
-    }
-  };
-
-  const handleRemove = async () => {
-    try {
-      setState("saving");
-      setError(null);
-      setTestResult(null);
-      const data = await updateSettings({ openai_api_key: null });
-      setSettings(data);
-      setKeyInput("");
-      setState("idle");
-    } catch {
-      setError("Failed to remove API key");
-      setState("idle");
-    }
-  };
-
-  const handleTest = async () => {
-    try {
-      setState("testing");
-      setError(null);
-      const result = await testApiKey();
-      setTestResult(result);
-      const data = await getSettings();
-      setSettings(data);
-      setState("idle");
-    } catch {
-      setTestResult({
-        success: false,
-        error: "Connection failed",
-        models_available: 0,
-      });
-      setState("idle");
-    }
-  };
-
   const handleClearHistory = () => {
     localStorage.removeItem("newslens-topics");
     localStorage.removeItem("newslens-theme");
     setSelectedTopics(new Set(defaultTopics));
     setTheme("dark");
   };
-
-  const isEditing = state === "editing" || keyInput.length > 0;
 
   return (
     <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)]">
@@ -363,198 +297,6 @@ export default function ProfilePage() {
             <ModelProviderCard />
           </motion.div>
 
-          {/* AI Configuration (OpenAI key) */}
-          <motion.div variants={fadeUp} className="mb-4">
-            <Card variant="raised">
-              <div className="p-3.5">
-                <div className="flex items-center gap-2 mb-1">
-                  <h2 className="text-heading text-[var(--text-primary)]">
-                    AI Configuration
-                  </h2>
-                  {settings?.has_openai_key && settings.openai_key_verified && (
-                    <Badge variant="free" size="sm">
-                      Active
-                    </Badge>
-                  )}
-                </div>
-                <p className="text-mono text-[var(--text-ghost)] mb-4">
-                  Powers AI summaries and related-story matching
-                </p>
-
-                {/* Current key display */}
-                {settings?.has_openai_key && !isEditing && (
-                  <div>
-                    <div className="flex items-center gap-2 py-2.5 px-3 rounded-[var(--radius-sm)] bg-[var(--surface)]">
-                      <span className="text-small text-[var(--text-muted)] tracking-wider flex-1">
-                        {"••••••••••••" +
-                          (settings.openai_key_last4 || "****")}
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setState("editing")}
-                      >
-                        Change
-                      </Button>
-                      <Button
-                        variant="danger"
-                        size="sm"
-                        onClick={handleRemove}
-                        loading={state === "saving"}
-                      >
-                        Remove
-                      </Button>
-                    </div>
-
-                    {/* Test connection */}
-                    <div className="mt-3">
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        fullWidth
-                        onClick={handleTest}
-                        loading={state === "testing"}
-                      >
-                        Test Connection
-                      </Button>
-                    </div>
-
-                    {/* Status */}
-                    <div className="mt-3 flex items-center gap-2">
-                      {testResult ? (
-                        testResult.success ? (
-                          <>
-                            <span className="w-2 h-2 rounded-full bg-[var(--agree)]" />
-                            <span className="text-mono text-[var(--agree)]">
-                              Connected
-                            </span>
-                            <span className="text-mono text-[var(--text-ghost)]">
-                              &middot; {testResult.models_available} models
-                            </span>
-                          </>
-                        ) : (
-                          <>
-                            <span className="w-2 h-2 rounded-full bg-[var(--dismiss)]" />
-                            <span className="text-mono text-[var(--dismiss)]">
-                              {testResult.error || "Test failed"}
-                            </span>
-                          </>
-                        )
-                      ) : settings.openai_key_verified ? (
-                        <>
-                          <span className="w-2 h-2 rounded-full bg-[var(--agree)]" />
-                          <span className="text-mono text-[var(--agree)]">
-                            Verified
-                          </span>
-                          {settings.openai_key_verified_at && (
-                            <span className="text-mono text-[var(--text-ghost)]">
-                              &middot;{" "}
-                              {relativeTime(settings.openai_key_verified_at)}
-                            </span>
-                          )}
-                        </>
-                      ) : (
-                        <>
-                          <span className="w-2 h-2 rounded-full bg-[var(--text-ghost)]" />
-                          <span className="text-mono text-[var(--text-ghost)]">
-                            Not tested
-                          </span>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {/* Input field */}
-                {(!settings?.has_openai_key || isEditing) && (
-                  <div>
-                    <Input
-                      type={showKey ? "text" : "password"}
-                      value={keyInput}
-                      onChange={(e) => {
-                        setKeyInput(e.target.value);
-                        if (state !== "editing") setState("editing");
-                      }}
-                      placeholder="sk-..."
-                      rightAction={
-                        <button
-                          type="button"
-                          onClick={() => setShowKey(!showKey)}
-                          className="text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
-                          aria-label={showKey ? "Hide key" : "Show key"}
-                        >
-                          {showKey ? (
-                            <svg
-                              width="18"
-                              height="18"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            >
-                              <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-                              <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-                              <line x1="1" y1="1" x2="23" y2="23" />
-                            </svg>
-                          ) : (
-                            <svg
-                              width="18"
-                              height="18"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            >
-                              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                              <circle cx="12" cy="12" r="3" />
-                            </svg>
-                          )}
-                        </button>
-                      }
-                    />
-                    <div className="flex gap-2 mt-3">
-                      <Button
-                        variant="primary"
-                        size="md"
-                        fullWidth
-                        onClick={handleSave}
-                        loading={state === "saving"}
-                      >
-                        Save Key
-                      </Button>
-                      {settings?.has_openai_key && (
-                        <Button
-                          variant="ghost"
-                          size="md"
-                          onClick={() => {
-                            setKeyInput("");
-                            setState("idle");
-                          }}
-                        >
-                          Cancel
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {/* Error */}
-                {error && (
-                  <div className="mt-3 p-3 rounded-[var(--radius-sm)] bg-[var(--dismiss-muted)]">
-                    <p className="text-mono text-[var(--dismiss)]">{error}</p>
-                  </div>
-                )}
-
-                <p className="mt-4 text-mono text-[var(--text-ghost)]">
-                  Your key is encrypted and stored securely.
-                </p>
-              </div>
-            </Card>
-          </motion.div>
 
           {/* Data & Privacy */}
           <motion.div variants={fadeUp} className="mb-4">

--- a/frontend/src/components/ModelProviderCard.test.tsx
+++ b/frontend/src/components/ModelProviderCard.test.tsx
@@ -1,3 +1,5 @@
+// WS-6 (#116): the unified provider card — chips (save on confirm), per-provider model + key,
+// Save auto-runs Test, Remove per provider, default provider from settings (Gemini fallback).
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -6,43 +8,67 @@ const BASE = {
   has_openai_key: false, openai_key_verified: false, openai_key_last4: null, openai_key_verified_at: null,
   has_gemini_key: false, gemini_key_verified: false, gemini_key_last4: null, gemini_key_verified_at: null,
   has_anthropic_key: false, anthropic_key_verified: false, anthropic_key_last4: null,
-  anthropic_key_verified_at: null, active_provider: "openai", model_prefs: {},
+  anthropic_key_verified_at: null, active_provider: "gemini", model_prefs: {},
 };
 
 vi.mock("@/lib/api", () => ({
   getSettings: vi.fn(),
   updateSettings: vi.fn().mockResolvedValue({}),
-  setAnthropicKey: vi.fn().mockResolvedValue({ has_anthropic_key: true }),
+  setGeminiKey: vi.fn().mockResolvedValue({}),
+  testGeminiKey: vi.fn().mockResolvedValue({ success: true, error: null, models_available: 1 }),
+  setAnthropicKey: vi.fn().mockResolvedValue({}),
   testAnthropicKey: vi.fn().mockResolvedValue({ success: true, error: null, models_available: 1 }),
+  testApiKey: vi.fn().mockResolvedValue({ success: true, error: null, models_available: 1 }),
 }));
 
 import { ModelProviderCard } from "./ModelProviderCard";
 import * as api from "@/lib/api";
 
 beforeEach(() => {
+  vi.clearAllMocks();
   vi.mocked(api.getSettings).mockResolvedValue({ ...BASE });
-  vi.mocked(api.updateSettings).mockClear();
 });
 
-describe("ModelProviderCard (Wave E)", () => {
-  it("renders the three providers", async () => {
+describe("ModelProviderCard (WS-6 unified)", () => {
+  it("renders all three providers and defaults to the active provider (Gemini)", async () => {
     render(<ModelProviderCard />);
-    expect(await screen.findByText("OpenAI")).toBeInTheDocument();
-    expect(screen.getByText("Anthropic")).toBeInTheDocument();
-    expect(screen.getByText("Gemini")).toBeInTheDocument();
-  });
-
-  it("selecting a provider persists active_provider", async () => {
-    render(<ModelProviderCard />);
-    await userEvent.click(await screen.findByText("Anthropic"));
+    expect(await screen.findByRole("button", { name: /Gemini/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /OpenAI/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Anthropic/ })).toBeInTheDocument();
     await waitFor(() =>
-      expect(vi.mocked(api.updateSettings)).toHaveBeenCalledWith({ active_provider: "anthropic" })
+      expect(screen.getByRole("button", { name: /Gemini/ })).toHaveAttribute("aria-pressed", "true")
     );
   });
 
-  it("shows the Anthropic key field when Anthropic is active", async () => {
-    vi.mocked(api.getSettings).mockResolvedValue({ ...BASE, active_provider: "anthropic" });
+  it("a chip tap selects locally and does NOT persist (save on confirm)", async () => {
     render(<ModelProviderCard />);
-    expect(await screen.findByPlaceholderText("sk-ant-...")).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole("button", { name: /OpenAI/ }));
+    expect(screen.getByRole("button", { name: /OpenAI/ })).toHaveAttribute("aria-pressed", "true");
+    expect(api.updateSettings).not.toHaveBeenCalled(); // nothing persisted until Save
+  });
+
+  it("Save confirms the provider + model and auto-runs the key test", async () => {
+    render(<ModelProviderCard />);
+    await screen.findByRole("button", { name: /Gemini/ });
+    await userEvent.type(screen.getByLabelText("Gemini API key"), "AIza-newkey");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(api.updateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ active_provider: "gemini" })
+      )
+    );
+    expect(api.setGeminiKey).toHaveBeenCalledWith("AIza-newkey"); // key saved
+    expect(api.testGeminiKey).toHaveBeenCalled();                  // …and auto-tested
+    expect(await screen.findByText(/verified/i)).toBeInTheDocument();
+  });
+
+  it("removes a saved key per provider", async () => {
+    vi.mocked(api.getSettings).mockResolvedValue({
+      ...BASE, active_provider: "gemini", has_gemini_key: true, gemini_key_last4: "beef",
+    });
+    render(<ModelProviderCard />);
+    await userEvent.click(await screen.findByRole("button", { name: /Remove key/ }));
+    expect(api.setGeminiKey).toHaveBeenCalledWith(null);
   });
 });

--- a/frontend/src/components/ModelProviderCard.tsx
+++ b/frontend/src/components/ModelProviderCard.tsx
@@ -1,5 +1,12 @@
 "use client";
 
+/**
+ * WS-6 (#116): the ONE provider card. Chips pick a provider (selection is local — nothing persists on
+ * tap; Save confirms it as active), each provider has its own model input + API key field (masked
+ * last-4), Save auto-runs the connection test, and a key can be removed per provider. Gemini is
+ * primary — it's the default provider and powers embeddings. Replaces the old split "AI Configuration"
+ * (OpenAI) card + the ProfileFields Gemini block.
+ */
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -8,143 +15,191 @@ import { cn } from "@/lib/utils";
 import {
   getSettings,
   setAnthropicKey,
+  setGeminiKey,
   testAnthropicKey,
+  testApiKey,
+  testGeminiKey,
   updateSettings,
   type KeyTestResult,
   type UserSettings,
 } from "@/lib/api";
 
-// Curated, current model ids per provider (free-text field — these are hints/defaults). Wave E.
-const PROVIDERS = [
-  { id: "openai", label: "OpenAI", models: ["gpt-4o-mini", "gpt-4o"] },
-  { id: "anthropic", label: "Anthropic", models: ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-8"] },
-  { id: "gemini", label: "Gemini", models: ["gemini-2.0-flash", "gemini-2.5-pro"] },
+type Provider = {
+  id: string;
+  label: string;
+  models: string[];
+  placeholder: string;
+  saveKey: (v: string | null) => Promise<unknown>;
+  test: () => Promise<KeyTestResult>;
+  has: (s: UserSettings) => boolean;
+  last4: (s: UserSettings) => string | null;
+};
+
+// Gemini first — the primary (default provider + embeddings).
+const PROVIDERS: Provider[] = [
+  {
+    id: "gemini", label: "Gemini", models: ["gemini-2.0-flash", "gemini-2.5-pro"], placeholder: "AIza…",
+    saveKey: (v) => setGeminiKey(v), test: testGeminiKey,
+    has: (s) => s.has_gemini_key, last4: (s) => s.gemini_key_last4,
+  },
+  {
+    id: "openai", label: "OpenAI", models: ["gpt-4o-mini", "gpt-4o"], placeholder: "sk-…",
+    saveKey: (v) => updateSettings({ openai_api_key: v }), test: testApiKey,
+    has: (s) => s.has_openai_key, last4: (s) => s.openai_key_last4,
+  },
+  {
+    id: "anthropic", label: "Anthropic", models: ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-8"],
+    placeholder: "sk-ant-…", saveKey: (v) => setAnthropicKey(v), test: testAnthropicKey,
+    has: (s) => s.has_anthropic_key, last4: (s) => s.anthropic_key_last4,
+  },
 ];
 
-/** Wave E "Bring Your Own Model": choose the active provider + per-provider model, and manage the
- *  Anthropic key. (OpenAI key card + Gemini key live in their existing controls.) */
 export function ModelProviderCard() {
   const [settings, setSettings] = useState<UserSettings | null>(null);
-  const [provider, setProvider] = useState("openai");
+  const [selected, setSelected] = useState("gemini"); // local pick; persisted only on Save
   const [model, setModel] = useState("");
-  const [anthKey, setAnthKey] = useState("");
+  const [keyInput, setKeyInput] = useState("");
   const [busy, setBusy] = useState(false);
-  const [test, setTest] = useState<KeyTestResult | null>(null);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
 
   async function refresh() {
     const s = await getSettings();
     setSettings(s);
-    const p = s.active_provider || "openai";
-    setProvider(p);
-    setModel((s.model_prefs && s.model_prefs[p]) || "");
+    return s;
   }
 
+  // Default provider from GET /settings (fallback GEMINI, not openai — matched to the backend default).
   useEffect(() => {
-    refresh().catch(() => {});
+    refresh()
+      .then((s) => {
+        const p = s.active_provider || "gemini";
+        setSelected(p);
+        setModel((s.model_prefs && s.model_prefs[p]) || "");
+      })
+      .catch(() => {});
   }, []);
 
-  async function selectProvider(p: string) {
-    setProvider(p);
+  function pick(p: string) {
+    setSelected(p);
     setModel((settings?.model_prefs && settings.model_prefs[p]) || "");
-    setTest(null);
+    setKeyInput("");
+    setMsg(null);
+  }
+
+  const cur = PROVIDERS.find((p) => p.id === selected) ?? PROVIDERS[0];
+
+  async function save() {
     setBusy(true);
+    setMsg(null);
     try {
-      await updateSettings({ active_provider: p });
+      // Confirm the provider choice + its model (save on confirm, not on chip tap).
+      await updateSettings({ active_provider: selected, model_prefs: { [selected]: model.trim() } });
+      // If a key was entered, save it and AUTO-RUN the connection test.
+      if (keyInput.trim()) {
+        await cur.saveKey(keyInput.trim());
+        const res = await cur.test();
+        setMsg({ ok: res.success, text: res.success ? "Saved · key verified" : res.error || "Couldn't verify key" });
+        if (res.success) setKeyInput("");
+      } else {
+        setMsg({ ok: true, text: `${cur.label} is now your provider` });
+      }
+      await refresh();
+    } catch {
+      setMsg({ ok: false, text: "Couldn't save — try again" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeKey() {
+    setBusy(true);
+    setMsg(null);
+    try {
+      await cur.saveKey(null);
+      setKeyInput("");
+      setMsg({ ok: true, text: `${cur.label} key removed` });
       await refresh();
     } finally {
       setBusy(false);
     }
   }
 
-  async function saveModel() {
-    setBusy(true);
-    try {
-      await updateSettings({ model_prefs: { [provider]: model.trim() } });
-      await refresh();
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function saveAnthKey() {
-    setBusy(true);
-    try {
-      await setAnthropicKey(anthKey.trim() || null);
-      setAnthKey("");
-      await refresh();
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function runTest() {
-    setBusy(true);
-    try {
-      setTest(await testAnthropicKey());
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  const cur = PROVIDERS.find((p) => p.id === provider) ?? PROVIDERS[0];
+  const activeProvider = settings?.active_provider || "gemini";
 
   return (
     <Card variant="raised">
       <div className="p-3.5">
-      <h2 className="text-h3 text-[var(--text-primary)]">Model provider</h2>
-      <p className="text-small text-[var(--text-secondary)] mt-1">
-        Which AI provider + model powers summaries, lenses, and entity extraction.
-      </p>
-      <p className="text-mono text-[var(--text-ghost)] mt-1">
-        Optional — NewsLens includes built-in AI, no key needed. Add your own key only to use
-        your own quota or a specific model.
-      </p>
+        <h2 className="text-h3 text-[var(--text-primary)]">Model provider</h2>
+        <p className="text-small text-[var(--text-secondary)] mt-1">
+          Gemini is the default provider. Add your own key to use your own quota or a specific model,
+          or switch to another provider.
+        </p>
+        <p className="text-mono text-[var(--text-ghost)] mt-1">
+          Optional — NewsLens includes built-in AI, no key needed.
+        </p>
 
-      <div className="mt-4 flex flex-wrap gap-2" role="group" aria-label="Provider">
-        {PROVIDERS.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            aria-pressed={provider === p.id}
-            onClick={() => selectProvider(p.id)}
-            disabled={busy}
-            className={cn(
-              "text-mono px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50",
-              provider === p.id
-                ? "border-[var(--accent-muted)] bg-[var(--accent-subtle)] text-[var(--accent)]"
-                : "border-[var(--border)] text-[var(--text-secondary)]"
-            )}
-          >
-            {p.label}
-          </button>
-        ))}
-      </div>
+        <div className="mt-4 flex flex-wrap gap-2" role="group" aria-label="Provider">
+          {PROVIDERS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              aria-pressed={selected === p.id}
+              onClick={() => pick(p.id)}
+              disabled={busy}
+              className={cn(
+                "text-mono px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50",
+                selected === p.id
+                  ? "border-[var(--accent-muted)] bg-[var(--accent-subtle)] text-[var(--accent)]"
+                  : "border-[var(--border)] text-[var(--text-secondary)]"
+              )}
+            >
+              {p.label}
+              {activeProvider === p.id && (
+                <span className="ml-1.5 text-[var(--text-ghost)]" aria-label="active provider">
+                  ·&nbsp;active
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
 
-      <div className="mt-4 space-y-2">
-        <label className="text-small text-[var(--text-secondary)]">Model for {cur.label}</label>
-        <Input value={model} onChange={(e) => setModel(e.target.value)} placeholder={cur.models[0]} />
-        <p className="text-mono text-[var(--text-tertiary)]">e.g. {cur.models.join(" · ")}</p>
-        <Button onClick={saveModel} disabled={busy}>Save model</Button>
-      </div>
-
-      {provider === "anthropic" && (
-        <div className="mt-5 space-y-2 border-t border-[var(--border)] pt-4">
-          <label className="text-small text-[var(--text-secondary)]">
-            Anthropic API key
-            {settings?.has_anthropic_key ? ` — saved ····${settings.anthropic_key_last4 ?? ""}` : ""}
+        <div className="mt-4 space-y-2">
+          <label className="text-small text-[var(--text-secondary)]" htmlFor="mp-model">
+            Model for {cur.label}
           </label>
-          <Input type="password" value={anthKey} onChange={(e) => setAnthKey(e.target.value)} placeholder="sk-ant-..." />
+          <Input id="mp-model" value={model} onChange={(e) => setModel(e.target.value)} placeholder={cur.models[0]} />
+          <p className="text-mono text-[var(--text-tertiary)]">e.g. {cur.models.join(" · ")}</p>
+        </div>
+
+        <div className="mt-4 space-y-2">
+          <label className="text-small text-[var(--text-secondary)]" htmlFor="mp-key">
+            {cur.label} API key
+            {settings && cur.has(settings) ? ` — saved ····${cur.last4(settings) ?? ""}` : ""}
+          </label>
+          <Input
+            id="mp-key"
+            type="password"
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            placeholder={cur.placeholder}
+            aria-label={`${cur.label} API key`}
+          />
           <div className="flex gap-2">
-            <Button onClick={saveAnthKey} disabled={busy}>Save key</Button>
-            <Button onClick={runTest} disabled={busy || !settings?.has_anthropic_key}>Test connection</Button>
+            <Button onClick={save} disabled={busy} loading={busy}>
+              Save
+            </Button>
+            {settings && cur.has(settings) && (
+              <Button variant="ghost" onClick={removeKey} disabled={busy}>
+                Remove key
+              </Button>
+            )}
           </div>
-          {test && (
-            <p className={cn("text-small", test.success ? "text-[var(--accent)]" : "text-red-400")}>
-              {test.success ? "Key works." : test.error}
+          {msg && (
+            <p role="status" className={cn("text-small", msg.ok ? "text-[var(--accent)]" : "text-[var(--dismiss)]")}>
+              {msg.text}
             </p>
           )}
         </div>
-      )}
       </div>
     </Card>
   );

--- a/frontend/src/components/ProfileFields.tsx
+++ b/frontend/src/components/ProfileFields.tsx
@@ -5,17 +5,12 @@ import { Card } from "@/components/ui/Card";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { cn } from "@/lib/utils";
-import {
-  getProfile,
-  updateProfile,
-  setGeminiKey,
-  testGeminiKey,
-} from "@/lib/api";
+import { getProfile, updateProfile } from "@/lib/api";
 
 const LOCALES = ["IN", "US", "GB", "global"];
 
-/** v2 Profile additions: Profession + Locale (drives the impact lens) and the
- *  Gemini API key. Self-contained — manages its own fetch/save. */
+/** v2 Profile additions: Profession + Locale (drives the impact lens) + Depth. Self-contained.
+ *  (WS-6: the Gemini key moved into the unified ModelProviderCard.) */
 export function ProfileFields() {
   const [profession, setProfession] = useState("");
   const [locale, setLocale] = useState("IN");
@@ -23,10 +18,6 @@ export function ProfileFields() {
   const [loaded, setLoaded] = useState(false);
   const [savingProfile, setSavingProfile] = useState(false);
   const [profileSaved, setProfileSaved] = useState(false);
-
-  const [geminiKey, setGeminiKeyInput] = useState("");
-  const [savingKey, setSavingKey] = useState(false);
-  const [keyMsg, setKeyMsg] = useState<string | null>(null);
 
   useEffect(() => {
     getProfile()
@@ -53,25 +44,7 @@ export function ProfileFields() {
     }
   }
 
-  async function saveGemini() {
-    if (!geminiKey.trim()) return;
-    setSavingKey(true);
-    setKeyMsg(null);
-    try {
-      await setGeminiKey(geminiKey.trim());
-      const res = await testGeminiKey();
-      setKeyMsg(res.success ? "Gemini key verified" : res.error || "Couldn't verify key");
-      if (res.success) setGeminiKeyInput("");
-    } catch {
-      setKeyMsg("Couldn't save the key");
-    } finally {
-      setSavingKey(false);
-    }
-  }
-
   return (
-    <>
-      {/* PROFILE */}
       <Card variant="raised">
         <div className="p-3.5">
           <h2 className="text-category text-[var(--text-muted)] mb-3">PROFILE</h2>
@@ -143,37 +116,5 @@ export function ProfileFields() {
           </Button>
         </div>
       </Card>
-
-      {/* GEMINI KEY */}
-      <Card variant="raised">
-        <div className="p-3.5">
-          <h2 className="text-category text-[var(--text-muted)] mb-1">
-            Gemini API key
-          </h2>
-          <p className="text-mono text-[var(--text-ghost)] mb-3">
-            Optional second AI provider for summaries and analysis.
-          </p>
-          <Input
-            type="password"
-            value={geminiKey}
-            onChange={(e) => setGeminiKeyInput(e.target.value)}
-            placeholder="AIza…"
-          />
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={saveGemini}
-            loading={savingKey}
-            disabled={!geminiKey.trim()}
-            className="mt-3"
-          >
-            Save &amp; verify
-          </Button>
-          {keyMsg && (
-            <p className="text-mono text-[var(--text-muted)] mt-2">{keyMsg}</p>
-          )}
-        </div>
-      </Card>
-    </>
   );
 }


### PR DESCRIPTION
## WS-6: settings consolidation + multi-user key/provider fix — closes #116

### The bug (backend)
Per-user LLM resolution was **hardcoded to user #1** in four places (`embeddings._get_user_api_key`, `llm._resolve_gemini_key`, `_resolve_anthropic_key`, `_active_settings`), each with a single global cache — so user #2's request resolved user #1's keys, provider, **and** model. A cross-user config leak in multi-user mode.

**Fix:** the resolvers key off the current request's user via `current_user_id()` (an async-task-local ContextVar set by `get_current_user`), with an optional explicit `user_id` override threaded through `generate()`. Per-user caches replace the global slots; TTL 300→60s, and the settings write **and** verify endpoints bust the caller's cache so a saved/verified key is live at once. Background jobs keep `force_platform_key=True` → env key, **byte-identical**.

### The consolidation (frontend)
One `ModelProviderCard` now manages all three providers: chips (a tap selects locally — nothing persists until **Save**, "save on confirm"), a per-provider model input, a per-provider key field (masked last-4), **Save auto-runs the connection test**, and per-provider **Remove**. Gemini is primary and the **default provider from `GET /settings`** (fallback `gemini`, fixing the old hardcoded `openai`). Deleted the redundant "AI Configuration" (OpenAI) card + its dead handlers/state, and the ProfileFields Gemini block. Copy fixed (no internal jargon).

### Adversarial review (5 agents · 1 confirmed · 2 rejected)
- **Fixed:** `test-*-key` endpoints flipped `verified→True` without busting the resolver cache, so a freshly-verified key stayed invisible for ≤60s (silent env-key fallback / `LLMUnavailable` on a BYOM deploy). Now invalidated on verify; regression test added.
- Contextvar propagation and the frontend removals were probed and **survived** review.

### Verification
- Backend **497 passed / 1 skipped** (multi-user resolution across all 4 sites + background byte-identical + cache-bust regression). Frontend **124 passed** (33 files); build + copy-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)