### PR TITLE
fix(discover): swipe-born interests get a topic follow (unify swipe half)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1251,6 +1251,17 @@ async def record_swipe(
                             weight=max(0.0, 1.0 + weight_delta),
                         )
                     )
+                # Unify (swipe half): a POSITIVE swipe (right/up) is an explicit "more of this",
+                # so mirror it into a kind='topic' Follow — otherwise a swipe-born interest shows in
+                # Your Topics / the topic chips / feed rank but never gets a "News You Follow" rail,
+                # re-forking the two lists the unify feature keeps as one. _sync_topic_follow is
+                # idempotent + case-insensitive (reuses the canonical Topic.name) and self-heals the
+                # interest; its topic backfill is deduped + config-gated (a no-op in the test harness).
+                # A LEFT swipe is NEGATIVE: it still nudges the interest weight (max(0, 1-0.2)=0.8) but
+                # must NOT raise a rail for a topic the user swiped AWAY from — hence the weight_delta>0
+                # gate (unknown/zero-delta directions fall through too).
+                if weight_delta > 0:
+                    await _sync_topic_follow(db, at.topic.name)
                 break  # Only adjust primary topic
 
     await db.commit()

--- a/backend/tests/integration/test_unify_topics_follows.py
+++ b/backend/tests/integration/test_unify_topics_follows.py
@@ -148,3 +148,94 @@ async def test_backfill_topics_reconciles_legacy_follow_without_interest(aclient
     r = await aclient.post("/profile/backfill-topics")
     assert r.status_code == 200
     assert await _interests(aclient) == {"Seeded A", "Seeded B"}  # follows reconciled into interests
+
+
+# ── Swipe path: a POSITIVE swipe mirrors the interest into a topic follow ──
+# (the item deferred by the 5762739 adversarial review — "needs a negative-swipe product call")
+
+
+async def _article_with_topic(db, topic_name):
+    """Seed a Source + Article tagged to a NEW Topic, so a swipe on that article has a primary topic
+    to mirror. Unique topic_name per test keeps the process-level rails cache from leaking rails across
+    tests (the negative assertions stay meaningful even on a stale-cache hit)."""
+    from datetime import datetime, timezone
+
+    from app.models import Article, ArticleTopic, Source, SourceType
+
+    src = Source(
+        name=f"src-{topic_name}", url=f"https://{topic_name}.example",
+        rss_url=f"https://{topic_name}.example/rss", source_type=SourceType.wire,
+        region="global", category="world",
+    )
+    db.add(src)
+    await db.flush()
+    topic = Topic(name=topic_name)
+    db.add(topic)
+    await db.flush()
+    art = Article(
+        title=f"{topic_name} headline", url=f"https://{topic_name}.example/a1",
+        source_id=src.id, snippet="A snippet.", published_at=datetime.now(timezone.utc),
+    )
+    db.add(art)
+    await db.flush()
+    db.add(ArticleTopic(article_id=art.id, topic_id=topic.id, relevance_score=1.0))
+    await db.flush()
+    return art, topic
+
+
+async def _rail_keys(aclient):
+    """Set of (kind, value) for the "News You Follow" rails — one per rail-able follow (even empty)."""
+    rails = (await aclient.get("/follows/rails")).json()["rails"]
+    return {(r["kind"], r["value"]) for r in rails}
+
+
+@pytest.mark.asyncio
+async def test_right_swipe_creates_interest_and_topic_follow(aclient, db_session, monkeypatch):
+    """Deferred gap from 5762739: a POSITIVE (right) swipe must create BOTH the UserPreference interest
+    AND the matching kind='topic' Follow — so a swipe-born interest also earns a "News You Follow" rail
+    instead of showing only in Your Topics / chips / feed rank."""
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+    art, _ = await _article_with_topic(db_session, "Space Exploration")
+    await db_session.commit()
+
+    r = await aclient.post("/discover/swipe", json={"article_id": art.id, "direction": "right"})
+    assert r.status_code == 204
+
+    assert "Space Exploration" in await _interests(aclient)                 # interest (existing behavior)
+    assert await _topic_follow_values(aclient) == ["Space Exploration"]     # topic follow (the fix)
+    assert ("topic", "Space Exploration") in await _rail_keys(aclient)      # → surfaces a rail
+
+
+@pytest.mark.asyncio
+async def test_up_swipe_also_creates_topic_follow(aclient, db_session, monkeypatch):
+    """The other positive direction (up / save, +0.3) mirrors into a topic follow too — the gate is
+    weight_delta > 0, not literally "right"."""
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+    art, _ = await _article_with_topic(db_session, "Marine Biology")
+    await db_session.commit()
+
+    r = await aclient.post("/discover/swipe", json={"article_id": art.id, "direction": "up"})
+    assert r.status_code == 204
+    assert await _topic_follow_values(aclient) == ["Marine Biology"]
+
+
+@pytest.mark.asyncio
+async def test_left_swipe_creates_no_follow_and_no_rail(aclient, db_session, monkeypatch):
+    """A NEGATIVE (left) swipe must NOT create a topic follow nor surface a rail for a topic the user
+    swiped AWAY from — even though it still nudges the interest weight (the intentional asymmetry that
+    is the whole reason for the weight_delta > 0 gate)."""
+    monkeypatch.setattr(fetcher, "schedule_topic_backfill", lambda tid: None)
+    await _ensure_user(db_session)
+    art, _ = await _article_with_topic(db_session, "Competitive Curling")
+    await db_session.commit()
+
+    r = await aclient.post("/discover/swipe", json={"article_id": art.id, "direction": "left"})
+    assert r.status_code == 204
+
+    assert await _topic_follow_values(aclient) == []                            # no topic follow
+    assert ("topic", "Competitive Curling") not in await _rail_keys(aclient)    # no rail surfaced
+    # The interest IS still created (weight max(0, 1-0.2)=0.8): a left swipe nudges personalization but
+    # must not promote the topic into "News You Follow".
+    assert "Competitive Curling" in await _interests(aclient)


### PR DESCRIPTION
## What

Closes the swipe-path gap the adversarial review of the interests↔topic-follows unify (commit `5762739`) surfaced — the item PR #131's hardening (`b6219af`) **explicitly deferred**:

> Deferred (tracked separately): swipe path interest->follow mirroring (needs a negative-swipe product call)

`record_swipe` (`POST /discover/swipe`) already creates/adjusts a `UserPreference` interest for the swiped article's primary topic, but never created the matching `kind='topic'` `Follow`. So a **swipe-born** interest showed in *Your Topics* / the topic chips / feed personalization yet got **no "News You Follow" rail** — re-forking the two lists the unify feature is meant to keep as one.

## The negative-swipe product call

A LEFT (negative) swipe *also* writes a positive-weight interest (`max(0.0, 1.0 - 0.2) = 0.8`) — it nudges personalization. Naively mirroring every swipe into a follow would raise a rail for a topic the user swiped **away** from. So the fix gates strictly on **positive** swipes:

| Direction | Δweight | Interest | Topic follow + rail |
|-----------|--------:|:--------:|:-------------------:|
| right     | +0.1    | ✅ (existing) | ✅ **new** |
| up (save) | +0.3    | ✅ (existing) | ✅ **new** |
| left      | −0.2    | ✅ (weight 0.8, unchanged) | ❌ (correct) |

## How

For positive swipes only (`weight_delta > 0`) `record_swipe` now calls the existing **`_sync_topic_follow()`** helper (introduced by #131's hardening), which in one transaction, idempotently and **case-insensitively**:
- creates the `kind='topic'` Follow with the canonical `Topic.name`,
- self-heals the `UserPreference` interest (ON CONFLICT DO NOTHING preserves the swipe's adjusted weight),
- invalidates the rails cache, and
- schedules the (deduped, config-gated) topic backfill.

No new endpoint, model, or migration. One 11-line branch in `record_swipe`.

## Tests

+3 integration tests in `test_unify_topics_follows.py`:
- right-swipe → creates the interest **and** the topic follow **and** surfaces a `("topic", …)` rail,
- up-swipe → also creates the topic follow (proves the gate is `weight_delta > 0`, not literally `"right"`),
- left-swipe → creates **neither** a follow nor a rail (while confirming the interest is still written — the intentional asymmetry).

Full backend suite in Docker (`db-test`/`tdd`): **551 passed, 1 skipped** (was 548 + 1; +3 new).

## Stacking / merge

Stacked on **#131** (`claude/unify-topics-follows`) because `_sync_topic_follow` and the whole unify feature live there and are **not yet on `master`**. Base retargets to `master` automatically once #131 lands. **Please review — do not merge ahead of #131.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)