### PR TITLE
perf: client stale-while-revalidate cache — instant paint, prefetch, eviction

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "clsx": "^2.1.1",
         "firebase": "^12.15.0",
         "framer-motion": "^12.38.0",
+        "idb-keyval": "^6.2.6",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -7053,6 +7054,12 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.6.tgz",
+      "integrity": "sha512-FY64UEhw+5liMzMQ1R9Mw6AF0+wyBrg1CIA1z4CjI/EvT5ty/SvQcWZgd8s9sgaNhX10Y8UzScTh89tEAls5nA==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "clsx": "^2.1.1",
     "firebase": "^12.15.0",
     "framer-motion": "^12.38.0",
+    "idb-keyval": "^6.2.6",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+// Stub the self-fetching children so this test is only about the briefing wiring.
+vi.mock("next/navigation", () => ({ useRouter: () => ({ replace: vi.fn(), push: vi.fn() }) }));
+vi.mock("@/hooks/useImpressions", () => ({ useImpressions: () => ({ observe: () => {} }) }));
+vi.mock("@/components/FollowRails", () => ({ FollowRails: () => null }));
+vi.mock("@/components/InfiniteFeed", () => ({ InfiniteFeed: () => null }));
+vi.mock("@/components/ui/DailyTriviaCard", () => ({ DailyTriviaCard: () => null }));
+vi.mock("@/components/ui/PersonalizeBanner", () => ({ PersonalizeBanner: () => null }));
+vi.mock("@/components/ui/WhileAwayCard", () => ({ WhileAwayCard: () => null }));
+vi.mock("@/components/PullToRefresh", () => ({
+  PullToRefresh: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/lib/api", async (orig) => {
+  const actual = await orig<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    getBriefing: vi.fn(),
+    getTopics: vi.fn().mockResolvedValue({ your_topics: [], explore_topics: [], trending_topics: [] }),
+  };
+});
+
+import BriefingPage from "./page";
+import { getBriefing, type Briefing, type BriefingStory } from "@/lib/api";
+import { store, memoryBackend, _setBackend, _resetCache } from "@/lib/cache";
+
+const story = (title: string): BriefingStory => ({
+  title,
+  summary: "S",
+  cluster_id: 1,
+  category: "World",
+  source_count: 3,
+  coherence: 0.8,
+});
+const briefing = (title: string): Briefing => ({
+  stories: [story(title)],
+  generated_at: new Date(0).toISOString(),
+});
+
+beforeEach(() => {
+  _setBackend(memoryBackend());
+  _resetCache();
+  vi.clearAllMocks();
+  localStorage.setItem("newslens-onboarded", "1"); // skip the first-run redirect
+});
+
+describe("BriefingPage cache-first paint", () => {
+  it("paints the cached briefing immediately, then swaps in the revalidated one", async () => {
+    await store("briefing", briefing("CACHED HERO"));
+    let resolveFresh: (b: Briefing) => void = () => {};
+    vi.mocked(getBriefing).mockReturnValue(
+      new Promise<Briefing>((r) => {
+        resolveFresh = r;
+      })
+    );
+
+    render(<BriefingPage />);
+    // Instant paint from cache — the network request is still pending.
+    expect(screen.getByText("CACHED HERO")).toBeInTheDocument();
+
+    resolveFresh(briefing("FRESH HERO"));
+    await waitFor(() => expect(screen.getByText("FRESH HERO")).toBeInTheDocument());
+  });
+
+  it("shows the cold-start loader when nothing is cached", () => {
+    vi.mocked(getBriefing).mockReturnValue(new Promise<Briefing>(() => {})); // never resolves
+    render(<BriefingPage />);
+    expect(screen.getByText(/assembling your briefing/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -18,8 +18,10 @@ import { InfiniteFeed } from "@/components/InfiniteFeed";
 import { useImpressions } from "@/hooks/useImpressions";
 import { AnimatedMark } from "@/components/SplashScreen";
 import { getBriefing, getTopics, type Briefing, type BriefingStory, type Topic } from "@/lib/api";
+import { useCachedResource } from "@/hooks/useCachedResource";
+import { usePrefetchClusters } from "@/hooks/usePrefetchClusters";
+import { CACHE_TTL_MS } from "@/lib/cache";
 import { isStale } from "@/lib/utils";
-import { cn } from "@/lib/utils";
 
 type PageState = "loading" | "success" | "error" | "empty" | "refreshing";
 
@@ -45,11 +47,7 @@ const staggerContainer = {
 };
 
 export default function BriefingPage() {
-  const [state, setState] = useState<PageState>("loading");
-  const [briefing, setBriefing] = useState<Briefing | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [activeCategory, setActiveCategory] = useState<string>("All");
-  const [rechecking, setRechecking] = useState(false);
   const [userTopics, setUserTopics] = useState<Topic[]>([]);
   // WS-3 (#113): cross-section dedupe — cluster ids the rails render, lifted up so the "All stories"
   // feed can filter them out (precedence hero > rails > categories > feed). And a key that pull-to-
@@ -59,6 +57,34 @@ export default function BriefingPage() {
   const router = useRouter();
   // WS-1: log which briefing stories were actually SEEN (>=50% for >=1s); tag taps with the surface.
   const { observe } = useImpressions("briefing");
+
+  // Briefing is served stale-first from the two-tier cache: the last-known briefing paints INSTANTLY
+  // (masking a cold Render backend and every back-navigation to home), then revalidates in the
+  // background. Cold first-ever launch has no cache → the loader shows until the first fetch returns.
+  const {
+    data: briefing,
+    status: cacheStatus,
+    validating,
+    refresh,
+  } = useCachedResource<Briefing>("briefing", getBriefing, { maxAgeMs: CACHE_TTL_MS.briefing });
+
+  // Prefetch the top few story details while the briefing is on screen → tapping a card opens instantly.
+  usePrefetchClusters(briefing?.stories.map((s) => s.cluster_id) ?? []);
+
+  const hasStories = !!briefing && briefing.stories.length > 0;
+  const pageState: PageState = hasStories
+    ? "success"
+    : briefing
+      ? "empty" // fetched, but zero stories → cold-start pipeline still warming up
+      : cacheStatus === "error"
+        ? "error"
+        : "loading";
+
+  // Pull-to-refresh / manual refresh: reset the feed's as_of cursor AND revalidate the briefing.
+  const handleRefresh = useCallback(async () => {
+    setFeedKey((k) => k + 1);
+    await refresh();
+  }, [refresh]);
 
   // The user's topics (with real article counts) — chips shouldn't be limited to whatever
   // categories happen to appear in today's 8 briefing stories.
@@ -75,56 +101,13 @@ export default function BriefingPage() {
     }
   }, [router]);
 
-  const fetchBriefing = useCallback(async (isRefresh = false) => {
-    try {
-      setState(isRefresh ? "refreshing" : "loading");
-      setError(null);
-      if (isRefresh) setFeedKey((k) => k + 1); // pull-to-refresh resets the feed's as_of cursor
-      const data = await getBriefing();
-
-      if (!data.stories || data.stories.length === 0) {
-        setState("empty");
-        return;
-      }
-
-      setBriefing(data);
-      setState("success");
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load briefing"
-      );
-      setState("error");
-    }
-  }, []);
-
+  // While the first briefing is still warming up (empty), quietly revalidate every 20s so the launch
+  // screen advances to the feed on its own.
   useEffect(() => {
-    fetchBriefing();
-  }, [fetchBriefing]);
-
-  // Silent cold-start re-check: keeps the launch screen mounted (no "refreshing"
-  // flash) and only flips to success once stories arrive.
-  const recheckBriefing = useCallback(async () => {
-    setRechecking(true);
-    try {
-      const data = await getBriefing();
-      if (data.stories && data.stories.length > 0) {
-        setBriefing(data);
-        setState("success");
-      }
-    } catch {
-      /* still warming up — stay on the launch screen */
-    } finally {
-      setRechecking(false);
-    }
-  }, []);
-
-  // While the first briefing is still warming up (empty), quietly re-check every
-  // 20s so the launch screen advances to the feed on its own.
-  useEffect(() => {
-    if (state !== "empty") return;
-    const id = setInterval(recheckBriefing, 20000);
+    if (pageState !== "empty") return;
+    const id = setInterval(() => void refresh(), 20000);
     return () => clearInterval(id);
-  }, [state, recheckBriefing]);
+  }, [pageState, refresh]);
 
   // Chips = union of today's briefing categories AND the user's topics that actually have
   // articles. Before, chips came only from the ≤8 briefing stories' categories, so the row was
@@ -176,10 +159,10 @@ export default function BriefingPage() {
   );
 
   return (
-    <PullToRefresh onRefresh={() => fetchBriefing(true)}>
+    <PullToRefresh onRefresh={handleRefresh}>
     <div className="mx-auto max-w-[640px] w-full px-[var(--space-md)]">
       {/* Greeting + Date */}
-      {(state === "success" || state === "refreshing") && (
+      {pageState === "success" && (
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -199,7 +182,7 @@ export default function BriefingPage() {
       )}
 
       {/* Topic chips */}
-      {(state === "success" || state === "refreshing") &&
+      {pageState === "success" &&
         categories.length > 2 && (
           <div className="flex flex-nowrap gap-2 overflow-x-auto no-scrollbar overscroll-x-contain py-3 -mx-4 px-4">
             {categories.map((cat) => (
@@ -215,7 +198,7 @@ export default function BriefingPage() {
         )}
 
       {/* Follow the topic you've filtered to — kept quiet until a topic is picked */}
-      {(state === "success" || state === "refreshing") &&
+      {pageState === "success" &&
         activeCategory !== "All" && (
           <div className="flex justify-end mb-2">
             <FollowButton
@@ -230,7 +213,7 @@ export default function BriefingPage() {
       {/* Loading state — FIRST load (no content yet) gets the branded animated-mark loader
           (device-QA #11: "I see news loading instead of the loader screen"); skeletons only
           when we already have content on screen (refresh / topic switch). */}
-      {state === "loading" &&
+      {pageState === "loading" &&
         (!briefing || briefing.stories.length === 0 ? (
           <div className="flex flex-col items-center justify-center text-center min-h-[60vh]">
             <AnimatedMark size={120} loop />
@@ -249,12 +232,12 @@ export default function BriefingPage() {
         ))}
 
       {/* Empty / first-run state — cold-start launch experience */}
-      {state === "empty" && (
-        <LaunchScreen onRetry={recheckBriefing} refreshing={rechecking} />
+      {pageState === "empty" && (
+        <LaunchScreen onRetry={refresh} refreshing={validating} />
       )}
 
       {/* Error state */}
-      {state === "error" && (
+      {pageState === "error" && (
         <div className="flex flex-col items-center justify-center pt-[var(--space-3xl)] text-center">
           <div className="w-12 h-12 rounded-full bg-[var(--dismiss-muted)] flex items-center justify-center mb-4">
             <svg
@@ -275,13 +258,10 @@ export default function BriefingPage() {
           <p className="text-heading text-[var(--text-primary)]">
             Couldn&apos;t load briefing
           </p>
-          {error && (
-            <p className="text-mono text-[var(--dismiss)] mt-2">{error}</p>
-          )}
           <Button
             variant="secondary"
             size="md"
-            onClick={() => fetchBriefing()}
+            onClick={() => refresh()}
             className="mt-4"
           >
             Try again
@@ -290,9 +270,8 @@ export default function BriefingPage() {
       )}
 
       {/* Success: hero + categorized stories */}
-      {(state === "success" || state === "refreshing") && (
+      {pageState === "success" && (
         <motion.div
-          className={cn(state === "refreshing" && "opacity-80")}
           variants={staggerContainer}
           initial="initial"
           animate="animate"
@@ -372,8 +351,8 @@ export default function BriefingPage() {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => fetchBriefing(true)}
-              loading={state === "refreshing"}
+              onClick={handleRefresh}
+              loading={validating}
             >
               Refresh briefing
             </Button>

--- a/frontend/src/components/DeepDiveView.test.tsx
+++ b/frontend/src/components/DeepDiveView.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+// Isolate the wiring: stub the self-fetching lens children + the deep-dive's own impact fetch.
+vi.mock("next/navigation", () => ({ useParams: () => ({}) }));
+vi.mock("@/components/ui/AISummaryBox", () => ({ AISummaryBox: () => null }));
+vi.mock("@/components/ui/ImpactCard", () => ({ ImpactCard: () => null }));
+vi.mock("@/components/ui/AskBox", () => ({ AskBox: () => null }));
+vi.mock("@/components/ui/FrameworksCard", () => ({ FrameworksCard: () => null }));
+vi.mock("@/components/ui/EntityChips", () => ({ EntityChips: () => null }));
+vi.mock("@/components/ui/ConsensusRow", () => ({ ConsensusRow: () => null }));
+vi.mock("@/components/ui/TriviaCard", () => ({ TriviaCard: () => null }));
+vi.mock("@/components/ui/AgreementMeter", () => ({ AgreementMeter: () => null }));
+vi.mock("@/components/SourceCard", () => ({ SourceCard: () => null }));
+vi.mock("@/components/SourceSpectrum", () => ({ SourceSpectrum: () => null }));
+vi.mock("@/components/ui/Collapsible", () => ({
+  Collapsible: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/lib/api", async (orig) => {
+  const actual = await orig<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    getCluster: vi.fn(),
+    getClusterImpact: vi.fn().mockResolvedValue({ unavailable: true }),
+    postDwell: vi.fn().mockResolvedValue(undefined),
+    postFeedback: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import DeepDiveView from "./DeepDiveView";
+import { getCluster, type ClusterDetail } from "@/lib/api";
+import { store, memoryBackend, _setBackend, _resetCache } from "@/lib/cache";
+
+const cluster = (title: string): ClusterDetail => ({
+  id: 5,
+  title,
+  summary: "A summary sentence.",
+  created_at: new Date(0).toISOString(),
+  coherence: 0.8,
+  sources: [],
+});
+
+beforeEach(() => {
+  _setBackend(memoryBackend());
+  _resetCache();
+  vi.clearAllMocks();
+});
+
+describe("DeepDiveView cache-first paint", () => {
+  it("paints a cached cluster instantly (no skeleton), then revalidates", async () => {
+    await store("cluster:5", cluster("CACHED STORY TITLE"));
+    let resolveFresh: (c: ClusterDetail) => void = () => {};
+    vi.mocked(getCluster).mockReturnValue(
+      new Promise<ClusterDetail>((r) => {
+        resolveFresh = r;
+      })
+    );
+
+    render(<DeepDiveView clusterIdOverride={5} />);
+    // instant paint from cache — the /clusters/5 request is still pending
+    expect(screen.getByText("CACHED STORY TITLE")).toBeInTheDocument();
+
+    resolveFresh(cluster("FRESH STORY TITLE"));
+    await waitFor(() => expect(screen.getByText("FRESH STORY TITLE")).toBeInTheDocument());
+  });
+
+  it("shows the error card when the fetch fails with nothing cached", async () => {
+    vi.mocked(getCluster).mockRejectedValue(new Error("boom"));
+    render(<DeepDiveView clusterIdOverride={9} />);
+    await waitFor(() =>
+      expect(screen.getByText(/couldn.t load this story/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/components/DeepDiveView.tsx
+++ b/frontend/src/components/DeepDiveView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { AISummaryBox } from "@/components/ui/AISummaryBox";
@@ -26,6 +26,8 @@ import {
   type ClusterDetail,
   type ImpactResult,
 } from "@/lib/api";
+import { useCachedResource } from "@/hooks/useCachedResource";
+import { CACHE_TTL_MS } from "@/lib/cache";
 
 type PageState = "loading" | "success" | "error";
 
@@ -57,9 +59,31 @@ export default function DeepDiveView({
   const params = useParams();
   const clusterId = clusterIdOverride ?? Number(params.clusterId);
 
-  const [state, setState] = useState<PageState>("loading");
-  const [cluster, setCluster] = useState<ClusterDetail | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const validId = !!clusterId && !isNaN(clusterId);
+  // Story detail is served stale-first from the two-tier cache: a previously-viewed (or prefetched)
+  // cluster paints INSTANTLY instead of flashing the skeleton, then revalidates in the background.
+  const {
+    data: cluster,
+    status: clusterStatus,
+    refresh: refetchCluster,
+  } = useCachedResource<ClusterDetail>(
+    validId ? `cluster:${clusterId}` : null,
+    () => getCluster(clusterId),
+    { maxAgeMs: CACHE_TTL_MS.cluster }
+  );
+  // Map onto the existing 3-state view: cached → success, cold miss → skeleton, hard fail / bad id → error.
+  const state: PageState = !validId
+    ? "error"
+    : cluster
+      ? "success"
+      : clusterStatus === "error"
+        ? "error"
+        : "loading";
+  const error = !validId
+    ? "Invalid story ID"
+    : clusterStatus === "error" && !cluster
+      ? "Failed to load story details"
+      : null;
   const [saved, setSaved] = useState(false);
   const [impact, setImpact] = useState<ImpactResult | null>(null);
   const [expandAll, setExpandAll] = useState(false); // BRIEF / FULL toggle (v4)
@@ -121,28 +145,6 @@ export default function DeepDiveView({
     };
   }, [clusterId]);
 
-  const fetchCluster = useCallback(async () => {
-    if (!clusterId || isNaN(clusterId)) {
-      setError("Invalid story ID");
-      setState("error");
-      return;
-    }
-    try {
-      setState("loading");
-      setError(null);
-      const data = await getCluster(clusterId);
-      setCluster(data);
-      setState("success");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load story details");
-      setState("error");
-    }
-  }, [clusterId]);
-
-  useEffect(() => {
-    fetchCluster();
-  }, [fetchCluster]);
-
   const sortedSources = cluster?.sources
     ? [...cluster.sources].sort((a, b) => {
         if (a.is_free !== b.is_free) return a.is_free ? -1 : 1;
@@ -191,7 +193,7 @@ export default function DeepDiveView({
             Couldn&apos;t load this story
           </p>
           {error && <p className="text-mono text-[var(--text-muted)] mt-2">{error}</p>}
-          <Button variant="secondary" onClick={fetchCluster} className="mt-4">
+          <Button variant="secondary" onClick={() => refetchCluster()} className="mt-4">
             Try again
           </Button>
         </div>

--- a/frontend/src/components/InfiniteFeed.test.tsx
+++ b/frontend/src/components/InfiniteFeed.test.tsx
@@ -7,6 +7,7 @@ vi.mock("@/lib/api", () => ({ getFeed: vi.fn(), postImpressions: vi.fn().mockRes
 
 import { getFeed } from "@/lib/api";
 import { InfiniteFeed } from "./InfiniteFeed";
+import { memoryBackend, _setBackend, _resetCache } from "@/lib/cache";
 
 const art = (id: number) => ({
   id, title: `S${id}`, url: `https://ex/${id}`, snippet: "snip", ai_summary: null,
@@ -17,7 +18,13 @@ const pageResp = (ids: number[], total = ids.length) => ({
   articles: ids.map(art), total, page: 1, per_page: 20, as_of: "T0",
 });
 
-beforeEach(() => vi.mocked(getFeed).mockReset());
+beforeEach(() => {
+  vi.mocked(getFeed).mockReset();
+  // The feed now seeds page 1 from the two-tier cache — isolate it so a prior test's page-1 write
+  // can't seed the "cold skeleton" test with stale rows.
+  _setBackend(memoryBackend());
+  _resetCache();
+});
 
 describe("InfiniteFeed", () => {
   it("renders feed rows and the caught-up terminal when the window fits one page", async () => {

--- a/frontend/src/hooks/useCachedResource.test.tsx
+++ b/frontend/src/hooks/useCachedResource.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { useCachedResource } from "./useCachedResource";
+import { store, memoryBackend, _setBackend, _resetCache } from "@/lib/cache";
+
+beforeEach(() => {
+  _setBackend(memoryBackend());
+  _resetCache();
+});
+
+const NO_FOCUS = { revalidateOnFocus: false } as const;
+
+describe("useCachedResource", () => {
+  it("cold cache: loading → fresh once the fetcher resolves", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+    const { result } = renderHook(() => useCachedResource("briefing", fetcher, NO_FOCUS));
+
+    expect(result.current.status).toBe("loading");
+    expect(result.current.data).toBeNull();
+
+    await waitFor(() => expect(result.current.status).toBe("fresh"));
+    expect(result.current.data).toEqual({ v: 1 });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("warm memory: paints cached data immediately (stale), then swaps in fresh", async () => {
+    await store("briefing", { v: "cached" });
+    const fetcher = vi.fn().mockResolvedValue({ v: "fresh" });
+    const { result } = renderHook(() => useCachedResource("briefing", fetcher, NO_FOCUS));
+
+    expect(result.current.data).toEqual({ v: "cached" }); // instant paint, no await
+    expect(result.current.status).toBe("stale");
+
+    await waitFor(() => expect(result.current.status).toBe("fresh"));
+    expect(result.current.data).toEqual({ v: "fresh" });
+  });
+
+  it("keeps cached data on a failed revalidate (never blanks to error)", async () => {
+    await store("cluster:1", { v: "cached" });
+    const fetcher = vi.fn(() => Promise.reject(new Error("net")));
+    const { result } = renderHook(() => useCachedResource("cluster:1", fetcher, NO_FOCUS));
+
+    expect(result.current.data).toEqual({ v: "cached" });
+    await waitFor(() => expect(result.current.validating).toBe(false));
+    expect(result.current.data).toEqual({ v: "cached" }); // survived the failure
+    expect(result.current.status).toBe("stale");
+  });
+
+  it("surfaces error when the fetcher fails and nothing is cached", async () => {
+    const fetcher = vi.fn(() => Promise.reject(new Error("net")));
+    const { result } = renderHook(() => useCachedResource("cluster:9", fetcher, NO_FOCUS));
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("is disabled when key is null (no fetch)", async () => {
+    const fetcher = vi.fn().mockResolvedValue({});
+    const { result } = renderHook(() => useCachedResource(null, fetcher, NO_FOCUS));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.status).toBe("loading");
+    await Promise.resolve();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useCachedResource.test.tsx
+++ b/frontend/src/hooks/useCachedResource.test.tsx
@@ -64,4 +64,28 @@ describe("useCachedResource", () => {
     await Promise.resolve();
     expect(fetcher).not.toHaveBeenCalled();
   });
+
+  it("drops a superseded (old-key) revalidation — A→B keeps B even if A resolves late (review #1)", async () => {
+    // Regression (adversarial review, HIGH): navigating between two cached resources changes the hook
+    // key IN PLACE (no remount, as DeepDiveView does). A slow in-flight run for the old key must NOT
+    // write its data into the new key's snapshot (cross-story torn read).
+    let resolveA: (v: { v: string }) => void = () => {};
+    const fetcherA = () => new Promise<{ v: string }>((r) => (resolveA = r));
+    const fetcherB = () => Promise.resolve({ v: "B" });
+
+    const { result, rerender } = renderHook(
+      ({ k, f }: { k: string; f: () => Promise<{ v: string }> }) => useCachedResource(k, f, NO_FOCUS),
+      { initialProps: { k: "story:a", f: fetcherA } }
+    );
+    expect(result.current.status).toBe("loading"); // A is in flight, nothing cached
+
+    rerender({ k: "story:b", f: fetcherB });
+    await waitFor(() => expect(result.current.data).toEqual({ v: "B" }));
+
+    resolveA({ v: "A" }); // the stale story-A request finally lands
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.current.data).toEqual({ v: "B" }); // B survived — A's late result was dropped
+    expect(result.current.status).toBe("fresh");
+  });
 });

--- a/frontend/src/hooks/useCachedResource.ts
+++ b/frontend/src/hooks/useCachedResource.ts
@@ -57,22 +57,28 @@ export function useCachedResource<T>(
 
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
-  const aliveRef = useRef(true);
+  // Monotonic run token: each run() claims a token, and a superseding run (key change, focus
+  // revalidate) or unmount bumps it. So a slow in-flight run for a now-stale key can't write its data
+  // into the current snapshot — the cross-story torn read a shared "alive" flag couldn't prevent
+  // (it can't tell "unmounted" from "key replaced in place", which is how DeepDiveView navigates).
+  const runIdRef = useRef(0);
 
   const run = useCallback(async () => {
     if (!key) return;
+    const myRun = ++runIdRef.current;
+    const active = () => runIdRef.current === myRun;
     // Cold start: nothing in memory but the persistent tier may hold last session's copy → paint it
     // before the network comes back.
     if (peek<T>(key, maxAgeMs) === undefined) {
       const cached = await load<T>(key, maxAgeMs);
-      if (aliveRef.current && cached !== undefined) setSnap({ data: cached, status: "stale" });
+      if (active() && cached !== undefined) setSnap({ data: cached, status: "stale" });
     }
-    setValidating(true);
+    if (active()) setValidating(true);
     try {
       const fresh = await revalidate<T>(key, () => fetcherRef.current());
-      if (aliveRef.current) setSnap({ data: fresh, status: "fresh" });
+      if (active()) setSnap({ data: fresh, status: "fresh" });
     } catch {
-      if (aliveRef.current) {
+      if (active()) {
         // keep cached data on screen; only show an error when we have nothing cached
         setSnap((prev) => ({
           data: prev.data,
@@ -80,15 +86,18 @@ export function useCachedResource<T>(
         }));
       }
     } finally {
-      if (aliveRef.current) setValidating(false);
+      if (active()) setValidating(false);
     }
   }, [key, maxAgeMs]);
 
   useEffect(() => {
-    aliveRef.current = true;
     void run();
     return () => {
-      aliveRef.current = false;
+      // Intentionally bump the CURRENT token (not a captured copy) so whatever run is in flight at
+      // unmount/key-change is invalidated. The exhaustive-deps ref-cleanup warning assumes a DOM ref;
+      // this is a monotonic counter, so reading .current at cleanup time is exactly what we want.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      runIdRef.current++;
     };
   }, [run]);
 

--- a/frontend/src/hooks/useCachedResource.ts
+++ b/frontend/src/hooks/useCachedResource.ts
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * useCachedResource — the ONE React binding over the two-tier cache (src/lib/cache.ts). Paints the
+ * last-known value instantly, then revalidates in the background (stale-while-revalidate).
+ *
+ *   mount ─▶ seed from memory (sync) ─▶ [cold? load from IDB] ─▶ revalidate ─▶ swap in fresh
+ *   focus ─▶ revalidate again (WebView resume)
+ *
+ * Never blanks the screen when a cached value exists: a failed revalidate keeps the stale data and
+ * only surfaces `error` when there's nothing cached to show.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { peek, load, revalidate } from "@/lib/cache";
+
+export type CacheStatus = "loading" | "stale" | "fresh" | "error";
+
+interface Snapshot<T> {
+  data: T | null;
+  status: CacheStatus;
+}
+
+export interface CachedResource<T> {
+  data: T | null;
+  status: CacheStatus;
+  /** a background revalidation is in flight (cached data may still be on screen). */
+  validating: boolean;
+  /** force a revalidation now (e.g. pull-to-refresh). */
+  refresh: () => Promise<void>;
+}
+
+export function useCachedResource<T>(
+  key: string | null, // null disables the hook (invalid id / not ready)
+  fetcher: () => Promise<T>,
+  opts: { maxAgeMs?: number; revalidateOnFocus?: boolean } = {}
+): CachedResource<T> {
+  const { maxAgeMs, revalidateOnFocus = true } = opts;
+
+  // Synchronous seed from the in-memory tier — the instant-paint path.
+  const seed = useCallback((): Snapshot<T> => {
+    if (!key) return { data: null, status: "loading" };
+    const cached = peek<T>(key, maxAgeMs);
+    return { data: cached ?? null, status: cached !== undefined ? "stale" : "loading" };
+  }, [key, maxAgeMs]);
+
+  const [snap, setSnap] = useState<Snapshot<T>>(seed);
+  const [validating, setValidating] = useState(false);
+  const [trackedKey, setTrackedKey] = useState(key);
+
+  // Reset synchronously when the key changes — React's "adjust state during render" pattern (not an
+  // effect), so navigating between two cached stories re-seeds instantly with no loader flash.
+  if (key !== trackedKey) {
+    setTrackedKey(key);
+    setSnap(seed());
+  }
+
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+  const aliveRef = useRef(true);
+
+  const run = useCallback(async () => {
+    if (!key) return;
+    // Cold start: nothing in memory but the persistent tier may hold last session's copy → paint it
+    // before the network comes back.
+    if (peek<T>(key, maxAgeMs) === undefined) {
+      const cached = await load<T>(key, maxAgeMs);
+      if (aliveRef.current && cached !== undefined) setSnap({ data: cached, status: "stale" });
+    }
+    setValidating(true);
+    try {
+      const fresh = await revalidate<T>(key, () => fetcherRef.current());
+      if (aliveRef.current) setSnap({ data: fresh, status: "fresh" });
+    } catch {
+      if (aliveRef.current) {
+        // keep cached data on screen; only show an error when we have nothing cached
+        setSnap((prev) => ({
+          data: prev.data,
+          status: peek<T>(key, maxAgeMs) !== undefined ? "stale" : "error",
+        }));
+      }
+    } finally {
+      if (aliveRef.current) setValidating(false);
+    }
+  }, [key, maxAgeMs]);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    void run();
+    return () => {
+      aliveRef.current = false;
+    };
+  }, [run]);
+
+  // Revalidate on foreground (tab/WebView resume) — the classic SWR refresh moment.
+  useEffect(() => {
+    if (!revalidateOnFocus || typeof document === "undefined") return;
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void run();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [run, revalidateOnFocus]);
+
+  return { data: snap.data, status: snap.status, validating, refresh: run };
+}

--- a/frontend/src/hooks/useInfiniteFeed.test.ts
+++ b/frontend/src/hooks/useInfiniteFeed.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/api", async (orig) => {
+  const actual = await orig<typeof import("@/lib/api")>();
+  return { ...actual, getFeed: vi.fn() };
+});
+
+import { useInfiniteFeed } from "./useInfiniteFeed";
+import { getFeed, type Article, type FeedResponse } from "@/lib/api";
+import { store, peek, memoryBackend, _setBackend, _resetCache } from "@/lib/cache";
+
+const FEED_KEY = "feed:all:all:20"; // default opts: perPage 20, no topic/sourceType
+
+function article(id: number, title: string): Article {
+  return {
+    id,
+    title,
+    url: `https://x/${id}`,
+    snippet: null,
+    ai_summary: null,
+    published_at: "2026-01-01T00:00:00Z",
+    fetched_at: "2026-01-01T00:00:00Z",
+    source: { id: 1, name: "S", url: "https://x", is_paywalled: false },
+    topics: [],
+    cluster_id: null,
+  };
+}
+function resp(arts: Article[], total = 100): FeedResponse {
+  return { articles: arts, total, page: 1, per_page: 20, as_of: "2026-01-01T00:00:00Z" };
+}
+
+beforeEach(() => {
+  _setBackend(memoryBackend());
+  _resetCache();
+  vi.clearAllMocks();
+});
+
+describe("useInfiniteFeed cache seeding", () => {
+  it("cold: loading → items once the first page loads, and writes page 1 through to cache", async () => {
+    vi.mocked(getFeed).mockResolvedValue(resp([article(1, "A"), article(2, "B")]));
+    const { result } = renderHook(() => useInfiniteFeed());
+
+    expect(result.current.status).toBe("loading");
+    await waitFor(() => expect(result.current.items.length).toBe(2));
+    expect(result.current.items.map((a) => a.title)).toEqual(["A", "B"]);
+    // cached for the next remount
+    expect(peek<FeedResponse>(FEED_KEY)?.articles.map((a) => a.title)).toEqual(["A", "B"]);
+  });
+
+  it("seeds the first paint from cache (no skeleton), then replaces with the revalidated page 1", async () => {
+    await store(FEED_KEY, resp([article(1, "CACHED")]));
+    let resolveFresh: (r: FeedResponse) => void = () => {};
+    vi.mocked(getFeed).mockReturnValue(
+      new Promise<FeedResponse>((r) => {
+        resolveFresh = r;
+      })
+    );
+
+    const { result } = renderHook(() => useInfiniteFeed());
+    // instant seed — status is idle (not loading), so InfiniteFeed shows rows not a skeleton
+    expect(result.current.items.map((a) => a.title)).toEqual(["CACHED"]);
+    expect(result.current.status).toBe("idle");
+
+    resolveFresh(resp([article(2, "FRESH1"), article(3, "FRESH2")]));
+    await waitFor(() =>
+      expect(result.current.items.map((a) => a.title)).toEqual(["FRESH1", "FRESH2"])
+    );
+  });
+});

--- a/frontend/src/hooks/useInfiniteFeed.test.ts
+++ b/frontend/src/hooks/useInfiniteFeed.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 
 vi.mock("@/lib/api", async (orig) => {
   const actual = await orig<typeof import("@/lib/api")>();
@@ -66,5 +66,23 @@ describe("useInfiniteFeed cache seeding", () => {
     await waitFor(() =>
       expect(result.current.items.map((a) => a.title)).toEqual(["FRESH1", "FRESH2"])
     );
+  });
+
+  it("does not page before loadFirst pins the cursor even when seeded (WS-3 cursor safety, review #4)", async () => {
+    await store(FEED_KEY, resp([article(1, "CACHED")]));
+    // loadFirst hangs → the as_of cursor is never pinned and pageRef stays 0
+    vi.mocked(getFeed).mockReturnValue(new Promise<FeedResponse>(() => {}));
+
+    const { result } = renderHook(() => useInfiniteFeed());
+    expect(result.current.status).toBe("idle"); // seeded from cache
+
+    await act(async () => {
+      await result.current.loadMore(); // a sentinel intersection would call this
+    });
+
+    // loadMore was a no-op (pageRef still 0): only loadFirst's single page-1 fetch fired — NOT a second
+    // page-1 fetch with a null cursor (the WS-3 pinning violation the guard prevents).
+    expect(vi.mocked(getFeed)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getFeed).mock.calls[0][0]).toBe(1);
   });
 });

--- a/frontend/src/hooks/useInfiniteFeed.test.tsx
+++ b/frontend/src/hooks/useInfiniteFeed.test.tsx
@@ -6,6 +6,7 @@ vi.mock("@/lib/api", () => ({ getFeed: vi.fn() }));
 
 import { getFeed } from "@/lib/api";
 import { useInfiniteFeed } from "./useInfiniteFeed";
+import { memoryBackend, _setBackend, _resetCache } from "@/lib/cache";
 
 const art = (id: number) => ({
   id, title: `S${id}`, url: `https://ex/${id}`, snippet: "s", ai_summary: null,
@@ -17,7 +18,13 @@ const pageResp = (ids: number[], opts: { total?: number; as_of?: string } = {}) 
 });
 const ids = (r: { items: { id: number }[] }) => r.items.map((i) => i.id);
 
-beforeEach(() => vi.mocked(getFeed).mockReset());
+beforeEach(() => {
+  vi.mocked(getFeed).mockReset();
+  // The hook now seeds page 1 from the two-tier cache — isolate it so one test's page-1 write can't
+  // seed the next test's "cold" load (which would mask a first-load error with stale rows).
+  _setBackend(memoryBackend());
+  _resetCache();
+});
 afterEach(() => vi.unstubAllGlobals());
 
 describe("useInfiniteFeed", () => {

--- a/frontend/src/hooks/useInfiniteFeed.ts
+++ b/frontend/src/hooks/useInfiniteFeed.ts
@@ -103,6 +103,12 @@ export function useInfiniteFeed({ perPage = 20, topicId, sourceType }: Options =
   }, [hasMore, prefetch]);
 
   const loadMore = useCallback(async function loadMore(): Promise<void> {
+    // WS-3 cursor safety: never page until a cursor has been pinned. A cache-seeded feed is 'idle'
+    // with pageRef=0 AND asOfRef=null before loadFirst's first fetch lands, and the sentinel can already
+    // be on screen — without this a scroll fires a page-1 fetch with a null cursor (unpinned window).
+    // (The stale-cursor recovery below also sets pageRef=0, but with asOfRef already pinned, so it is
+    // NOT blocked here.)
+    if (pageRef.current === 0 && asOfRef.current === null) return;
     if (statusRef.current !== "idle") return;  // only page from a settled, has-more state (single-fire)
     setStatus("paging");
     const nextPage = pageRef.current + 1;

--- a/frontend/src/hooks/useInfiniteFeed.ts
+++ b/frontend/src/hooks/useInfiniteFeed.ts
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { getFeed, type Article, type FeedResponse } from "@/lib/api";
+import { peek, store } from "@/lib/cache";
 
 export type FeedStatus = "loading" | "idle" | "paging" | "done" | "error";
 
@@ -40,6 +41,11 @@ export function useInfiniteFeed({ perPage = 20, topicId, sourceType }: Options =
   const mountedRef = useRef(true);
   const optsRef = useRef({ perPage, topicId, sourceType });
   optsRef.current = { perPage, topicId, sourceType };
+  // Cache key for the FIRST page of this query — a remount (back-navigation) seeds its initial paint
+  // from here instead of a skeleton; loadFirst then revalidates and replaces the page-1 window.
+  const cacheKey = `feed:${topicId ?? "all"}:${sourceType ?? "all"}:${perPage}`;
+  const cacheKeyRef = useRef(cacheKey);
+  cacheKeyRef.current = cacheKey;
 
   const setStatus = (s: FeedStatus) => {
     statusRef.current = s;
@@ -73,14 +79,18 @@ export function useInfiniteFeed({ perPage = 20, topicId, sourceType }: Options =
   }, []);
 
   const loadFirst = useCallback(async (): Promise<void> => {
-    setStatus("loading");
+    if (idsRef.current.size === 0) setStatus("loading"); // seeded-from-cache → revalidate silently
     try {
       const { perPage, topicId, sourceType } = optsRef.current;
       const resp = await getFeed(1, perPage, topicId, sourceType);  // first page: NO cursor (unfiltered)
       asOfRef.current = resp.as_of ?? null;
       pageRef.current = 1;
-      append(resp.articles);
+      // REPLACE the page-1 window (not append) so a fresh page 1 supersedes any cache-seeded rows in
+      // the correct order; loadMore keeps appending pages 2+.
+      idsRef.current = new Set(resp.articles.map((a) => a.id));
+      if (mountedRef.current) setItems(resp.articles);
       setTotal(resp.total);
+      void store(cacheKeyRef.current, resp); // cache page 1 for the next remount
       if (hasMore(resp, 1)) {
         prefetch(2);
         setStatus("idle");
@@ -88,9 +98,9 @@ export function useInfiniteFeed({ perPage = 20, topicId, sourceType }: Options =
         setStatus("done");
       }
     } catch {
-      setStatus("error");
+      if (idsRef.current.size === 0) setStatus("error"); // keep cache-seeded rows on a failed revalidate
     }
-  }, [append, hasMore, prefetch]);
+  }, [hasMore, prefetch]);
 
   const loadMore = useCallback(async function loadMore(): Promise<void> {
     if (statusRef.current !== "idle") return;  // only page from a settled, has-more state (single-fire)
@@ -149,9 +159,19 @@ export function useInfiniteFeed({ perPage = 20, topicId, sourceType }: Options =
     mountedRef.current = true;
     pageRef.current = 0;
     asOfRef.current = null;
-    idsRef.current = new Set();
     prefetchRef.current = null;
-    setItems([]);
+    // Seed the first paint from cache (in-session back-navigation) so the feed shows instantly rather
+    // than a skeleton; loadFirst then revalidates and replaces the page-1 window.
+    const seeded = peek<FeedResponse>(cacheKeyRef.current);
+    if (seeded && seeded.articles.length) {
+      idsRef.current = new Set(seeded.articles.map((a) => a.id));
+      setItems(seeded.articles);
+      setTotal(seeded.total);
+      setStatus("idle");
+    } else {
+      idsRef.current = new Set();
+      setItems([]);
+    }
     void loadFirst();
     return () => {
       mountedRef.current = false;

--- a/frontend/src/hooks/usePrefetchClusters.test.ts
+++ b/frontend/src/hooks/usePrefetchClusters.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/api", async (orig) => {
+  const actual = await orig<typeof import("@/lib/api")>();
+  return { ...actual, getCluster: vi.fn() };
+});
+
+import { usePrefetchClusters, PREFETCH_TOP_N } from "./usePrefetchClusters";
+import { getCluster, type ClusterDetail } from "@/lib/api";
+import { store, peek, memoryBackend, _setBackend, _resetCache } from "@/lib/cache";
+
+const detail = (id: number): ClusterDetail => ({
+  id,
+  title: `T${id}`,
+  summary: "s",
+  created_at: "2026-01-01T00:00:00Z",
+  coherence: 0.8,
+  sources: [],
+});
+
+beforeEach(() => {
+  _setBackend(memoryBackend());
+  _resetCache();
+  vi.clearAllMocks();
+  vi.mocked(getCluster).mockImplementation(async (id) => detail(id));
+});
+
+describe("usePrefetchClusters", () => {
+  it("warms the top-N uncached cluster ids into the cache", async () => {
+    renderHook(() => usePrefetchClusters([10, 11, 12, 13, 14]));
+
+    await waitFor(() => expect(peek("cluster:10")).toBeDefined());
+    expect(peek("cluster:12")).toBeDefined();
+    // capped at PREFETCH_TOP_N → the rest are left cold
+    expect(getCluster).toHaveBeenCalledTimes(PREFETCH_TOP_N);
+    expect(peek("cluster:13")).toBeUndefined();
+  });
+
+  it("skips ids already in the cache (no redundant fetch)", async () => {
+    await store("cluster:20", detail(20));
+    renderHook(() => usePrefetchClusters([20, 21]));
+
+    await waitFor(() => expect(peek("cluster:21")).toBeDefined());
+    expect(getCluster).toHaveBeenCalledTimes(1); // only the uncached 21
+    expect(getCluster).toHaveBeenCalledWith(21);
+  });
+
+  it("ignores nulls (unclustered fallback stories) without fetching", async () => {
+    renderHook(() => usePrefetchClusters([null, undefined]));
+    await Promise.resolve();
+    expect(getCluster).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/usePrefetchClusters.ts
+++ b/frontend/src/hooks/usePrefetchClusters.ts
@@ -1,0 +1,35 @@
+"use client";
+
+/**
+ * usePrefetchClusters — warm the top-N story details into the cache while the briefing/feed is on
+ * screen, so tapping a card opens the deep dive INSTANTLY (DeepDiveView peeks the same cache key).
+ *
+ * Guards: only the first N ids (protect the already-slow backend), skips ids already cached, and
+ * dedupes via revalidate() so it never double-fetches a story the user is already opening.
+ */
+import { useEffect } from "react";
+
+import { getCluster } from "@/lib/api";
+import { peek, revalidate, CACHE_TTL_MS } from "@/lib/cache";
+
+export const PREFETCH_TOP_N = 3;
+
+export function usePrefetchClusters(
+  clusterIds: Array<number | null | undefined>,
+  maxAgeMs: number = CACHE_TTL_MS.cluster
+) {
+  // Derive a stable signature (top-N numeric ids) so the effect only refires when the set changes,
+  // not on every render or background revalidation that returns the same stories.
+  const key = clusterIds
+    .filter((x): x is number => typeof x === "number")
+    .slice(0, PREFETCH_TOP_N)
+    .join(",");
+
+  useEffect(() => {
+    if (!key) return;
+    for (const id of key.split(",").map(Number)) {
+      if (peek(`cluster:${id}`, maxAgeMs) !== undefined) continue; // already warm — don't refetch
+      void revalidate(`cluster:${id}`, () => getCluster(id)).catch(() => {});
+    }
+  }, [key, maxAgeMs]);
+}

--- a/frontend/src/lib/cache.test.ts
+++ b/frontend/src/lib/cache.test.ts
@@ -9,6 +9,7 @@ import {
   _resetCache,
   CACHE_TTL_MS,
   CACHE_LIMITS,
+  type PersistBackend,
 } from "./cache";
 
 beforeEach(() => {
@@ -147,6 +148,51 @@ describe("cache eviction (TTL + oldest-first)", () => {
     } finally {
       CACHE_LIMITS.maxBytes = orig.maxBytes;
       CACHE_LIMITS.maxEntries = orig.maxEntries;
+    }
+  });
+
+  it("keeps a lone entry that exceeds the byte ceiling — no self-eviction on its own write (review #2)", async () => {
+    const backend = memoryBackend();
+    _setBackend(backend);
+    const orig = { ...CACHE_LIMITS };
+    CACHE_LIMITS.maxBytes = 50;
+    try {
+      const huge = "x".repeat(200); // ~202 bytes stringified, well over the 50B ceiling
+      await store("cluster:1", huge);
+      expect(peek("cluster:1")).toBe(huge); // retained, not wiped by the write that stored it
+      expect((await backend.entries()).some(([k]) => k === "cluster:1")).toBe(true);
+    } finally {
+      Object.assign(CACHE_LIMITS, orig);
+    }
+  });
+
+  it("bounds the memory tier even when the persistent backend rejects every write (review #3)", async () => {
+    const failing: PersistBackend = {
+      get: async () => undefined,
+      set: async () => {
+        throw new Error("QuotaExceeded");
+      },
+      del: async () => {},
+      entries: async () => [],
+    };
+    _setBackend(failing);
+    const orig = { ...CACHE_LIMITS };
+    CACHE_LIMITS.maxEntries = 3;
+    try {
+      vi.useFakeTimers();
+      for (let i = 0; i < 6; i++) {
+        vi.setSystemTime(i + 1); // strictly increasing storedAt
+        await store(`cluster:${i}`, { i }); // backend.set throws → enforceLimits is skipped
+      }
+      // memory is still capped to the 3 newest (trimMemory runs regardless of the backend)
+      expect(peek("cluster:0")).toBeUndefined();
+      expect(peek("cluster:1")).toBeUndefined();
+      expect(peek("cluster:2")).toBeUndefined();
+      expect(peek("cluster:3")).toBeDefined();
+      expect(peek("cluster:5")).toBeDefined();
+      vi.useRealTimers();
+    } finally {
+      Object.assign(CACHE_LIMITS, orig);
     }
   });
 });

--- a/frontend/src/lib/cache.test.ts
+++ b/frontend/src/lib/cache.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  peek,
+  load,
+  store,
+  revalidate,
+  memoryBackend,
+  _setBackend,
+  _resetCache,
+  CACHE_TTL_MS,
+  CACHE_LIMITS,
+} from "./cache";
+
+beforeEach(() => {
+  _setBackend(memoryBackend());
+  _resetCache();
+});
+
+describe("cache core (two-tier SWR)", () => {
+  it("store() then peek() returns the data synchronously (memory tier)", async () => {
+    await store("briefing", { a: 1 });
+    expect(peek("briefing")).toEqual({ a: 1 });
+  });
+
+  it("peek() returns undefined for a missing key", () => {
+    expect(peek("nope")).toBeUndefined();
+  });
+
+  it("load() falls back to the persistent backend and hydrates memory", async () => {
+    // Seed the backend directly, bypassing the in-memory Map, to simulate a fresh app launch
+    // where nothing is in memory yet but the last session persisted to IndexedDB.
+    const backend = memoryBackend();
+    await backend.set("cluster:7", { data: { title: "Persisted" }, storedAt: Date.now() });
+    _setBackend(backend);
+
+    expect(peek("cluster:7")).toBeUndefined(); // not in memory yet
+    expect(await load("cluster:7")).toEqual({ title: "Persisted" });
+    expect(peek("cluster:7")).toEqual({ title: "Persisted" }); // hydrated into memory
+  });
+
+  it("peek()/load() honor maxAgeMs (a stale entry is a miss)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    await store("feed:p1", ["x"]);
+    vi.setSystemTime(1000);
+    expect(peek("feed:p1", 500)).toBeUndefined(); // age 1000 > 500 → miss
+    expect(peek("feed:p1", 2000)).toEqual(["x"]); // within window → hit
+    expect(await load("feed:p1", 500)).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("revalidate() runs the fetcher, write-throughs the result, and returns it", async () => {
+    const fresh = await revalidate("briefing", async () => ({ stories: [1, 2] }));
+    expect(fresh).toEqual({ stories: [1, 2] });
+    expect(peek("briefing")).toEqual({ stories: [1, 2] }); // written through both tiers
+  });
+
+  it("revalidate() dedupes concurrent calls for the same key (fetcher fires once)", async () => {
+    let calls = 0;
+    let resolveFetch: (v: unknown) => void = () => {};
+    const fetcher = () => {
+      calls++;
+      return new Promise((r) => {
+        resolveFetch = r;
+      });
+    };
+
+    const p1 = revalidate("k", fetcher);
+    const p2 = revalidate("k", fetcher);
+    expect(calls).toBe(1); // single in-flight request shared
+
+    resolveFetch("VALUE");
+    expect(await p1).toBe("VALUE");
+    expect(await p2).toBe("VALUE");
+
+    // in-flight cleared on settle → a later revalidate issues a fresh fetch (the deferred fetcher is
+    // NOT re-used, so its call count stays 1; the new immediate fetcher supplies the value).
+    const again = await revalidate("k", async () => "AGAIN");
+    expect(again).toBe("AGAIN");
+    expect(calls).toBe(1);
+  });
+
+  it("a rejected revalidate() clears the in-flight slot so a retry can re-fetch", async () => {
+    let calls = 0;
+    const boom = () => {
+      calls++;
+      return Promise.reject(new Error("network"));
+    };
+    await expect(revalidate("k", boom)).rejects.toThrow("network");
+    await expect(revalidate("k", boom)).rejects.toThrow("network");
+    expect(calls).toBe(2); // not wedged on the first rejected promise
+  });
+});
+
+describe("cache eviction (TTL + oldest-first)", () => {
+  it("prunes entries past their namespace TTL on the next write", async () => {
+    const backend = memoryBackend();
+    _setBackend(backend);
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    await store("feed:old", [1]); // feed TTL is 30m
+    vi.setSystemTime(CACHE_TTL_MS.feed + 1000); // now well past it
+    await store("briefing", { stories: [] }); // any write triggers the prune
+
+    const keys = (await backend.entries()).map(([k]) => k);
+    expect(keys).not.toContain("feed:old"); // expired → dropped from the backend
+    expect(keys).toContain("briefing");
+    expect(peek("feed:old")).toBeUndefined(); // and from memory
+    vi.useRealTimers();
+  });
+
+  it("evicts the oldest-written entries once over the count cap", async () => {
+    const backend = memoryBackend();
+    _setBackend(backend);
+    vi.useFakeTimers();
+    const n = CACHE_LIMITS.maxEntries + 3;
+    for (let i = 0; i < n; i++) {
+      vi.setSystemTime(i * 1000); // strictly increasing storedAt; all within cluster's 2h TTL
+      await store(`cluster:${i}`, { i });
+    }
+    const keys = (await backend.entries()).map(([k]) => k);
+    expect(keys.length).toBe(CACHE_LIMITS.maxEntries); // capped
+    expect(keys).not.toContain("cluster:0"); // three oldest evicted
+    expect(keys).not.toContain("cluster:1");
+    expect(keys).not.toContain("cluster:2");
+    expect(keys).toContain(`cluster:${n - 1}`); // newest kept
+    vi.useRealTimers();
+  });
+
+  it("evicts oldest to stay under the byte ceiling", async () => {
+    const backend = memoryBackend();
+    _setBackend(backend);
+    const orig = { ...CACHE_LIMITS };
+    CACHE_LIMITS.maxBytes = 100; // isolate the size path from the count path
+    CACHE_LIMITS.maxEntries = 1000;
+    try {
+      vi.useFakeTimers();
+      const big = "x".repeat(80); // ~82 bytes stringified — two exceed the 100B ceiling
+      vi.setSystemTime(1);
+      await store("cluster:a", big);
+      vi.setSystemTime(2);
+      await store("cluster:b", big);
+      const keys = (await backend.entries()).map(([k]) => k);
+      expect(keys).toContain("cluster:b"); // newest kept
+      expect(keys).not.toContain("cluster:a"); // oldest evicted to fit
+      vi.useRealTimers();
+    } finally {
+      CACHE_LIMITS.maxBytes = orig.maxBytes;
+      CACHE_LIMITS.maxEntries = orig.maxEntries;
+    }
+  });
+});

--- a/frontend/src/lib/cache.ts
+++ b/frontend/src/lib/cache.ts
@@ -1,0 +1,202 @@
+/* ═══════════════════════════════════════
+   NewsLens client cache — two-tier stale-while-revalidate
+
+   WHY: every screen used to fetch from zero on mount (data lived only in React state, discarded on
+   navigation), so a cold Render backend meant a 3-min blank home and every "back to home" re-loaded.
+   This cache lets a screen paint the LAST-KNOWN response instantly, then revalidate in the background.
+
+   Two tiers:
+   - in-memory Map  → instant, survives SPA navigation within one app session
+   - persistent backend (IndexedDB via idb-keyval) → survives full app restarts (Firebase already uses
+     IDB in this WebView, so it's a proven-persistent store here)
+
+   In SSR / jsdom (no `indexedDB`) the default backend degrades to memory-only, so import never throws
+   and server render simply behaves as a cold cache.
+   ═══════════════════════════════════════ */
+
+import {
+  get as idbGet,
+  set as idbSet,
+  del as idbDel,
+  entries as idbEntries,
+  createStore,
+  type UseStore,
+} from "idb-keyval";
+
+export interface CacheEntry<T> {
+  data: T;
+  /** ms epoch when written — drives TTL freshness checks and oldest-first eviction. */
+  storedAt: number;
+}
+
+export interface PersistBackend {
+  get<T>(key: string): Promise<CacheEntry<T> | undefined>;
+  set<T>(key: string, entry: CacheEntry<T>): Promise<void>;
+  del(key: string): Promise<void>;
+  entries(): Promise<Array<[string, CacheEntry<unknown>]>>;
+}
+
+/** In-memory PersistBackend — the SSR/jsdom fallback and the test double. */
+export function memoryBackend(): PersistBackend {
+  const m = new Map<string, CacheEntry<unknown>>();
+  return {
+    async get<T>(key: string) {
+      return m.get(key) as CacheEntry<T> | undefined;
+    },
+    async set<T>(key: string, entry: CacheEntry<T>) {
+      m.set(key, entry as CacheEntry<unknown>);
+    },
+    async del(key: string) {
+      m.delete(key);
+    },
+    async entries() {
+      return [...m.entries()];
+    },
+  };
+}
+
+/** IndexedDB-backed PersistBackend. The store is created only when `indexedDB` exists, because
+ *  idb-keyval's createStore opens the DB immediately and would throw under SSR/jsdom. (The static
+ *  import above is inert at load time — only createStore touches IndexedDB.) */
+function idbBackend(): PersistBackend {
+  const s: UseStore = createStore("newslens-cache", "swr");
+  return {
+    get: <T,>(key: string) => idbGet<CacheEntry<T>>(key, s),
+    set: <T,>(key: string, entry: CacheEntry<T>) => idbSet(key, entry, s),
+    del: (key: string) => idbDel(key, s),
+    entries: () => idbEntries(s) as Promise<Array<[string, CacheEntry<unknown>]>>,
+  };
+}
+
+function defaultBackend(): PersistBackend {
+  try {
+    if (typeof indexedDB !== "undefined") return idbBackend();
+  } catch {
+    /* fall through to memory */
+  }
+  return memoryBackend();
+}
+
+let backend: PersistBackend = defaultBackend();
+const memory = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+/* ── test seams ── */
+export function _setBackend(b: PersistBackend): void {
+  backend = b;
+}
+export function _resetCache(): void {
+  memory.clear();
+  inflight.clear();
+}
+
+/* ── TTL + eviction limits (namespace = key prefix before ":") ── */
+/** Per-namespace hard TTL. Past this, an entry is a miss AND is pruned on the next write. */
+export const CACHE_TTL_MS: Record<string, number> = {
+  briefing: 6 * 60 * 60 * 1000, // a briefing is "today" — hold 6h
+  cluster: 2 * 60 * 60 * 1000, // story detail — 2h
+  feed: 30 * 60 * 1000, // firehose page — 30m
+  topics: 60 * 60 * 1000,
+  _default: 60 * 60 * 1000,
+};
+/** Overflow caps: evict oldest-written first once either is exceeded. */
+export const CACHE_LIMITS = { maxEntries: 60, maxBytes: 4_000_000 };
+
+function ttlFor(key: string): number {
+  return CACHE_TTL_MS[key.split(":")[0]] ?? CACHE_TTL_MS._default;
+}
+function fresh(key: string, entry: CacheEntry<unknown>, maxAgeMs?: number): boolean {
+  return maxAgeMs == null || Date.now() - entry.storedAt <= maxAgeMs;
+}
+
+/** Synchronous memory read — the instant-paint path. `undefined` = miss or stale. */
+export function peek<T>(key: string, maxAgeMs?: number): T | undefined {
+  const e = memory.get(key) as CacheEntry<T> | undefined;
+  if (!e || !fresh(key, e, maxAgeMs)) return undefined;
+  return e.data;
+}
+
+/** Async read: memory, then the persistent backend (hydrating memory on a hit). */
+export async function load<T>(key: string, maxAgeMs?: number): Promise<T | undefined> {
+  const hit = peek<T>(key, maxAgeMs);
+  if (hit !== undefined) return hit;
+  try {
+    const e = await backend.get<T>(key);
+    if (!e || !fresh(key, e, maxAgeMs)) return undefined;
+    memory.set(key, e);
+    return e.data;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Write-through both tiers, then evict stale/overflow entries. */
+export async function store<T>(key: string, data: T): Promise<void> {
+  const entry: CacheEntry<T> = { data, storedAt: Date.now() };
+  memory.set(key, entry);
+  try {
+    await backend.set(key, entry);
+    await enforceLimits();
+  } catch {
+    /* best-effort persistence — memory tier still works */
+  }
+}
+
+/** Fetch fresh data, write it through, and return it. Concurrent calls for the same key share one
+ *  in-flight request (dedupe); the slot is cleared on settle so a later call (or a retry after a
+ *  rejection) fetches again. */
+export function revalidate<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const p = fetcher()
+    .then(async (data) => {
+      await store(key, data);
+      return data;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+  inflight.set(key, p);
+  return p;
+}
+
+/** Prune expired entries (per-namespace TTL), then evict oldest-first until under the count/size caps.
+ *  Runs on every write; entry counts are small (dozens), so the full-scan cost is negligible. */
+async function enforceLimits(): Promise<void> {
+  let all: Array<[string, CacheEntry<unknown>]>;
+  try {
+    all = await backend.entries();
+  } catch {
+    return;
+  }
+  const now = Date.now();
+
+  // 1) TTL prune
+  const live: Array<[string, CacheEntry<unknown>]> = [];
+  for (const [k, e] of all) {
+    if (now - e.storedAt > ttlFor(k)) {
+      memory.delete(k);
+      await backend.del(k);
+    } else {
+      live.push([k, e]);
+    }
+  }
+
+  // 2) count + size cap → drop the oldest-written entries first
+  live.sort((a, b) => a[1].storedAt - b[1].storedAt);
+  const bytes = (e: CacheEntry<unknown>) => {
+    try {
+      return JSON.stringify(e.data).length;
+    } catch {
+      return 0;
+    }
+  };
+  let total = live.reduce((s, [, e]) => s + bytes(e), 0);
+  while (live.length > CACHE_LIMITS.maxEntries || total > CACHE_LIMITS.maxBytes) {
+    const oldest = live.shift();
+    if (!oldest) break;
+    total -= bytes(oldest[1]);
+    memory.delete(oldest[0]);
+    await backend.del(oldest[0]);
+  }
+}

--- a/frontend/src/lib/cache.ts
+++ b/frontend/src/lib/cache.ts
@@ -134,11 +134,12 @@ export async function load<T>(key: string, maxAgeMs?: number): Promise<T | undef
 export async function store<T>(key: string, data: T): Promise<void> {
   const entry: CacheEntry<T> = { data, storedAt: Date.now() };
   memory.set(key, entry);
+  trimMemory(); // bound the memory tier even if the persistent write below rejects (IDB quota)
   try {
     await backend.set(key, entry);
     await enforceLimits();
   } catch {
-    /* best-effort persistence — memory tier still works */
+    /* best-effort persistence — the memory tier is already bounded by trimMemory() */
   }
 }
 
@@ -182,21 +183,41 @@ async function enforceLimits(): Promise<void> {
     }
   }
 
-  // 2) count + size cap → drop the oldest-written entries first
+  // 2) count + size cap → drop the oldest-written entries first, but never the sole newest entry
+  //    (a single payload over the byte ceiling is kept, not self-evicted on the write that stored it).
   live.sort((a, b) => a[1].storedAt - b[1].storedAt);
-  const bytes = (e: CacheEntry<unknown>) => {
-    try {
-      return JSON.stringify(e.data).length;
-    } catch {
-      return 0;
-    }
-  };
-  let total = live.reduce((s, [, e]) => s + bytes(e), 0);
-  while (live.length > CACHE_LIMITS.maxEntries || total > CACHE_LIMITS.maxBytes) {
+  let total = live.reduce((s, [, e]) => s + entryBytes(e), 0);
+  while (live.length > 1 && (live.length > CACHE_LIMITS.maxEntries || total > CACHE_LIMITS.maxBytes)) {
     const oldest = live.shift();
     if (!oldest) break;
-    total -= bytes(oldest[1]);
+    total -= entryBytes(oldest[1]);
     memory.delete(oldest[0]);
     await backend.del(oldest[0]);
+  }
+}
+
+/** JSON byte estimate for an entry's payload (0 if it can't be serialized). */
+function entryBytes(e: CacheEntry<unknown>): number {
+  try {
+    return JSON.stringify(e.data).length;
+  } catch {
+    return 0;
+  }
+}
+
+/** Bound the in-memory tier independently of the persistent backend (which may reject writes on a
+ *  quota-limited WebView, in which case enforceLimits never runs). TTL-prunes, then evicts oldest-first
+ *  to the count/byte caps, always keeping the single newest entry so a lone oversized payload survives. */
+function trimMemory(): void {
+  const now = Date.now();
+  for (const [k, e] of [...memory.entries()]) {
+    if (now - e.storedAt > ttlFor(k)) memory.delete(k);
+  }
+  const live = [...memory.entries()].sort((a, b) => a[1].storedAt - b[1].storedAt);
+  let total = live.reduce((s, [, e]) => s + entryBytes(e), 0);
+  while (live.length > 1 && (live.length > CACHE_LIMITS.maxEntries || total > CACHE_LIMITS.maxBytes)) {
+    const [k, e] = live.shift()!;
+    total -= entryBytes(e);
+    memory.delete(k);
   }
 }


### PR DESCRIPTION
## Why

Two independent problems made the app feel slow (both surfaced by the user on-device):

1. **3-min blank "ASSEMBLING YOUR BRIEFING" on open** — Render free-tier cold start (~40–60s) *stacked with* on-demand LLM briefing generation.
2. **Every "back to home" re-loaded from scratch; every article tap flashed skeletons** — the app had **zero client-side caching**; all data lived in React `useState` and was discarded on navigation.

This PR fixes #2 outright and *masks* #1: the app now paints the **last-known** briefing / story / feed instantly, then revalidates in the background. (The backend fix that makes that revalidation fast — non-blocking + eager summaries — is a separate PR.)

## What

A two-tier **stale-while-revalidate** cache:

- **`src/lib/cache.ts`** — in-memory `Map` (survives SPA navigation) + **IndexedDB** via `idb-keyval` (survives app restart; Firebase already proves IDB works in this WebView). `peek`/`load`/`store`/`revalidate` with deduped in-flight requests, per-namespace **TTL** + oldest-first **count/byte eviction**. Degrades to memory-only under SSR/jsdom (import never throws).
- **`src/hooks/useCachedResource.ts`** — the one React binding: seeds from cache, revalidates on mount + foreground, and **keeps stale data on a failed revalidate** (only errors when nothing is cached).
- Wired into **briefing** (`page.tsx`), **story detail** (`DeepDiveView`), and **feed page-1** (`useInfiniteFeed` — seed + replace-and-write-through, keeping the WS-3 cursor/prefetch/dedupe logic intact).
- **`src/hooks/usePrefetchClusters.ts`** — warms the top-3 story details while the briefing is on screen, so a tap opens instantly.

## Adversarial review

Ran a find→verify multi-agent review; **4 confirmed defects folded, each with a regression test** (commit `9a674b1`):

| Sev | Defect | Fix |
|---|---|---|
| HIGH | Cross-story torn read — a shared alive-flag couldn't tell "unmounted" from "key changed in place", so a slow revalidate for story A could overwrite story B | Monotonic per-run token; superseded run's result is dropped |
| HIGH | WS-3 cursor safety — a cache-seeded feed went `idle` before `loadFirst` pinned `as_of`, so a scroll could fire `loadMore` with a null cursor | Guard `loadMore` on `pageRef===0 && asOfRef===null` (does **not** block stale-cursor recovery) |
| MED | Byte-cap self-eviction — a lone payload > 4 MB got deleted on its own write | `live.length > 1` guard keeps the sole newest entry |
| LOW | Unbounded memory if the IDB write rejects (quota) | Synchronous `trimMemory()` on every write, backend-independent |

## Test / build

- **156 vitest tests pass** (40 files; +6 for this change incl. the 4 regression tests).
- `next build --webpack` clean; changed files lint-clean.
- Verified via tests + build (local browser QA is blocked on Windows-ARM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
