### PR TITLE
Unify interests ↔ topic follows (backend) + adversarial-review hardening

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1684,6 +1684,7 @@ async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)
     if body.locale is not None:
         u.locale = body.locale.strip() or "IN"
     new_topic_ids: list[int] = []
+    interest_names: set[str] = set()
     if body.interests is not None:
         await db.execute(
             UserPreference.__table__.delete().where(
@@ -1694,6 +1695,7 @@ async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)
             name = raw.strip()
             if not name:
                 continue
+            interest_names.add(name)
             topic = (
                 await db.execute(select(Topic).where(Topic.name == name))
             ).scalar_one_or_none()
@@ -1705,6 +1707,25 @@ async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)
             db.add(
                 UserPreference(user_id=current_user_id(), topic_id=topic.id, weight=1.0)
             )
+        # Unify interests ↔ topic follows: ensure a topic follow for each interest, drop topic follows
+        # whose topic is no longer an interest — so "News You Follow" mirrors the user's topics.
+        existing_follows = (
+            await db.execute(
+                select(Follow).where(
+                    Follow.user_id == current_user_id(), Follow.kind == "topic"
+                )
+            )
+        ).scalars().all()
+        have = {ef.value for ef in existing_follows}
+        for nm in interest_names:
+            if nm not in have:
+                db.add(Follow(user_id=current_user_id(), kind="topic", value=nm))
+        for ef in existing_follows:
+            if ef.value not in interest_names:
+                await db.delete(ef)
+        from app.services import rails as _rails
+
+        _rails.invalidate(current_user_id())
     if body.watchlist is not None:
         u.watchlist = [w.model_dump() for w in body.watchlist]
     if body.depth_pref is not None:
@@ -1973,6 +1994,15 @@ async def list_follows(db: AsyncSession = Depends(get_db)):
     return [FollowOut.model_validate(f) for f in rows]
 
 
+async def _get_or_create_topic(db: AsyncSession, name: str) -> Topic:
+    t = (await db.execute(select(Topic).where(Topic.name == name))).scalar_one_or_none()
+    if t is None:
+        t = Topic(name=name)
+        db.add(t)
+        await db.flush()
+    return t
+
+
 @router.post("/follows", response_model=FollowOut, status_code=201, dependencies=[Depends(get_current_user)])
 async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
     from fastapi import HTTPException
@@ -2057,6 +2087,24 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
                 )
                 await db.commit()
             logger.info("entity_follow_resolved", value=value, entity_id=eid)
+    if kind == "topic":
+        # Unify: a followed topic is also an INTEREST (drives feed personalization + the topic chips),
+        # and gets a background article backfill so its "News You Follow" rail has content right away.
+        topic = await _get_or_create_topic(db, value)
+        has_pref = (
+            await db.execute(
+                select(UserPreference.id).where(
+                    UserPreference.user_id == current_user_id(),
+                    UserPreference.topic_id == topic.id,
+                )
+            )
+        ).scalar_one_or_none()
+        if has_pref is None:
+            db.add(UserPreference(user_id=current_user_id(), topic_id=topic.id, weight=1.0))
+            await db.commit()
+        from app.services.fetcher import schedule_topic_backfill
+
+        schedule_topic_backfill(topic.id)
     return FollowOut.model_validate(f)
 
 
@@ -2070,6 +2118,16 @@ async def delete_follow(follow_id: int, db: AsyncSession = Depends(get_db)):
         )
     ).scalar_one_or_none()
     if f is not None:
+        if f.kind == "topic":
+            # Unify: unfollowing a topic also drops the matching interest.
+            t = (await db.execute(select(Topic).where(Topic.name == f.value))).scalar_one_or_none()
+            if t is not None:
+                await db.execute(
+                    UserPreference.__table__.delete().where(
+                        UserPreference.user_id == current_user_id(),
+                        UserPreference.topic_id == t.id,
+                    )
+                )
         await db.delete(f)
         await db.commit()
         from app.services import rails as _rails

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2,6 +2,7 @@ import structlog
 from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -1684,7 +1685,7 @@ async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)
     if body.locale is not None:
         u.locale = body.locale.strip() or "IN"
     new_topic_ids: list[int] = []
-    interest_names: set[str] = set()
+    canonical_names: set[str] = set()  # the canonical Topic.name for each requested interest
     if body.interests is not None:
         await db.execute(
             UserPreference.__table__.delete().where(
@@ -1695,20 +1696,17 @@ async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)
             name = raw.strip()
             if not name:
                 continue
-            interest_names.add(name)
-            topic = (
-                await db.execute(select(Topic).where(Topic.name == name))
-            ).scalar_one_or_none()
-            if not topic:
-                topic = Topic(name=name)
-                db.add(topic)
-                await db.flush()
-                new_topic_ids.append(topic.id)
-            db.add(
-                UserPreference(user_id=current_user_id(), topic_id=topic.id, weight=1.0)
+            topic, created = await _get_or_create_topic(db, name)  # case-insensitive + race-safe
+            canonical_names.add(topic.name)
+            if created:
+                new_topic_ids.append(topic.id)  # only brand-new topics need an article backfill
+            await db.execute(
+                pg_insert(UserPreference)
+                .values(user_id=current_user_id(), topic_id=topic.id, weight=1.0)
+                .on_conflict_do_nothing(constraint="uq_user_topic_pref")
             )
-        # Unify interests ↔ topic follows: ensure a topic follow for each interest, drop topic follows
-        # whose topic is no longer an interest — so "News You Follow" mirrors the user's topics.
+        # Unify interests ↔ topic follows: mirror the canonical interest set into topic follows
+        # (case-insensitively, so 'AI'/'ai' never fork into two rails), dropping follows no longer wanted.
         existing_follows = (
             await db.execute(
                 select(Follow).where(
@@ -1716,12 +1714,13 @@ async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)
                 )
             )
         ).scalars().all()
-        have = {ef.value for ef in existing_follows}
-        for nm in interest_names:
-            if nm not in have:
+        have_lower = {ef.value.lower() for ef in existing_follows}
+        for nm in canonical_names:
+            if nm.lower() not in have_lower:
                 db.add(Follow(user_id=current_user_id(), kind="topic", value=nm))
+        wanted_lower = {n.lower() for n in canonical_names}
         for ef in existing_follows:
-            if ef.value not in interest_names:
+            if ef.value.lower() not in wanted_lower:
                 await db.delete(ef)
         from app.services import rails as _rails
 
@@ -1748,18 +1747,38 @@ async def update_profile(body: ProfileUpdate, db: AsyncSession = Depends(get_db)
 
 @router.post("/profile/backfill-topics", dependencies=[Depends(get_current_user)])
 async def backfill_my_topics(db: AsyncSession = Depends(get_db)):
-    """Kick a background article→topic backfill for EVERY topic the caller subscribes to — for topics
-    that were subscribed BEFORE the on-subscribe auto-backfill existed (so they still show 0 articles).
-    Idempotent + deduped; returns how many were scheduled."""
+    """Repair + backfill the caller's topics. First RECONCILE legacy topic follows into interests:
+    topics followed before unify (e.g. seeded as follows-only) have no UserPreference, so they never
+    reach Your Topics / feed rank and the re-follow early-return can't self-heal them — insert the
+    missing interest for each. THEN kick a background article→topic backfill for every subscribed topic
+    (topics subscribed before the on-subscribe auto-backfill still show 0 articles). Idempotent + deduped."""
     from app.services.fetcher import schedule_topic_backfill
 
-    topic_ids = (
+    uid = current_user_id()
+    # Reconcile: every kind='topic' Follow should have a matching interest.
+    follows = (
         await db.execute(
-            select(UserPreference.topic_id).where(UserPreference.user_id == current_user_id())
+            select(Follow).where(Follow.user_id == uid, Follow.kind == "topic")
         )
     ).scalars().all()
+    reconciled = 0
+    for fl in follows:
+        topic, _created = await _get_or_create_topic(db, fl.value)
+        res = await db.execute(
+            pg_insert(UserPreference)
+            .values(user_id=uid, topic_id=topic.id, weight=1.0)
+            .on_conflict_do_nothing(constraint="uq_user_topic_pref")
+        )
+        if res.rowcount:
+            reconciled += 1
+    if reconciled:
+        await db.commit()
+
+    topic_ids = (
+        await db.execute(select(UserPreference.topic_id).where(UserPreference.user_id == uid))
+    ).scalars().all()
     scheduled = sum(1 for tid in topic_ids if schedule_topic_backfill(tid) is not None)
-    return {"topics": len(topic_ids), "scheduled": scheduled}
+    return {"topics": len(topic_ids), "scheduled": scheduled, "reconciled": reconciled}
 
 
 # ── E1: per-user Gemini key ──
@@ -1994,13 +2013,60 @@ async def list_follows(db: AsyncSession = Depends(get_db)):
     return [FollowOut.model_validate(f) for f in rows]
 
 
-async def _get_or_create_topic(db: AsyncSession, name: str) -> Topic:
-    t = (await db.execute(select(Topic).where(Topic.name == name))).scalar_one_or_none()
-    if t is None:
-        t = Topic(name=name)
-        db.add(t)
-        await db.flush()
-    return t
+async def _get_or_create_topic(db: AsyncSession, name: str) -> tuple[Topic, bool]:
+    """Case-INSENSITIVE get-or-create → (topic, created). Returns the canonical existing Topic when the
+    name matches case-insensitively (rails match Topic.name via lower(), so the write paths must too, or
+    'AI'/'ai' fork into two Topic rows + two rails). Race-safe: a concurrent create is absorbed by
+    ON CONFLICT DO NOTHING and we re-SELECT the winner (mirrors the auth.py User-creation guard)."""
+    t = (
+        await db.execute(select(Topic).where(func.lower(Topic.name) == name.lower()))
+    ).scalars().first()
+    if t is not None:
+        return t, False
+    await db.execute(
+        pg_insert(Topic).values(name=name).on_conflict_do_nothing(index_elements=["name"])
+    )
+    t = (
+        await db.execute(select(Topic).where(func.lower(Topic.name) == name.lower()))
+    ).scalars().first()
+    return t, True
+
+
+async def _sync_topic_follow(db: AsyncSession, name: str) -> "FollowOut":
+    """Create/repair a topic follow AND its unified UserPreference interest in ONE transaction,
+    idempotently and case-insensitively. Self-heals: re-following a topic that has a Follow but no
+    interest (the legacy pre-unify shape) inserts the missing UserPreference instead of no-op'ing at
+    the idempotency check. Stores the canonical Topic.name as the follow value so the two never drift."""
+    uid = current_user_id()
+    topic, _created = await _get_or_create_topic(db, name)
+    # Interest (idempotent + race-safe) — the unify half that drives Your Topics / chips / feed rank.
+    await db.execute(
+        pg_insert(UserPreference)
+        .values(user_id=uid, topic_id=topic.id, weight=1.0)
+        .on_conflict_do_nothing(constraint="uq_user_topic_pref")
+    )
+    # Follow (idempotent by case-insensitive value; canonical Topic.name).
+    f = (
+        await db.execute(
+            select(Follow).where(
+                Follow.user_id == uid,
+                Follow.kind == "topic",
+                func.lower(Follow.value) == topic.name.lower(),
+            )
+        )
+    ).scalars().first()
+    if f is None:
+        f = Follow(user_id=uid, kind="topic", value=topic.name)
+        db.add(f)
+    await db.commit()
+    await db.refresh(f)
+    from app.services import rails as _rails
+
+    _rails.invalidate(uid)
+    from app.services.fetcher import schedule_topic_backfill
+
+    schedule_topic_backfill(topic.id)
+    return FollowOut.model_validate(f)
 
 
 @router.post("/follows", response_model=FollowOut, status_code=201, dependencies=[Depends(get_current_user)])
@@ -2011,6 +2077,11 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
     value = (body.value or "").strip()
     if kind not in _FOLLOW_KINDS or not value:
         raise HTTPException(status_code=400, detail="invalid kind or empty value")
+    # Unify: a topic follow is handled end-to-end (follow + interest, one transaction, self-healing,
+    # case-insensitive) so it never falls through the generic idempotent early-return below — which
+    # would otherwise skip the interest repair for an already-followed topic.
+    if kind == "topic":
+        return await _sync_topic_follow(db, value)
     # #81: a source-follow must reference a real source (value = source id) — 404 otherwise, so a
     # typo can't create a dangling opt-in that silently does nothing.
     if kind == "source":
@@ -2087,24 +2158,6 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
                 )
                 await db.commit()
             logger.info("entity_follow_resolved", value=value, entity_id=eid)
-    if kind == "topic":
-        # Unify: a followed topic is also an INTEREST (drives feed personalization + the topic chips),
-        # and gets a background article backfill so its "News You Follow" rail has content right away.
-        topic = await _get_or_create_topic(db, value)
-        has_pref = (
-            await db.execute(
-                select(UserPreference.id).where(
-                    UserPreference.user_id == current_user_id(),
-                    UserPreference.topic_id == topic.id,
-                )
-            )
-        ).scalar_one_or_none()
-        if has_pref is None:
-            db.add(UserPreference(user_id=current_user_id(), topic_id=topic.id, weight=1.0))
-            await db.commit()
-        from app.services.fetcher import schedule_topic_backfill
-
-        schedule_topic_backfill(topic.id)
     return FollowOut.model_validate(f)
 
 
@@ -2119,8 +2172,11 @@ async def delete_follow(follow_id: int, db: AsyncSession = Depends(get_db)):
     ).scalar_one_or_none()
     if f is not None:
         if f.kind == "topic":
-            # Unify: unfollowing a topic also drops the matching interest.
-            t = (await db.execute(select(Topic).where(Topic.name == f.value))).scalar_one_or_none()
+            # Unify: unfollowing a topic also drops the matching interest. Case-insensitive resolve so
+            # a legacy follow whose value differs in case from the canonical Topic.name still matches.
+            t = (
+                await db.execute(select(Topic).where(func.lower(Topic.name) == f.value.lower()))
+            ).scalars().first()
             if t is not None:
                 await db.execute(
                     UserPreference.__table__.delete().where(

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -29,6 +29,23 @@ TEST_DB_URL = os.getenv(
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_bg_fire_and_forget(monkeypatch):
+    """Disable per-request fire-and-forget background jobs in the integration harness.
+
+    ``schedule_topic_backfill`` (fired from POST /follows and PUT /profile) spawns an
+    ``asyncio.create_task`` that opens its OWN ``async_session()`` — a real pool connection
+    OUTSIDE the per-test outer transaction — and makes a network embedding call. When the
+    per-test event loop tears down mid-flight, that connection is left ``idle in transaction``
+    and later deadlocks ``test_foundation``'s ``DROP SCHEMA public CASCADE``. Off by default:
+    the scheduler + backfill are covered directly (``backfill_topic_articles``) or via a stubbed
+    ``schedule_topic_backfill``; the one test that exercises a real task opts back in.
+    """
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "topic_backfill_enabled", False, raising=False)
+
+
 @pytest_asyncio.fixture
 async def engine():
     eng = create_async_engine(TEST_DB_URL, future=True)

--- a/backend/tests/integration/test_topic_backfill.py
+++ b/backend/tests/integration/test_topic_backfill.py
@@ -226,5 +226,5 @@ async def test_backfill_my_topics_endpoint_schedules_all_subscriptions(aclient, 
 
     r = await aclient.post("/profile/backfill-topics")
     assert r.status_code == 200
-    assert r.json() == {"topics": 2, "scheduled": 2}
+    assert r.json() == {"topics": 2, "scheduled": 2, "reconciled": 0}  # interests only, no legacy follows
     assert set(scheduled) == {t1.id, t2.id}

--- a/backend/tests/integration/test_topic_backfill.py
+++ b/backend/tests/integration/test_topic_backfill.py
@@ -99,6 +99,9 @@ async def test_backfill_keyword_fallback_on_topic_name(db_session):
 
 @pytest.mark.asyncio
 async def test_schedule_topic_backfill_dedupes_and_runs_once(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "topic_backfill_enabled", True)  # opt back in (conftest disables it)
     calls = []
 
     async def fake_backfill(session, tid):

--- a/backend/tests/integration/test_unify_topics_follows.py
+++ b/backend/tests/integration/test_unify_topics_follows.py
@@ -1,8 +1,9 @@
 """Unify interests ↔ topic follows: following a topic makes it an interest (+ backfill), unfollowing
 drops the interest, and setting profile interests keeps the topic follows ("News You Follow") in sync."""
 import pytest
+from sqlalchemy import func, select
 
-from app.models import User
+from app.models import Follow, Topic, User, UserPreference
 from app.services import fetcher
 
 DEFAULT_USER = 1
@@ -12,6 +13,26 @@ async def _ensure_user(db, uid=DEFAULT_USER):
     if not await db.get(User, uid):
         db.add(User(id=uid))
         await db.flush()
+
+
+async def _legacy_topic_follow(db, name, uid=DEFAULT_USER):
+    """A topic Follow + its Topic row but NO UserPreference — the pre-unify prod shape
+    (topics were follows-only). Used to test that re-follow / backfill repair the missing interest."""
+    t = Topic(name=name)
+    db.add(t)
+    await db.flush()
+    db.add(Follow(user_id=uid, kind="topic", value=name))
+    await db.flush()
+    return t
+
+
+async def _interests(aclient):
+    return set((await aclient.get("/profile")).json()["interests"])
+
+
+async def _topic_follow_values(aclient):
+    rows = (await aclient.get("/follows")).json()
+    return [f["value"] for f in rows if f["kind"] == "topic"]
 
 
 @pytest.mark.asyncio
@@ -55,3 +76,75 @@ async def test_setting_interests_syncs_topic_follows(aclient, db_session, monkey
     # drop Beta, add Gamma → follows reconcile to match the new interest set
     await aclient.put("/profile", json={"interests": ["Alpha Topic", "Gamma Topic"]})
     assert await topic_follows() == {"Alpha Topic", "Gamma Topic"}
+
+
+# ── Review fixes (adversarial review of 5762739) ──
+
+
+@pytest.mark.asyncio
+async def test_refollow_existing_topic_repairs_missing_interest(aclient, db_session, monkeypatch):
+    """Finding 1: the idempotent early-return must SELF-HEAL — re-following a topic that has a Follow
+    but no UserPreference (the legacy prod shape) creates the missing interest instead of no-op'ing."""
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+    await _legacy_topic_follow(db_session, "Legacy Topic")
+    await db_session.commit()
+    assert "Legacy Topic" not in await _interests(aclient)  # precondition: orphan follow, no interest
+
+    r = await aclient.post("/follows", json={"kind": "topic", "value": "Legacy Topic"})
+    assert r.status_code == 201
+    assert "Legacy Topic" in await _interests(aclient)  # re-follow repaired the interest
+    assert await _topic_follow_values(aclient) == ["Legacy Topic"]  # no duplicate follow
+
+
+@pytest.mark.asyncio
+async def test_follow_topic_is_case_insensitive_no_duplicates(aclient, db_session, monkeypatch):
+    """Finding 2: following 'AI' then 'ai' must NOT create a second Topic / interest / follow / rail —
+    write paths match case-insensitively and reuse the canonical Topic.name."""
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+
+    assert (await aclient.post("/follows", json={"kind": "topic", "value": "AI"})).status_code == 201
+    assert (await aclient.post("/follows", json={"kind": "topic", "value": "ai"})).status_code == 201
+
+    assert await _topic_follow_values(aclient) == ["AI"]  # one canonical follow, not two
+    assert await _interests(aclient) == {"AI"}  # one canonical interest
+    topic_rows = (
+        await db_session.execute(select(func.count()).select_from(Topic).where(func.lower(Topic.name) == "ai"))
+    ).scalar()
+    assert topic_rows == 1  # one Topic row, not two case-variants
+
+
+@pytest.mark.asyncio
+async def test_delete_topic_follow_removes_interest_case_insensitively(aclient, db_session, monkeypatch):
+    """Finding 2 (delete path): a follow whose value differs in case from the Topic.name must still
+    resolve the Topic and drop the interest."""
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+    t = Topic(name="Robotics")
+    db_session.add(t)
+    await db_session.flush()
+    db_session.add(UserPreference(user_id=DEFAULT_USER, topic_id=t.id, weight=1.0))
+    f = Follow(user_id=DEFAULT_USER, kind="topic", value="robotics")  # lower-case value vs 'Robotics'
+    db_session.add(f)
+    await db_session.flush()
+    await db_session.commit()
+
+    assert (await aclient.delete(f"/follows/{f.id}")).status_code == 204
+    assert "Robotics" not in await _interests(aclient)
+
+
+@pytest.mark.asyncio
+async def test_backfill_topics_reconciles_legacy_follow_without_interest(aclient, db_session, monkeypatch):
+    """Finding 5: POST /profile/backfill-topics must repair EVERY legacy topic follow that has no
+    interest (e.g. user 1's 7 topics seeded as follows before unify), inserting the missing UserPreference."""
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+    await _legacy_topic_follow(db_session, "Seeded A")
+    await _legacy_topic_follow(db_session, "Seeded B")
+    await db_session.commit()
+    assert await _interests(aclient) == set()  # legacy follows, zero interests
+
+    r = await aclient.post("/profile/backfill-topics")
+    assert r.status_code == 200
+    assert await _interests(aclient) == {"Seeded A", "Seeded B"}  # follows reconciled into interests

--- a/backend/tests/integration/test_unify_topics_follows.py
+++ b/backend/tests/integration/test_unify_topics_follows.py
@@ -1,0 +1,57 @@
+"""Unify interests ↔ topic follows: following a topic makes it an interest (+ backfill), unfollowing
+drops the interest, and setting profile interests keeps the topic follows ("News You Follow") in sync."""
+import pytest
+
+from app.models import User
+from app.services import fetcher
+
+DEFAULT_USER = 1
+
+
+async def _ensure_user(db, uid=DEFAULT_USER):
+    if not await db.get(User, uid):
+        db.add(User(id=uid))
+        await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_follow_topic_creates_interest_and_schedules_backfill(aclient, db_session, monkeypatch):
+    scheduled = []
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: scheduled.append(tid))
+    await _ensure_user(db_session)
+
+    r = await aclient.post("/follows", json={"kind": "topic", "value": "Quantum Computing"})
+    assert r.status_code == 201
+    # following a topic makes it an interest (get_profile reads UserPreference → Topic names)
+    assert "Quantum Computing" in (await aclient.get("/profile")).json()["interests"]
+    # and schedules the article backfill so the rail has content
+    assert len(scheduled) == 1
+
+
+@pytest.mark.asyncio
+async def test_unfollow_topic_removes_interest(aclient, db_session, monkeypatch):
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+
+    fid = (await aclient.post("/follows", json={"kind": "topic", "value": "Fusion Energy"})).json()["id"]
+    assert "Fusion Energy" in (await aclient.get("/profile")).json()["interests"]
+
+    assert (await aclient.delete(f"/follows/{fid}")).status_code == 204
+    assert "Fusion Energy" not in (await aclient.get("/profile")).json()["interests"]
+
+
+@pytest.mark.asyncio
+async def test_setting_interests_syncs_topic_follows(aclient, db_session, monkeypatch):
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+
+    async def topic_follows():
+        rows = (await aclient.get("/follows")).json()
+        return {f["value"] for f in rows if f["kind"] == "topic"}
+
+    await aclient.put("/profile", json={"interests": ["Alpha Topic", "Beta Topic"]})
+    assert await topic_follows() == {"Alpha Topic", "Beta Topic"}  # interests → follows
+
+    # drop Beta, add Gamma → follows reconcile to match the new interest set
+    await aclient.put("/profile", json={"interests": ["Alpha Topic", "Gamma Topic"]})
+    assert await topic_follows() == {"Alpha Topic", "Gamma Topic"}


### PR DESCRIPTION
## Unify B (backend): interests ↔ topic follows are one list

NewsLens modeled topics in two disjoint tables — `UserPreference` (interests: Your Topics, topic chips, feed explore/exploit rank) and `follows(kind='topic')` (the "News You Follow" rails). Following a topic touched one; setting interests touched the other. They drifted, and the dev user's 7 seeded topics showed rails but weren't interests. This makes them **one list**.

### What changed
- **POST /follows {kind:topic}** → `_sync_topic_follow`: creates the follow **and** the `UserPreference` interest in one transaction, then schedules the article backfill so the rail has content fast.
- **DELETE /follows/{id}** (topic) → also drops the matching interest.
- **PUT /profile** → reconciles topic follows to mirror the interest set (add missing, drop removed).
- **POST /profile/backfill-topics** → now also **reconciles legacy topic follows into interests** (repairs pre-unify follows-only topics, incl. the dev user's 7) + backfills articles.

### Adversarial review (find → verify), fixes folded in
A 4-lens review (20 agents) surfaced 16 findings; 9 verified. The 6 backend ones are fixed in `b6219af`:
| # | Sev | Fix |
|---|-----|-----|
| 1 | med | **Self-healing re-follow** — topic path runs before the idempotent early-return, so re-following repairs a missing interest |
| 3 | med | **Single transaction** — follow + interest commit together (no orphan on mid-failure) |
| 2 | med | **Case-insensitive** topic/follow matching (canonical `Topic.name`) — `AI`/`ai` no longer fork into two topics/rails |
| 4,6 | med/low | **`ON CONFLICT DO NOTHING`** on topic + interest inserts (house pattern) — concurrent same-name create no longer 500s |
| 5 | med | **Legacy reconcile** in `/profile/backfill-topics` |

Also fixed a **test-harness deadlock** the earlier suite runs were hitting: `schedule_topic_backfill` is a per-request fire-and-forget that opens its own pool connection (outside the per-test transaction) and makes a network call; wiring it into `create_follow` made dozens of tests spawn those tasks, leaking `idle in transaction` connections at loop-teardown that deadlocked `test_foundation`'s `DROP SCHEMA`. New autouse fixture gates it off in the integration harness.

### Tests
`548 passed, 1 skipped` — +4 regression tests (self-heal re-follow, case-insensitive follow, case-insensitive delete, legacy backfill reconcile).

### Deferred (tracked separately, not in this PR)
- **HIGH (frontend)** — Settings topic toggle full-replaces from stale `localStorage`, which (with this PR's follow-reconcile) can wipe curated interests + follows on one tap from a fresh device/Capacitor. Fixed in the **Unify A** frontend PR (seed the toggle from server truth).
- Swipe path interest→follow mirroring (needs a negative-swipe product call).
- `saved_search` vs `topic` duplicate-rail dedupe (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
