### PR TITLE
Refresh topics + News You Follow without relaunch; fix settings topic-wipe (Unify A)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -17,7 +17,7 @@ import { FollowRails } from "@/components/FollowRails";
 import { InfiniteFeed } from "@/components/InfiniteFeed";
 import { useImpressions } from "@/hooks/useImpressions";
 import { AnimatedMark } from "@/components/SplashScreen";
-import { getBriefing, getTopics, type Briefing, type BriefingStory, type Topic } from "@/lib/api";
+import { getBriefing, getTopics, type Briefing, type BriefingStory, type TopicsResponse } from "@/lib/api";
 import { useCachedResource } from "@/hooks/useCachedResource";
 import { usePrefetchClusters } from "@/hooks/usePrefetchClusters";
 import { CACHE_TTL_MS } from "@/lib/cache";
@@ -48,12 +48,13 @@ const staggerContainer = {
 
 export default function BriefingPage() {
   const [activeCategory, setActiveCategory] = useState<string>("All");
-  const [userTopics, setUserTopics] = useState<Topic[]>([]);
   // WS-3 (#113): cross-section dedupe — cluster ids the rails render, lifted up so the "All stories"
   // feed can filter them out (precedence hero > rails > categories > feed). And a key that pull-to-
   // refresh bumps to remount the feed with a fresh as_of cursor.
   const [railClusterIds, setRailClusterIds] = useState<number[]>([]);
   const [feedKey, setFeedKey] = useState(0);
+  // Unify A: pull-to-refresh bumps this so FollowRails re-fetches without an app relaunch.
+  const [railsRefresh, setRailsRefresh] = useState(0);
   const router = useRouter();
   // WS-1: log which briefing stories were actually SEEN (>=50% for >=1s); tag taps with the surface.
   const { observe } = useImpressions("briefing");
@@ -68,6 +69,16 @@ export default function BriefingPage() {
     refresh,
   } = useCachedResource<Briefing>("briefing", getBriefing, { maxAgeMs: CACHE_TTL_MS.briefing });
 
+  // The user's topics come from the same two-tier cache: paint instantly, revalidate on foreground
+  // (WebView resume), and expose a refresh() that pull-to-refresh drives — so "Your Topics" reflects a
+  // follow/unfollow made elsewhere without an app relaunch.
+  const { data: topicsData, refresh: refreshTopics } = useCachedResource<TopicsResponse>(
+    "topics:home",
+    getTopics,
+    { maxAgeMs: CACHE_TTL_MS.topics }
+  );
+  const userTopics = useMemo(() => topicsData?.your_topics ?? [], [topicsData]);
+
   // Prefetch the top few story details while the briefing is on screen → tapping a card opens instantly.
   usePrefetchClusters(briefing?.stories.map((s) => s.cluster_id) ?? []);
 
@@ -80,19 +91,13 @@ export default function BriefingPage() {
         ? "error"
         : "loading";
 
-  // Pull-to-refresh / manual refresh: reset the feed's as_of cursor AND revalidate the briefing.
+  // Pull-to-refresh / manual refresh: reset the feed's as_of cursor AND revalidate the briefing, the
+  // topics, and the "News You Follow" rails together.
   const handleRefresh = useCallback(async () => {
     setFeedKey((k) => k + 1);
-    await refresh();
-  }, [refresh]);
-
-  // The user's topics (with real article counts) — chips shouldn't be limited to whatever
-  // categories happen to appear in today's 8 briefing stories.
-  useEffect(() => {
-    getTopics()
-      .then((t) => setUserTopics(t.your_topics ?? []))
-      .catch(() => setUserTopics([]));
-  }, []);
+    setRailsRefresh((k) => k + 1);
+    await Promise.all([refresh(), refreshTopics()]);
+  }, [refresh, refreshTopics]);
 
   // First-run: send new users through the intro (once per browser).
   useEffect(() => {
@@ -303,7 +308,7 @@ export default function BriefingPage() {
           )}
 
           {/* WS-2 (#112): News You Follow rails — renders nothing until the user has follows */}
-          <FollowRails onClusterIdsRendered={handleRailIds} />
+          <FollowRails onClusterIdsRendered={handleRailIds} refreshSignal={railsRefresh} />
 
           {/* Empty topic filter: the chip's topic has articles, just none in today's 8-story
               brief. Say so instead of rendering a blank page. */}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -78,7 +78,18 @@ export default function ProfilePage() {
         getTopics().catch(() => null),
       ]);
       if (statsData) setStats(statsData);
-      if (topicsData) setTopics(topicsData.your_topics);
+      if (topicsData) {
+        setTopics(topicsData.your_topics);
+        // Finding 7 fix (HIGH): seed the toggle set from SERVER truth, never stale localStorage /
+        // the 8 hardcoded defaults. toggleTopic PUTs this whole set as the full interests list, and
+        // PUT /profile is a full-replace that also reconciles topic follows — so on a fresh device /
+        // cleared storage / first Capacitor launch (empty localStorage → defaults), one tap would
+        // otherwise DELETE every real interest AND topic follow not in the default set. Seeding from
+        // the server makes a toggle a precise add/remove against the user's actual topics.
+        const serverInterests = topicsData.your_topics.map((t) => t.name);
+        setSelectedTopics(new Set(serverInterests));
+        localStorage.setItem("newslens-topics", JSON.stringify(serverInterests));
+      }
       setState("idle");
     } catch {
       setState("idle");

--- a/frontend/src/app/settings/settings.test.tsx
+++ b/frontend/src/app/settings/settings.test.tsx
@@ -1,0 +1,66 @@
+// Unify A / adversarial-review finding 7 (HIGH): the Settings topic toggle must operate on the
+// user's REAL server interests, never the stale localStorage / hardcoded-defaults set — otherwise one
+// tap on a fresh device (empty localStorage → 8 defaults) full-replaces and WIPES curated interests +
+// topic follows.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+vi.mock("next/link", () => ({ default: ({ children }: { children: ReactNode }) => children }));
+vi.mock("@/components/ThemeProvider", () => ({
+  useTheme: () => ({ theme: "dark", setTheme: vi.fn() }),
+}));
+vi.mock("@/components/ProfileFields", () => ({ ProfileFields: () => null }));
+vi.mock("@/components/ModelProviderCard", () => ({ ModelProviderCard: () => null }));
+vi.mock("@/components/AccountCard", () => ({ AccountCard: () => null }));
+vi.mock("@/components/SystemCard", () => ({ SystemCard: () => null }));
+vi.mock("@/lib/api", () => ({
+  getStats: vi.fn().mockResolvedValue(null),
+  getTopics: vi.fn(),
+  updateProfile: vi.fn().mockResolvedValue(undefined),
+}));
+
+import ProfilePage from "./page";
+import { getTopics, updateProfile } from "@/lib/api";
+
+const topic = (name: string) => ({ id: name, name, article_count: 5 });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear(); // fresh device: no persisted topics → the buggy path would fall back to defaults
+});
+
+describe("Settings topic toggle (finding 7)", () => {
+  it("toggling a topic off PUTs the server set minus that topic — never the stale hardcoded defaults", async () => {
+    vi.mocked(getTopics).mockResolvedValue({
+      your_topics: [topic("Physics"), topic("Fusion Energy"), topic("Quantum Computing")],
+      explore_topics: [],
+      trending_topics: [],
+    });
+
+    render(<ProfilePage />);
+    await userEvent.click(await screen.findByText("Physics")); // toggle OFF Physics
+
+    await waitFor(() => expect(updateProfile).toHaveBeenCalled());
+    const sent = vi.mocked(updateProfile).mock.calls[0][0].interests ?? [];
+    expect(new Set(sent)).toEqual(new Set(["Fusion Energy", "Quantum Computing"])); // kept the rest
+    expect(sent).not.toContain("Technology"); // did NOT resurrect the hardcoded defaults
+    expect(sent).not.toContain("Physics"); // removed the one tapped
+  });
+
+  it("toggling a topic on (no prior interests) PUTs only that topic, not the 8 defaults", async () => {
+    vi.mocked(getTopics).mockResolvedValue({
+      your_topics: [], // brand-new user, zero interests → chips fall back to the default catalog
+      explore_topics: [],
+      trending_topics: [],
+    });
+
+    render(<ProfilePage />);
+    await userEvent.click(await screen.findByText("Technology")); // pick one default
+
+    await waitFor(() => expect(updateProfile).toHaveBeenCalled());
+    const sent = vi.mocked(updateProfile).mock.calls[0][0].interests ?? [];
+    expect(sent).toEqual(["Technology"]); // exactly the one chosen, not all 8 defaults
+  });
+});

--- a/frontend/src/components/FollowRails.test.tsx
+++ b/frontend/src/components/FollowRails.test.tsx
@@ -25,6 +25,7 @@ const rail = (over = {}) => ({
 describe("FollowRails", () => {
   beforeEach(() => {
     push.mockReset();
+    vi.mocked(getFollowRails).mockClear();
     vi.mocked(markFollowSeen).mockClear().mockResolvedValue(undefined);
   });
 
@@ -76,5 +77,24 @@ describe("FollowRails", () => {
     vi.mocked(getFollowRails).mockResolvedValue([rail()]);
     render(<FollowRails onClusterIdsRendered={onIds} />);
     await waitFor(() => expect(onIds).toHaveBeenCalledWith([10, 11]));
+  });
+
+  // Unify A: refresh without an app relaunch.
+  it("re-fetches when refreshSignal changes (pull-to-refresh)", async () => {
+    vi.mocked(getFollowRails).mockResolvedValue([rail()]);
+    const { rerender } = render(<FollowRails refreshSignal={0} />);
+    await screen.findByText("US Iran war");
+    expect(getFollowRails).toHaveBeenCalledTimes(1);
+    rerender(<FollowRails refreshSignal={1} />); // pull-to-refresh bumps the signal
+    await waitFor(() => expect(getFollowRails).toHaveBeenCalledTimes(2));
+  });
+
+  it("re-fetches on foreground (visibilitychange → visible)", async () => {
+    vi.mocked(getFollowRails).mockResolvedValue([rail()]);
+    render(<FollowRails />);
+    await screen.findByText("US Iran war");
+    expect(getFollowRails).toHaveBeenCalledTimes(1);
+    document.dispatchEvent(new Event("visibilitychange")); // jsdom visibilityState defaults to 'visible'
+    await waitFor(() => expect(getFollowRails).toHaveBeenCalledTimes(2));
   });
 });

--- a/frontend/src/components/FollowRails.tsx
+++ b/frontend/src/components/FollowRails.tsx
@@ -69,18 +69,21 @@ function RailPanel({ rail, onOpen }: { rail: FollowRail; onOpen: (r: FollowRail,
 
 export function FollowRails({
   onClusterIdsRendered,
+  refreshSignal = 0,
 }: {
   /** WS-3 (#113): report the cluster ids these rails render so the home feed can dedupe them out
    *  (cross-section precedence hero > rails > categories > feed). */
   onClusterIdsRendered?: (ids: number[]) => void;
+  /** Unify A: bump to force a re-fetch (pull-to-refresh from the home page). */
+  refreshSignal?: number;
 } = {}) {
   const router = useRouter();
   const [rails, setRails] = useState<FollowRail[] | null>(null);
-  // Ref so the single-fetch mount effect always calls the latest callback without re-fetching.
+  // Ref so the fetch effect always calls the latest callback without re-fetching on every render.
   const onIdsRef = useRef(onClusterIdsRendered);
   onIdsRef.current = onClusterIdsRendered;
 
-  useEffect(() => {
+  const load = useCallback(() => {
     getFollowRails()
       .then((rs) => {
         setRails(rs);
@@ -88,6 +91,23 @@ export function FollowRails({
       })
       .catch(() => setRails([])); // a failed rails fetch must never break the briefing
   }, []);
+
+  // Fetch on mount AND whenever pull-to-refresh bumps refreshSignal — so a follow/unfollow or new
+  // stories show without an app relaunch.
+  useEffect(() => {
+    load();
+  }, [load, refreshSignal]);
+
+  // Revalidate on foreground (WebView/tab resume) — the classic SWR refresh moment. Re-fetching
+  // replaces the whole rails payload, so an optimistically-cleared badge resolves to server truth.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onVisible = () => {
+      if (document.visibilityState === "visible") load();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [load]);
 
   const onOpen = useCallback(
     (rail: FollowRail, clusterId?: number) => {


### PR DESCRIPTION
## Unify A (frontend): refresh Your Topics + News You Follow without a relaunch

Closes the "each time I go back to home it reloads / topics only update after an app relaunch" friction, and fixes the **HIGH data-loss** finding the Unify-B review surfaced.

### 1. Refresh without relaunch
- **Your Topics** now reads `getTopics` through the two-tier SWR cache (`useCachedResource`, `topics:home`): instant paint from cache, **revalidate on foreground** (WebView resume), plus a `refresh()` that pull-to-refresh drives. A follow/unfollow made on another screen now shows on home without relaunching.
- **News You Follow** (`FollowRails`) gains a `refreshSignal` prop (bumped by pull-to-refresh) and a `visibilitychange` listener → the rails re-fetch on pull **and** on foreground. Re-fetching replaces the whole payload, so an optimistically-cleared badge resolves back to server truth.
- `handleRefresh` now revalidates **briefing + topics + rails** together.

### 2. Fix review finding #7 (HIGH — silent topic wipe)
The Settings "Your Topics" toggle seeded its set from stale `localStorage` / 8 hardcoded defaults and PUT it as the **full** interests list. On a fresh device / cleared storage / first Capacitor launch (empty `localStorage` → defaults), **one tap replaced the user's real interests** — and, with Unify-B's follow-reconcile, their topic follows too. Now `fetchSettings` seeds the toggle set from **server truth** (`getTopics().your_topics`), so a toggle is a precise add/remove against the user's actual topics.

### Tests / validation
- +2 `FollowRails` tests (re-fetch on `refreshSignal`, re-fetch on foreground), +2 `settings` tests (toggle sends the reconciled server set, not the defaults).
- **Full frontend suite: 160 passed** (41 files). **Production build clean** (webpack, all 18 routes, TypeScript ✓). Copy-guard: 0 errors.
- Local browser QA is blocked on Windows-ARM (the Next dev `/api` proxy to the Docker backend hangs), so verification is via vitest + build + DOM assertions per the project's established practice.

### Relationship to other PRs
Independent, frontend-only, off `master`. Backend unify is #131; the same-term rail dedupe (review finding #9) is #132. All three can merge in any order. Finding #7 is fixed here as flagged in #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
