### PR TITLE
fix(rails): dedupe "News You Follow" rails across kinds on a shared value

### DIFF
--- a/backend/app/services/rails.py
+++ b/backend/app/services/rails.py
@@ -286,6 +286,32 @@ async def _cluster_id_since(db: AsyncSession, cluster_ids: list[int]):
     return {s.id: s for s in story_rows}, meta
 
 
+# Kind priority when two follows collide on a normalized value: keep the most precise rail. A `topic`
+# rail is an exact ArticleTopic membership match; an `entity` rail is a resolved-entity match; a
+# `saved_search` rail is a fuzzy hybrid over the same words. So topic > entity > saved_search.
+_KIND_PRIORITY = {"topic": 0, "entity": 1, "saved_search": 2}
+
+
+def _dedupe_follows(follows: list[Follow]) -> list[Follow]:
+    """Collapse rail-able follows that share a value (case-insensitively) ACROSS kinds, so "News You
+    Follow" never renders two rails with an identical header. This collision is legal — uq_follow keys
+    on (user_id, kind, value), so a `topic` 'AI' and a `saved_search` 'AI' are two distinct rows — and
+    the interests↔topic-follow unify makes it likely: chips/onboarding auto-create the `topic` follow
+    while /follows and "Follow this search" create a `saved_search` follow on the SAME free text.
+
+    Keep the highest-priority kind per normalized value (topic beats saved_search — see _KIND_PRIORITY);
+    same-priority ties keep the first seen, which is the newest since `follows` arrive created_at desc.
+    Input order is otherwise preserved (each surviving follow stays at its own position)."""
+    winner: dict[str, Follow] = {}
+    for f in follows:
+        key = (f.value or "").strip().lower()
+        cur = winner.get(key)
+        if cur is None or _KIND_PRIORITY.get(f.kind, 99) < _KIND_PRIORITY.get(cur.kind, 99):
+            winner[key] = f
+    kept = {f.id for f in winner.values()}
+    return [f for f in follows if f.id in kept]
+
+
 async def rails_for_user(db: AsyncSession, user_id: int) -> list[dict]:
     """The whole "News You Follow" payload for a user: one rail per rail-able follow, newest-first,
     each with ≤N stories in the 72h window and a badge new_count. Source follows are excluded.
@@ -312,6 +338,10 @@ async def rails_for_user(db: AsyncSession, user_id: int) -> list[dict]:
             .order_by(Follow.created_at.desc())
         )
     ).scalars().all()
+    # Collapse cross-kind collisions on the same value (e.g. topic 'AI' + saved_search 'AI') so we
+    # don't render two rails with an identical header. Do it BEFORE building so the dropped follow's
+    # eval never runs.
+    follows = _dedupe_follows(follows)
 
     rails: list[dict] = []
     for f in follows:

--- a/backend/tests/integration/test_rails.py
+++ b/backend/tests/integration/test_rails.py
@@ -200,3 +200,22 @@ async def test_invalidate_mid_build_skips_stale_cache_write(db_session, monkeypa
     await rails_svc.rails_for_user(db_session, 1)
     # The generation advanced during the build → the stale result was NOT cached.
     assert 1 not in rails_svc._cache
+
+
+@pytest.mark.asyncio
+async def test_topic_and_saved_search_same_value_dedupe_to_one_rail(aclient, db_session):
+    """Adversarial-review fix: a `topic` follow and a `saved_search` follow may legally share a value
+    (uq_follow keys on kind too), which the interests↔topic-follow unify makes likely. Rails must
+    collapse them to a SINGLE 'AI' header, keeping the precise topic rail — not render two identical
+    headers over overlapping clusters."""
+    await _ensure_user(db_session)
+    c, _ = await _story(db_session, "AI breakthrough", topic="AI")
+    db_session.add(Follow(user_id=1, kind="topic", value="AI"))
+    db_session.add(Follow(user_id=1, kind="saved_search", value="AI"))
+    await db_session.flush()
+
+    rails = (await aclient.get("/follows/rails")).json()["rails"]
+    ai_rails = [x for x in rails if x["value"].strip().lower() == "ai"]
+    assert len(ai_rails) == 1                                   # collapsed, not two identical headers
+    assert ai_rails[0]["kind"] == "topic"                       # kept the precise ArticleTopic match
+    assert {s["cluster_id"] for s in ai_rails[0]["stories"]} == {c.id}


### PR DESCRIPTION
## Problem

A user can legally hold **both** a `kind='topic'` follow and a `kind='saved_search'` follow with the **same value** (e.g. `"AI"`). `uq_follow` keys on `(user_id, kind, value)`, so a different `kind` means both rows are valid. `rails.rails_for_user` (backend/app/services/rails.py) looped every rail-able follow with **no cross-kind dedupe**, so "News You Follow" rendered **two rails with an identical header** ("AI") over overlapping clusters.

The recent **interests↔topic-follow unify** makes this collision much more likely: onboarding + interest chips now auto-create the `topic` follow, while `/follows` and search's "Follow this search" create a `saved_search` follow on the **same free text**.

## Fix

Collapse rail-able follows by **normalized (lower-cased) value across kinds**, *before* building the rails:

- Keep the highest-priority kind per normalized value: **topic > entity > saved_search**. A `topic` rail is an exact `ArticleTopic` membership match, so it wins over the fuzzy hybrid `saved_search` — as called out in the review.
- Same-priority ties keep the first seen (newest, since follows arrive `created_at desc`).
- Deduping *before* the per-follow eval also skips the dropped follow's (potentially expensive) hybrid query.
- Kept in `rails.rails_for_user` — a small `_dedupe_follows` helper + one call site. No schema/API change.

## Test

New integration test in `tests/integration/test_rails.py`:
`test_topic_and_saved_search_same_value_dedupe_to_one_rail` — with both a `topic` 'AI' and a `saved_search` 'AI' follow, `GET /follows/rails` returns a **single** 'AI' rail, and it's the `topic` one.

Verified the test **fails without the fix** (`assert 2 == 1` — two 'AI' rails) and **passes with it**.

## Verification (Docker, container `dreamy_franklin`)

- New rails test: pass
- `tests/integration/test_rails.py`: 9 passed
- **Full backend suite: 542 passed, 1 skipped** (skip + warnings pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)