### PR TITLE
fix(follows): redirect a redundant saved_search to an existing topic/entity follow

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2011,6 +2011,25 @@ async def create_follow(body: FollowCreate, db: AsyncSession = Depends(get_db)):
     ).scalar_one_or_none()
     if existing is not None:
         return FollowOut.model_validate(existing)
+    # WS-2 dedupe (write-side): a saved_search is the least precise rail, so if a more-precise
+    # topic/entity follow already covers this value (case-insensitively), return THAT follow instead
+    # of minting a redundant row that would render a second identical header. Prefer topic (the exact
+    # ArticleTopic match) over entity. Closes the door the interests<->topic-follow unify opened — a
+    # chip/onboarding auto-creates the topic follow, and "Follow this search" would re-add it as free
+    # text. rails._dedupe_follows still covers rows minted by other paths (read-side complement).
+    if kind == "saved_search":
+        for _pkind in ("topic", "entity"):
+            precise = (
+                await db.execute(
+                    select(Follow).where(
+                        Follow.user_id == current_user_id(),
+                        Follow.kind == _pkind,
+                        func.lower(Follow.value) == value.lower(),
+                    )
+                )
+            ).scalars().first()
+            if precise is not None:
+                return FollowOut.model_validate(precise)
     # WS-2 (#112): cap free-text follows so the rails section stays a curated shelf, not a firehose.
     if kind == "saved_search":
         from app.config import settings as _cfg

--- a/backend/tests/integration/test_follows.py
+++ b/backend/tests/integration/test_follows.py
@@ -47,3 +47,33 @@ async def test_follow_rejects_invalid_kind(aclient, db_session):
     await _user(db_session)
     r = await aclient.post("/follows", json={"kind": "bogus", "value": "x"})
     assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_saved_search_redirects_to_existing_topic_follow(aclient, db_session):
+    """Write-side dedupe: when a topic follow already covers a value, creating a saved_search on the
+    SAME value (case-insensitively) must NOT mint a redundant row — it returns the existing topic
+    follow. Prevents the duplicate-rail collision at the source (complements rails._dedupe_follows)."""
+    await _user(db_session)
+    topic = (await aclient.post("/follows", json={"kind": "topic", "value": "AI"})).json()
+
+    # "Follow this search: ai" — same value, different case — must resolve to the existing topic row.
+    r = await aclient.post("/follows", json={"kind": "saved_search", "value": "ai"})
+    assert r.status_code == 201
+    assert r.json()["id"] == topic["id"]      # redirected, not a new row
+    assert r.json()["kind"] == "topic"        # kept the precise topic follow
+
+    follows = (await aclient.get("/follows")).json()
+    assert [f["kind"] for f in follows] == ["topic"]              # exactly one follow, no saved_search
+    assert not any(f["kind"] == "saved_search" for f in follows)
+
+
+@pytest.mark.asyncio
+async def test_saved_search_still_created_when_no_topic_collision(aclient, db_session):
+    """Guard is narrow: a saved_search whose value no topic/entity follow covers is created normally."""
+    await _user(db_session)
+    r = await aclient.post("/follows", json={"kind": "saved_search", "value": "US Iran war"})
+    assert r.status_code == 201
+    assert r.json()["kind"] == "saved_search"
+    assert any(f["kind"] == "saved_search" and f["value"] == "US Iran war"
+               for f in (await aclient.get("/follows")).json())


### PR DESCRIPTION
Follow-up to #132. That PR deduped the collision at **render** time; this one closes it at the **source** so the duplicate row is never born.

## Problem

`uq_follow` keys on `(user_id, kind, value)`, so a `topic` 'AI' and a `saved_search` 'AI' are two legal rows. The interests↔topic-follow unify makes this collision routine: a chip / onboarding auto-creates the **topic** follow, while search's "Follow this search" on the same text creates a **saved_search** follow. Result: a redundant row that renders a second identical "News You Follow" header.

## Fix

In `POST /follows` (`create_follow`), after the exact-dup idempotency check: when creating a `saved_search`, if a more-precise **topic** (then **entity**) follow already covers the same value **case-insensitively**, return that existing follow instead of minting a new row.

- `saved_search` is the least precise rail, so the precise topic/entity rail wins — matching `rails._dedupe_follows`' priority (topic > entity > saved_search).
- Narrow scope: only a redundant `saved_search` is redirected. Rows minted by **other** paths (e.g. a topic auto-created *after* a saved_search already exists) are still collapsed at render by `_dedupe_follows` — this is the **write-side complement**, not a replacement.
- Behavior matches the endpoint's existing idempotent branch (returns the existing `FollowOut`).

## Tests (`tests/integration/test_follows.py`)

- `test_saved_search_redirects_to_existing_topic_follow` — POST `saved_search` 'ai' with an existing topic 'AI' returns the **topic** row (same id), and the user ends with exactly one follow, no `saved_search`.
- `test_saved_search_still_created_when_no_topic_collision` — a `saved_search` with no topic/entity collision is created normally (guard stays narrow).

Verified the redirect test **fails without the guard** (a new row is minted: `assert 42 == 41`) and **passes with it**.

## Verification (Docker, `newslens-backend-ig` image → isolated `tdd_guard` DB)

- `test_follows.py`: 6 passed · `test_rails.py`: 9 passed
- **Full backend suite: 544 passed, 1 skipped** (skip + warnings pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)