### PR TITLE
perf: non-blocking + eager cluster summaries (kill the on-demand LLM stall)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -457,15 +457,14 @@ async def get_cluster(cluster_id: int, db: AsyncSession = Depends(get_db)):
             ],
         )
 
-    # On-demand summary generation if batch missed this cluster
+    # Non-blocking summary: return a snippet fallback instantly and generate the real summary in the
+    # background (schedule_summary) so the next view is warm. NEVER mutate cluster.summary here — the
+    # db.commit() below (for read marks) would persist the snippet and make backfill skip this cluster.
+    response_summary = cluster.summary
     if not cluster.summary:
-        try:
-            from app.services.summarizer import summarize_cluster
-            summary_result = await summarize_cluster(cluster.id)
-            if summary_result:
-                cluster.summary, cluster.coherence = summary_result
-        except Exception as e:
-            logger.warning("on_demand_summary_failed", cluster_id=cluster.id, error=str(e))
+        from app.services.summarizer import snippet_summary, schedule_summary
+        response_summary = snippet_summary([ca.article.snippet or "" for ca in cluster.articles])
+        schedule_summary(cluster.id)
 
     # Mark all articles in cluster as read
     article_ids = [ca.article.id for ca in cluster.articles]
@@ -511,7 +510,7 @@ async def get_cluster(cluster_id: int, db: AsyncSession = Depends(get_db)):
     return ClusterDetailOut(
         id=cluster.id,
         title=cluster.title,
-        summary=cluster.summary,
+        summary=response_summary,
         created_at=cluster.created_at,
         # Real source-agreement ratio when a consensus pass is cached; else stored value / heuristic.
         coherence=lenses.cluster_coherence(cluster, [ca.article for ca in cluster.articles]),
@@ -887,19 +886,13 @@ async def get_briefing(db: AsyncSession = Depends(get_db)):
                     ca.article.source.category, category
                 )
 
-        # Use real summary or on-demand generate
+        # Non-blocking summary: use the cached real one if present, else return the snippet fallback
+        # instantly and warm the real summary in the background (schedule_summary) for the next view.
         summary = cluster.summary
         coherence = cluster.coherence
         if not summary:
-            try:
-                from app.services.summarizer import summarize_cluster
-                sr = await summarize_cluster(cluster.id)
-                if sr:
-                    summary, coherence = sr
-            except Exception as e:
-                logger.warning("briefing_summary_failed", cluster_id=cluster.id, error=str(e))
-
-        if not summary:
+            from app.services.summarizer import schedule_summary
+            schedule_summary(cluster.id)
             summary = first_snippet or "No summary available."
             sentences = summary.split(". ")
             if len(sentences) > 2:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -230,7 +230,11 @@ class Settings(BaseSettings):
 
     # Summary config
     summary_model: str = "gpt-4o-mini"
-    summary_batch_size: int = 5
+    summary_batch_size: int = 12  # per backfill run (was 5) — keep up with ingest so fewer cold on-demands
+    # Non-blocking + eager summaries: the read paths return a snippet fallback instantly and generate the
+    # real summary in the background; new clusters are summarized eagerly on creation. Kill-switch → the
+    # read paths still fall back to snippets, just without the background warm.
+    eager_summaries_enabled: bool = True
 
     # Impact engine v2 (Wave A): structured + validated + guarded WIIFM.
     # Flip off to fall back to the legacy free-text impact lens.

--- a/backend/app/services/clustering.py
+++ b/backend/app/services/clustering.py
@@ -79,6 +79,10 @@ async def run_clustering():
                     await link_cluster(session, cluster.id)
                 except Exception as e:  # noqa: BLE001 — never break clustering on edge-linking
                     logger.warning("cluster_link_failed", cluster_id=cluster.id, error=str(e))
+                # Eagerly summarize the brand-new cluster in the background so it's warm before any user
+                # opens it — turns the read-path on-demand into a rare cold path (deduped + gated inside).
+                from app.services.summarizer import schedule_summary
+                schedule_summary(cluster.id)
                 new_clusters += 1
 
     logger.info(

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -161,6 +161,10 @@ async def summarize_cluster(cluster_id: int) -> tuple[str, float] | None:
 # Clusters currently being summarized in the background — dedupes a burst of read requests (or eager
 # creation) so only ONE task per cluster is in flight at a time.
 _scheduled: set[int] = set()
+# Strong references to the in-flight tasks. The event loop keeps only a WEAK reference to a bare
+# create_task result, so without this a background summary could be garbage-collected mid-run
+# (documented CPython footgun) and silently cancelled — defeating the warm-up. Discarded on completion.
+_tasks: "set[asyncio.Task]" = set()
 
 
 def schedule_summary(cluster_id: int) -> "asyncio.Task | None":
@@ -186,11 +190,15 @@ def schedule_summary(cluster_id: int) -> "asyncio.Task | None":
             _scheduled.discard(cluster_id)
 
     try:
-        return asyncio.create_task(_run())
+        task = asyncio.create_task(_run())
     except RuntimeError:
         # No running loop (e.g. invoked from a sync context) — undo the guard so a later call retries.
         _scheduled.discard(cluster_id)
         return None
+    # Hold a strong reference until the task finishes so it can't be GC-cancelled mid-run.
+    _tasks.add(task)
+    task.add_done_callback(_tasks.discard)
+    return task
 
 
 async def backfill_summaries():

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -5,6 +5,7 @@ Generates cluster summaries from article titles and snippets through the provide
 Hybrid strategy: batch job pre-generates + on-demand fallback.
 """
 
+import asyncio
 import structlog
 from datetime import datetime, timezone, timedelta
 
@@ -12,7 +13,7 @@ from sqlalchemy import select, update
 
 from app.config import settings
 from app.database import async_session
-from app.models import ClusterArticle, StoryCluster, Article, EmbeddingStatus
+from app.models import ClusterArticle, StoryCluster, Article
 
 logger = structlog.get_logger()
 
@@ -24,6 +25,21 @@ def _staleness_cutoff(now: datetime | None = None) -> datetime:
     """
     now = now or datetime.now(timezone.utc)
     return now - timedelta(hours=4)
+
+
+def snippet_summary(snippets: list[str]) -> str:
+    """No-LLM fallback summary: the first non-empty snippet, HTML-unescaped, trimmed to ~2 sentences.
+
+    Returned INSTANTLY by the read paths (/briefing, /clusters/{id}) while the real LLM summary
+    generates in the background, and reused as generate_cluster_summary's degradation text. Must never
+    be persisted as a cluster's ``summary`` — that would make backfill_summaries treat the cluster as
+    done and skip the real generation.
+    """
+    import html as _html
+
+    text = _html.unescape(next((s for s in snippets if s), "No summary available."))
+    sentences = text.split(". ")
+    return ". ".join(sentences[:2]) + "." if len(sentences) > 1 else text
 
 
 async def generate_cluster_summary(
@@ -38,12 +54,8 @@ async def generate_cluster_summary(
     or guard trip → callers keep the existing title. Coherence is estimated from the
     number of corroborating sources.
     """
-    # Fallback: first available snippet, trimmed to ~2 sentences. Unescape defensively — rows
-    # ingested before the fetcher decoded entities still carry &nbsp;/&#8377; in the DB.
-    import html as _html
-    fallback_text = _html.unescape(next((s for s in snippets if s), "No summary available."))
-    sentences = fallback_text.split(". ")
-    fallback_summary = ". ".join(sentences[:2]) + "." if len(sentences) > 1 else fallback_text
+    # Fallback: first available snippet, trimmed to ~2 sentences — shared with the read-path fallback.
+    fallback_summary = snippet_summary(snippets)
 
     # Coherence heuristic (source-count fallback; the real ratio is computed in lenses.cluster_coherence).
     source_count = len(titles)
@@ -144,6 +156,41 @@ async def summarize_cluster(cluster_id: int) -> tuple[str, float] | None:
     )
 
     return summary, coherence
+
+
+# Clusters currently being summarized in the background — dedupes a burst of read requests (or eager
+# creation) so only ONE task per cluster is in flight at a time.
+_scheduled: set[int] = set()
+
+
+def schedule_summary(cluster_id: int) -> "asyncio.Task | None":
+    """Fire-and-forget background summary generation for a cluster.
+
+    The read paths call this instead of awaiting summarize_cluster, so /briefing and /clusters/{id}
+    return instantly (with a snippet fallback) and the real summary is warm on the next view. Deduped
+    per cluster and gated by ``settings.eager_summaries_enabled``. Returns the Task, or None when it was
+    deduped / gated off / there is no running event loop.
+    """
+    if not settings.eager_summaries_enabled:
+        return None
+    if cluster_id in _scheduled:
+        return None
+    _scheduled.add(cluster_id)
+
+    async def _run() -> None:
+        try:
+            await summarize_cluster(cluster_id)
+        except Exception as e:  # noqa: BLE001 — best-effort; backfill_summaries retries misses
+            logger.warning("scheduled_summary_failed", cluster_id=cluster_id, error=str(e))
+        finally:
+            _scheduled.discard(cluster_id)
+
+    try:
+        return asyncio.create_task(_run())
+    except RuntimeError:
+        # No running loop (e.g. invoked from a sync context) — undo the guard so a later call retries.
+        _scheduled.discard(cluster_id)
+        return None
 
 
 async def backfill_summaries():

--- a/backend/tests/integration/test_clustering_eager_summary.py
+++ b/backend/tests/integration/test_clustering_eager_summary.py
@@ -1,0 +1,41 @@
+"""Eager summaries: run_clustering schedules a background summary the moment a NEW cluster forms, so
+it's warm before any user opens it (turns the read-path on-demand into a rare cold path)."""
+import contextlib
+
+import pytest
+
+from app.models import Article, EmbeddingStatus, Source, SourceType
+
+
+@pytest.mark.asyncio
+async def test_run_clustering_eagerly_schedules_summary_for_a_new_cluster(db_session, monkeypatch):
+    from app.services import clustering, summarizer
+
+    # Route the job's own async_session() to the test's (uncommitted) transaction.
+    @contextlib.asynccontextmanager
+    async def _fake():
+        yield db_session
+
+    monkeypatch.setattr(clustering, "async_session", _fake)
+
+    # Force the new-cluster path (no nearest match) and capture the eager schedule.
+    async def _no_match(_article):
+        return None
+
+    monkeypatch.setattr(clustering, "_find_nearest_cluster", _no_match)
+    scheduled: list[int] = []
+    monkeypatch.setattr(summarizer, "schedule_summary", lambda cid: scheduled.append(cid))
+
+    src = Source(name="ECL", url="https://x.example/ecl", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    art = Article(
+        title="Fresh cluster seed", url="https://x.example/ecl-a", source_id=src.id,
+        embedding_status=EmbeddingStatus.complete, embedding=[0.1] * 768,
+    )
+    db_session.add(art)
+    await db_session.flush()
+
+    await clustering.run_clustering()
+
+    assert len(scheduled) == 1  # the newly-created cluster was scheduled for a background summary

--- a/backend/tests/integration/test_nonblocking_summaries.py
+++ b/backend/tests/integration/test_nonblocking_summaries.py
@@ -1,0 +1,68 @@
+"""Non-blocking summaries: /clusters/{id} and /briefing return a snippet fallback INSTANTLY for a
+cluster with no summary yet, schedule the real LLM summary in the background, and never persist the
+snippet (so backfill_summaries still generates the real one)."""
+import pytest
+
+from app.models import Article, ClusterArticle, EmbeddingStatus, Source, SourceType, StoryCluster
+
+SNIPPET = "First sentence here. Second sentence here. Third one."
+EXPECTED = "First sentence here. Second sentence here."
+
+
+async def _cluster_without_summary(db_session, n_articles: int = 1):
+    src = Source(name=f"NB{id(object())}", url=f"https://x.example/nb-{id(object())}", source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    cl = StoryCluster(title="Story", summary=None)  # no summary yet
+    db_session.add(cl)
+    await db_session.flush()
+    for i in range(n_articles):
+        art = Article(
+            title=f"T{i}", url=f"https://x.example/nb-a-{cl.id}-{i}", source_id=src.id,
+            snippet=SNIPPET, embedding_status=EmbeddingStatus.complete,
+        )
+        db_session.add(art)
+        await db_session.flush()
+        db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    await db_session.flush()
+    return cl
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_returns_snippet_fallback_and_schedules_without_persisting(
+    aclient, db_session, monkeypatch
+):
+    from app.services import summarizer
+
+    scheduled: list[int] = []
+    monkeypatch.setattr(summarizer, "schedule_summary", lambda cid: scheduled.append(cid))
+
+    cl = await _cluster_without_summary(db_session)
+
+    resp = await aclient.get(f"/clusters/{cl.id}")
+    assert resp.status_code == 200
+    assert resp.json()["summary"] == EXPECTED  # instant snippet fallback, not blocked on the LLM
+    assert scheduled == [cl.id]  # real summary warmed in the background
+
+    await db_session.refresh(cl)
+    assert cl.summary is None  # snippet was NOT persisted — backfill must still generate the real one
+
+
+@pytest.mark.asyncio
+async def test_briefing_returns_snippet_fallback_and_schedules(aclient, db_session, monkeypatch):
+    from app.services import summarizer
+
+    scheduled: list[int] = []
+    monkeypatch.setattr(summarizer, "schedule_summary", lambda cid: scheduled.append(cid))
+
+    cl = await _cluster_without_summary(db_session, n_articles=2)  # multi-source → "settled"
+
+    resp = await aclient.get("/briefing")
+    assert resp.status_code == 200
+    story = next((s for s in resp.json()["stories"] if s.get("cluster_id") == cl.id), None)
+    assert story is not None, "the no-summary cluster should still appear in the briefing"
+    assert story["summary"] == EXPECTED  # snippet fallback, not a blocking LLM call
+    assert cl.id in scheduled
+
+    await db_session.refresh(cl)
+    assert cl.summary is None  # not persisted

--- a/backend/tests/unit/test_summarizer.py
+++ b/backend/tests/unit/test_summarizer.py
@@ -1,0 +1,60 @@
+"""Unit tests for the no-LLM snippet fallback + the fire-and-forget summary scheduler (PR: non-blocking
++ eager summaries)."""
+import pytest
+
+from app.services.summarizer import snippet_summary
+
+
+def test_snippet_summary_first_nonempty_trimmed_to_two_sentences():
+    assert (
+        snippet_summary(["", "First sentence. Second sentence. Third one."])
+        == "First sentence. Second sentence."
+    )
+
+
+def test_snippet_summary_single_sentence_returned_whole():
+    assert snippet_summary(["Only one sentence here"]) == "Only one sentence here"
+
+
+def test_snippet_summary_all_empty_placeholder():
+    assert snippet_summary(["", ""]) == "No summary available."
+    assert snippet_summary([]) == "No summary available."
+
+
+def test_snippet_summary_unescapes_html_entities():
+    # Rows ingested before the fetcher decoded entities still carry &amp;/&#8377; in the DB.
+    assert snippet_summary(["Reliance &amp; Adani"]) == "Reliance & Adani"
+    assert "₹" in snippet_summary(["Price is &#8377;100 crore. More context."])
+
+
+@pytest.mark.asyncio
+async def test_schedule_summary_dedupes_and_runs_once(monkeypatch):
+    from app.services import summarizer
+
+    calls: list[int] = []
+
+    async def fake_summarize(cid: int):
+        calls.append(cid)
+
+    monkeypatch.setattr(summarizer, "summarize_cluster", fake_summarize)
+    summarizer._scheduled.discard(1)
+
+    t1 = summarizer.schedule_summary(1)
+    t2 = summarizer.schedule_summary(1)  # deduped while the first is still in flight
+    assert t1 is not None
+    assert t2 is None
+
+    await t1
+    assert calls == [1]  # ran exactly once
+    assert 1 not in summarizer._scheduled  # slot cleared on completion → a later view can re-schedule
+
+
+@pytest.mark.asyncio
+async def test_schedule_summary_gated_off_is_noop(monkeypatch):
+    from app.services import summarizer
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "eager_summaries_enabled", False)
+    summarizer._scheduled.discard(99)
+    assert summarizer.schedule_summary(99) is None
+    assert 99 not in summarizer._scheduled

--- a/backend/tests/unit/test_summarizer.py
+++ b/backend/tests/unit/test_summarizer.py
@@ -58,3 +58,30 @@ async def test_schedule_summary_gated_off_is_noop(monkeypatch):
     summarizer._scheduled.discard(99)
     assert summarizer.schedule_summary(99) is None
     assert 99 not in summarizer._scheduled
+
+
+@pytest.mark.asyncio
+async def test_schedule_summary_holds_strong_task_ref_until_done(monkeypatch):
+    # Regression (adversarial review): asyncio keeps only a WEAK ref to a bare create_task result, so
+    # the task must be strongly referenced (in _tasks) until it completes — else GC could cancel the
+    # background summary mid-run. The ref is cleared by the done-callback on completion.
+    import asyncio
+
+    from app.services import summarizer
+
+    release = asyncio.Event()
+
+    async def fake_summarize(_cid):
+        await release.wait()
+
+    monkeypatch.setattr(summarizer, "summarize_cluster", fake_summarize)
+    summarizer._scheduled.discard(7)
+
+    t = summarizer.schedule_summary(7)
+    assert t is not None
+    assert t in summarizer._tasks  # strong ref held while the summary is in flight
+
+    release.set()
+    await t
+    assert t not in summarizer._tasks  # done-callback cleaned it up
+    assert 7 not in summarizer._scheduled


### PR DESCRIPTION
## Why

The "3-min ASSEMBLING YOUR BRIEFING" was a **stack** of Render cold-start *and* on-demand LLM summary generation: `/briefing` and `/clusters/{id}` called `summarize_cluster()` **inline** whenever a cluster's summary wasn't cached yet — up to 8 blocking LLM round-trips (24–64s) on a cold briefing. This PR makes the read paths never block on the LLM.

Pairs with the client SWR cache ([#127](https://github.com/Mr-Genesis/newslens/pull/127)): the cache paints instantly, and this makes the background revalidation *fast* once the backend is warm.

## What

- **`summarizer.snippet_summary()`** — the no-LLM fallback (first snippet, HTML-unescaped, ~2 sentences), extracted so it's shared by the read paths and `generate_cluster_summary`'s degradation text.
- **`summarizer.schedule_summary()`** — fire-and-forget background generation, **deduped per cluster**, gated by `eager_summaries_enabled`, with a strong task reference so it can't be GC-cancelled mid-run.
- **`/clusters/{id}` + `/briefing`** — return the snippet fallback **instantly** and schedule the real summary in the background. Critically, the snippet is **never persisted** (that would make `backfill_summaries` skip the real generation) — `get_cluster` uses a *local* response var because it commits read-marks.
- **`clustering.run_clustering()`** — eagerly schedules a summary the moment a new cluster forms, so on-demand becomes a rare cold path.
- **config** — `summary_batch_size` 5 → 12; `eager_summaries_enabled` kill-switch (off → still falls back to snippets, just no background warm).

## Adversarial review

Find→verify review across 3 dimensions. Read-path persistence dimension was **clean**. Two confirmed findings (same root cause) folded in `5599c15`:

| Sev | Finding | Fix |
|---|---|---|
| MED/LOW | Fire-and-forget task reference discarded → `asyncio` holds only a weak ref → GC could cancel the background summary mid-run | Module-level `_tasks` set + `add_done_callback`; regression test |

**Refuted (documented, no change):** an uncapped concurrent-summary burst vs. the tight free-tier Gemini quota — verified that `llm.generate` degrades gracefully on 429 and `schedule_summary` dedupes per cluster, so there's no self-perpetuating quota loop and no semaphore is warranted.

## Test

- **518 passed, 1 skipped** (full backend suite; +9 new: snippet fallback, scheduler dedupe/gate/strong-ref, non-blocking read paths, eager clustering). Ruff clean.
- Verified in the Dockerized test harness (backend can't run natively on Windows-ARM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
