### PR TITLE
fix(clustering): embed article body + reconcile/collapse to stop same-event under-clustering

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -261,13 +261,15 @@ async def get_feed(
             as_of = as_of.replace(tzinfo=timezone.utc)
         query = query.where(Article.fetched_at <= as_of)
 
-    # G2: when personalizing, fetch a bounded recent pool and rerank it (recency + entity relevance)
-    # BEFORE paginating, so a high-affinity story can cross page boundaries within the horizon. When
-    # off, take the exact legacy path (count + offset/limit) → byte-identical response.
-    if app_settings.uer_enabled:
+    # Fetch a bounded recent pool whenever we need the full candidate set BEFORE paginating — either to
+    # personalize (rerank so a high-affinity story crosses page boundaries) OR to collapse same-cluster
+    # siblings to one row (Phase 4). Only when BOTH are off do we take the exact legacy path
+    # (count + offset/limit) → byte-identical response.
+    use_pool = app_settings.uer_enabled or app_settings.feed_collapse_clusters
+    if use_pool:
         pool_result = await db.execute(query.limit(app_settings.uer_feed_pool_size))
         articles = pool_result.scalars().all()
-        total = len(articles)  # personalization horizon = the pool
+        total = len(articles)  # provisional (pool horizon); corrected after any collapse below
     else:
         count_query = select(func.count()).select_from(query.subquery())
         total = (await db.execute(count_query)).scalar_one()
@@ -309,8 +311,8 @@ async def get_feed(
             ).all()
             clusters_with_summary = {row[0] for row in sum_rows}
 
-    # G2: rerank the pool by the recency+relevance blend, then slice the requested page. When off,
-    # `articles` is already the legacy page, so page_articles == articles (byte-identical).
+    # G2: rerank the pool by the recency+relevance blend (in place). The page slice happens in the
+    # collapse block below (pool path) or is a no-op passthrough on the legacy path.
     if app_settings.uer_enabled:
         from app.services import entities
 
@@ -337,6 +339,23 @@ async def get_feed(
             key=lambda a: (blends[a.id], pub_ts[a.id] if pub_ts[a.id] is not None else float("-inf"), a.id),
             reverse=True,
         )
+
+    # Phase 4: collapse same-cluster siblings to ONE representative (the first in the current order =
+    # freshest / top-ranked), keeping each unclustered article as its own row. Done BEFORE the page
+    # slice so per_page counts STORIES, not articles; get_cluster still shows every sibling. See
+    # docs/fixes/follow-rails-identical-rootcause.md.
+    if use_pool:
+        if app_settings.feed_collapse_clusters:
+            _seen: set[int] = set()
+            _collapsed: list[Article] = []
+            for a in articles:
+                cid = art_to_cluster.get(a.id)
+                if cid is None or cid not in _seen:
+                    if cid is not None:
+                        _seen.add(cid)
+                    _collapsed.append(a)
+            articles = _collapsed
+        total = len(articles)  # stories in the horizon (post-collapse)
         page_articles = articles[offset:offset + per_page]
     else:
         page_articles = articles

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -227,6 +227,15 @@ class Settings(BaseSettings):
     embedding_quota_cooldown_minutes: int = 30   # after a 429, skip backfill runs this long (RPD resets)
     embedding_error_cooldown_minutes: int = 10   # after a systemic non-quota failure (nothing embedded
                                                  # even per-text), back off this long instead of re-firing
+    # Article-embedding INPUT. Historically the vector was title + snippet[:300] only — the full body
+    # (extracted_text, ≤16k) was captured but NEVER embedded, starving BOTH clustering (doc↔doc NN) and
+    # the saved-search rails/search (query↔doc ANN) of the shared body signal — see
+    # docs/fixes/follow-rails-identical-rootcause.md. >0 folds a bounded body window into the embed text
+    # (falling back to snippet, then title); 0 restores the legacy snippet-only behavior. CHANGING THIS
+    # REQUIRES A RE-EMBED (scripts/reembed.py) so old/new vectors are comparable, plus re-tuning
+    # cluster_similarity_threshold + rails_dist_*. Kept modest (not the full 16k) to avoid whole-article
+    # topic drift over-merging distinct same-domain events.
+    embedding_body_chars: int = 2000
 
     # Summary config
     summary_model: str = "gpt-4o-mini"
@@ -248,6 +257,23 @@ class Settings(BaseSettings):
     # Clustering
     cluster_similarity_threshold: float = 0.15  # cosine distance (1 - similarity)
     new_topic_max_similarity: float = 0.6
+    # Phase 3 (docs/fixes/follow-rails-identical-rootcause.md) — periodic cluster reconcile/merge.
+    # Fixes the "permanent parallel singletons" trap: the strict join bar + single-linkage can seed two
+    # clusters for ONE event, and placement is permanent with no merge. This job merges clusters whose
+    # centroids are a tight pure-semantic match, OR a looser match CONFIRMED by a shared entity/topic
+    # (mirrors the rails precision guard). Ship DARK (off) until the Phase-2 threshold is calibrated —
+    # it reassigns rows, so it is harder to reverse than a threshold bump. Thresholds are hypotheses;
+    # calibrate with scripts/measure_cluster_distances.py.
+    cluster_merge_enabled: bool = False
+    cluster_merge_interval_minutes: int = 60
+    cluster_merge_window_hours: int = 72      # only reconcile clusters with an article this recent
+    cluster_merge_max: int = 300              # cap candidate clusters/run (bounds the O(k^2) centroid scan)
+    cluster_merge_threshold_tight: float = 0.13  # pure-semantic centroid match → merge, no confirmation
+    cluster_merge_threshold_loose: float = 0.25  # merge only when a shared entity/topic confirms
+    # Phase 4 — collapse same-cluster articles to ONE feed row (freshest/top-ranked representative) so a
+    # 3-source story shows once with a source_count badge instead of 3 near-identical rows. On ⇒ the feed
+    # always paginates over a bounded pool (like the personalized path) so per_page counts STORIES.
+    feed_collapse_clusters: bool = True
 
     # Recommendation
     default_explore_ratio: float = 0.3

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -147,7 +147,7 @@ async def start_scheduler():
     from app.services.fetcher import fetch_all_rss
     from app.services.gdelt import fetch_gdelt
     from app.services.embeddings import backfill_embeddings
-    from app.services.clustering import run_clustering
+    from app.services.clustering import reconcile_clusters, run_clustering
     from app.services.summarizer import backfill_summaries
     from app.services.fetcher import backfill_topic_assignments
     from app.services.entities import backfill_entities
@@ -215,6 +215,19 @@ async def start_scheduler():
         minutes=settings.rss_fetch_interval_minutes,
         id="clustering",
         replace_existing=True,
+    )
+    # Phase 3 (docs/fixes/follow-rails-identical-rootcause.md): periodic cluster reconcile/merge — folds
+    # same-event clusters mis-seeded as parallel singletons. Internally gated by cluster_merge_enabled
+    # (dark by default); max_instances=1 + coalesce so a slow centroid scan never overlaps itself.
+    scheduler.add_job(
+        reconcile_clusters,
+        "interval",
+        minutes=settings.cluster_merge_interval_minutes,
+        id="cluster_reconcile",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=300,
     )
     scheduler.add_job(
         backfill_summaries,

--- a/backend/app/services/clustering.py
+++ b/backend/app/services/clustering.py
@@ -6,13 +6,14 @@ O(n^2) pairwise comparison in Python.
 """
 
 import structlog
-from sqlalchemy import select, text
+from sqlalchemy import delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database import async_session
 from app.models import (
     Article,
+    ArticleEntity,
     ArticleTopic,
     ClusterArticle,
     ClusterEdge,
@@ -144,7 +145,12 @@ async def _find_nearest_cluster(article: Article) -> int | None:
     or None if this should start a new cluster.
     """
     async with async_session() as session:
-        # Use pgvector cosine distance operator to find similar articles that are already in clusters.
+        # Fetch the nearest already-clustered article WITHOUT the threshold in the WHERE, then apply the
+        # threshold in Python. This is behaviourally identical to filtering in SQL (the global-nearest
+        # is the nearest-under-threshold iff it is itself under threshold), but it lets us LOG the
+        # near-miss distance for every article — the doc↔doc distribution needed to calibrate
+        # cluster_similarity_threshold from real data (mirrors rails' rail_distance_histogram). See
+        # docs/fixes/follow-rails-identical-rootcause.md. The ORDER BY … LIMIT 1 rides the HNSW index.
         try:
             result = await session.execute(
                 text("""
@@ -152,14 +158,10 @@ async def _find_nearest_cluster(article: Article) -> int | None:
                     FROM articles a
                     JOIN cluster_articles ca ON ca.article_id = a.id
                     WHERE a.embedding IS NOT NULL
-                      AND a.embedding <=> :embedding < :threshold
                     ORDER BY distance
                     LIMIT 1
                 """),
-                {
-                    "embedding": vector_literal(article.embedding),
-                    "threshold": settings.cluster_similarity_threshold,
-                },
+                {"embedding": vector_literal(article.embedding)},
             )
             row = result.first()
         except Exception as e:  # noqa: BLE001 — a NN lookup failure must not abort the whole run;
@@ -167,7 +169,213 @@ async def _find_nearest_cluster(article: Article) -> int | None:
             logger.warning("cluster_nn_lookup_failed", article_id=getattr(article, "id", None), error=str(e))
             return None
 
-        if row:
-            return row[0]  # cluster_id
+        if not row:
+            return None
+
+        cluster_id, distance = row[0], float(row[1])
+        threshold = settings.cluster_similarity_threshold
+        # Near-miss = just outside the bar (threshold ≤ dist < 2×threshold): the same-event pair we are
+        # most likely failing to club. A pile of these is the signal to loosen the threshold (Phase 2).
+        logger.info(
+            "cluster_distance_probe",
+            article_id=getattr(article, "id", None),
+            nearest_cluster_id=cluster_id,
+            distance=round(distance, 4),
+            threshold=threshold,
+            matched=distance < threshold,
+            near_miss=threshold <= distance < threshold * 2,
+        )
+        return cluster_id if distance < threshold else None
 
     return None
+
+
+# ── Phase 3: cluster reconcile / merge ───────────────────────────────────────────────
+# See docs/fixes/follow-rails-identical-rootcause.md. The strict 0.15 join bar + single-linkage +
+# permanent placement can seed TWO clusters for one event that never reconcile. This job merges them.
+
+
+async def _cluster_entity_sets(session: AsyncSession, cluster_ids: list[int]) -> dict[int, set[int]]:
+    """cluster_id -> set of entity_ids featured in its articles (loose-band merge confirmation)."""
+    rows = (
+        await session.execute(
+            select(ClusterArticle.cluster_id, ArticleEntity.entity_id)
+            .join(ArticleEntity, ArticleEntity.article_id == ClusterArticle.article_id)
+            .where(ClusterArticle.cluster_id.in_(cluster_ids))
+        )
+    ).all()
+    out: dict[int, set[int]] = {}
+    for cid, eid in rows:
+        out.setdefault(cid, set()).add(eid)
+    return out
+
+
+async def _cluster_topic_sets(session: AsyncSession, cluster_ids: list[int]) -> dict[int, set[int]]:
+    """cluster_id -> set of topic_ids on its articles. Topics are assigned at ingest, so this
+    confirmation works on singletons too — unlike entities, which need a settled (≥2-source) cluster."""
+    rows = (
+        await session.execute(
+            select(ClusterArticle.cluster_id, ArticleTopic.topic_id)
+            .join(ArticleTopic, ArticleTopic.article_id == ClusterArticle.article_id)
+            .where(ClusterArticle.cluster_id.in_(cluster_ids))
+        )
+    ).all()
+    out: dict[int, set[int]] = {}
+    for cid, tid in rows:
+        out.setdefault(cid, set()).add(tid)
+    return out
+
+
+async def _merge_into(session: AsyncSession, survivor: int, losers: list[int]) -> None:
+    """Fold `losers` into `survivor` in ONE transaction. FK order matters (cluster_articles and
+    cluster_edges are RESTRICT): move the child cluster_articles off each loser, drop its best-effort
+    timeline edges, THEN delete the emptied cluster (impressions CASCADE). No article overlap is
+    possible — an article lives in exactly one cluster — so uq_cluster_article can't fire."""
+    for lid in losers:
+        await session.execute(
+            update(ClusterArticle).where(ClusterArticle.cluster_id == lid).values(cluster_id=survivor)
+        )
+        # Drop edges touching the loser rather than re-point (avoids self-edge + uq_cluster_edge
+        # conflicts); timeline links are best-effort and re-form on cluster creation.
+        await session.execute(
+            delete(ClusterEdge).where(
+                or_(ClusterEdge.src_cluster_id == lid, ClusterEdge.dst_cluster_id == lid)
+            )
+        )
+        await session.execute(delete(StoryCluster).where(StoryCluster.id == lid))
+    # Survivor's article set changed → every source-set-keyed cache is stale. Clearing source_hash
+    # invalidates the lens read-paths; nulling summary re-arms the snippet fallback + schedule_summary.
+    await session.execute(
+        update(StoryCluster)
+        .where(StoryCluster.id == survivor)
+        .values(
+            summary=None,
+            summary_generated_at=None,
+            coherence=None,
+            analysis_json=None,
+            impact_json=None,
+            strategic_json=None,
+            trivia_json=None,
+            extra_json=None,
+            source_hash=None,
+        )
+    )
+
+
+async def reconcile_clusters() -> None:
+    """Merge same-event clusters mis-seeded as parallel singletons. Centroid-distance driven with a
+    two-tier precision guard (tight pure-semantic OR loose + shared entity/topic) and union-find so a
+    chain A~B~C collapses to one. Gated by cluster_merge_enabled. Idempotent + skip-tolerant: each
+    group merges in its own transaction, one failure never aborts the rest, and a re-run is a no-op
+    once the near-duplicates are gone. See docs/fixes/follow-rails-identical-rootcause.md."""
+    if not settings.cluster_merge_enabled:
+        return
+
+    from datetime import datetime, timedelta, timezone
+
+    import numpy as np
+
+    async with async_session() as session:
+        since = datetime.now(timezone.utc) - timedelta(hours=settings.cluster_merge_window_hours)
+        cand_ids = (
+            await session.execute(
+                select(ClusterArticle.cluster_id)
+                .join(Article, Article.id == ClusterArticle.article_id)
+                .where(Article.published_at.isnot(None), Article.published_at >= since)
+                .distinct()
+                .limit(settings.cluster_merge_max)
+            )
+        ).scalars().all()
+        if len(cand_ids) < 2:
+            return
+
+        rows = (
+            await session.execute(
+                select(ClusterArticle.cluster_id, Article.embedding)
+                .join(Article, Article.id == ClusterArticle.article_id)
+                .where(ClusterArticle.cluster_id.in_(cand_ids), Article.embedding.isnot(None))
+            )
+        ).all()
+        vecs: dict[int, list] = {}
+        for cid, emb in rows:
+            if emb is not None:
+                vecs.setdefault(cid, []).append(np.asarray(emb, dtype=float))
+        ids = [c for c in cand_ids if c in vecs]
+        if len(ids) < 2:
+            return
+
+        # Per-cluster L2-normalized centroid → dot product IS cosine similarity; distance = 1 - dot.
+        cents = []
+        for c in ids:
+            m = np.mean(np.stack(vecs[c]), axis=0)
+            norm = float(np.linalg.norm(m))
+            cents.append(m / norm if norm > 0 else m)
+        sim = np.stack(cents) @ np.stack(cents).T
+
+        counts = dict(
+            (
+                await session.execute(
+                    select(ClusterArticle.cluster_id, func.count())
+                    .where(ClusterArticle.cluster_id.in_(ids))
+                    .group_by(ClusterArticle.cluster_id)
+                )
+            ).all()
+        )
+        ent_sets = await _cluster_entity_sets(session, ids)
+        topic_sets = await _cluster_topic_sets(session, ids)
+
+    # Union-find over confirmed merge pairs.
+    parent = {c: c for c in ids}
+
+    def _find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def _union(a: int, b: int) -> None:
+        ra, rb = _find(a), _find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    tight, loose = settings.cluster_merge_threshold_tight, settings.cluster_merge_threshold_loose
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            dist = 1.0 - float(sim[i][j])
+            if dist >= loose:
+                continue
+            if dist < tight:
+                _union(ids[i], ids[j])  # pure-semantic: merge, no confirmation
+            elif (ent_sets.get(ids[i], set()) & ent_sets.get(ids[j], set())) or (
+                topic_sets.get(ids[i], set()) & topic_sets.get(ids[j], set())
+            ):
+                _union(ids[i], ids[j])  # loose band: only with a shared entity/topic
+
+    groups: dict[int, list[int]] = {}
+    for c in ids:
+        groups.setdefault(_find(c), []).append(c)
+    merges = [g for g in groups.values() if len(g) >= 2]
+    if not merges:
+        return
+
+    merged = 0
+    for group in merges:
+        survivor = max(group, key=lambda c: (counts.get(c, 0), -c))  # most articles, tie → lowest id
+        losers = [c for c in group if c != survivor]
+        try:
+            async with async_session() as session:
+                await _merge_into(session, survivor, losers)
+                await session.commit()
+            from app.services.summarizer import schedule_summary
+
+            schedule_summary(survivor)  # article set changed → regenerate the summary in the background
+            merged += len(losers)
+        except Exception as e:  # noqa: BLE001 — one bad group must not abort the rest
+            logger.warning("cluster_merge_failed", survivor=survivor, losers=losers, error=str(e))
+
+    logger.info(
+        "cluster_reconcile_complete",
+        candidate_clusters=len(ids),
+        groups=len(merges),
+        clusters_merged=merged,
+    )

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -290,11 +290,9 @@ async def embed_article(article_id: int):
         if not article:
             return
 
-        text = article.title
-        if article.snippet:
-            text += " " + article.snippet
-
-        embedding = await generate_embedding(text)
+        # Single source of truth for the embed recipe (title + bounded body) — must match the batch
+        # path in _backfill_once so single- and batch-embedded articles land in the same space.
+        embedding = await generate_embedding(_article_embed_text(article))
 
         if embedding:
             await session.execute(
@@ -316,10 +314,25 @@ async def embed_article(article_id: int):
 
 
 def _article_embed_text(article: Article) -> str:
-    text = article.title or ""
-    if article.snippet:
-        text += " " + article.snippet
-    return text
+    """Text fed to the embedding model for an article. Title + a bounded slice of the article BODY
+    (extracted_text), falling back to the card snippet and then to title-only.
+
+    Historically this was title + snippet[:300] ONLY: the ≤16k-char body was captured (models.py
+    extracted_text) but never embedded, which starved BOTH clustering (doc↔doc NN) AND the
+    saved-search rails/search (query↔doc ANN) — every feature that matches on articles.embedding — of
+    the shared body signal that makes same-event coverage from different outlets look similar. See
+    docs/fixes/follow-rails-identical-rootcause.md. `embedding_body_chars=0` restores the legacy path.
+    """
+    title = article.title or ""
+    n = settings.embedding_body_chars
+    if n > 0:
+        # Prefer the full body; snippet is a 300-char prefix of it, so this is a strict superset when
+        # a body exists. Fall back to snippet (then nothing) when no body was extracted.
+        body = (article.extracted_text or article.snippet or "")[:n]
+    else:
+        body = article.snippet or ""  # legacy: card snippet only
+    text = f"{title} {body}".strip() if body else title
+    return text or title
 
 
 async def backfill_embeddings(session=None):

--- a/backend/scripts/measure_cluster_distances.py
+++ b/backend/scripts/measure_cluster_distances.py
@@ -1,0 +1,104 @@
+"""Calibrate cluster_similarity_threshold from REAL doc↔doc distances.
+
+Clustering joins an article to a cluster iff its cosine distance to some already-clustered article is
+< cluster_similarity_threshold (0.15). Nobody has ever measured the actual nearest-neighbour distance
+distribution of this corpus — 0.15 was set in the initial scaffold and never tuned. This samples
+recent embedded articles, finds each one's nearest OTHER article, and histograms the distances. If a
+lot of mass sits in 0.15–0.30, the threshold is too strict and same-event pairs are being split into
+separate clusters. Set the threshold at the valley before the off-topic tail.
+
+Mirrors scripts/measure_follow_distances.py (which does the query↔doc side for rails). This side needs
+NO Gemini key — it reads stored document vectors directly. RUN AFTER a re-embed (scripts/reembed.py),
+so the vectors reflect the current embed recipe. See docs/fixes/follow-rails-identical-rootcause.md.
+
+RUN (needs DB access only):
+    cd backend
+    DATABASE_URL=postgresql+asyncpg://... python -m scripts.measure_cluster_distances --sample 300
+"""
+import argparse
+import asyncio
+import statistics
+
+from sqlalchemy import text
+
+from app.config import settings
+from app.database import async_session
+
+CANDIDATE_THRESHOLDS = (0.12, 0.15, 0.18, 0.20, 0.22, 0.25, 0.28, 0.30)
+
+
+async def _nearest_other_distances(session, sample: int, window_hours: int | None) -> list[float]:
+    """For each of the newest `sample` embedded articles, the cosine distance to its nearest OTHER
+    embedded article. One indexed ORDER BY … LIMIT 1 per sampled row."""
+    where_window = ""
+    params: dict = {"sample": sample}
+    if window_hours:
+        where_window = "AND fetched_at >= now() - (:hrs || ' hours')::interval"
+        params["hrs"] = window_hours
+    ids = (
+        await session.execute(
+            text(
+                f"SELECT id FROM articles WHERE embedding IS NOT NULL {where_window} "
+                "ORDER BY fetched_at DESC LIMIT :sample"
+            ),
+            params,
+        )
+    ).scalars().all()
+
+    dists: list[float] = []
+    for aid in ids:
+        row = (
+            await session.execute(
+                text(
+                    "SELECT b.embedding <=> (SELECT embedding FROM articles WHERE id = :aid) AS dist "
+                    "FROM articles b "
+                    "WHERE b.embedding IS NOT NULL AND b.id <> :aid "
+                    "ORDER BY dist LIMIT 1"
+                ),
+                {"aid": aid},
+            )
+        ).first()
+        if row is not None and row[0] is not None:
+            dists.append(float(row[0]))
+    return dists
+
+
+def _report(dists: list[float]) -> None:
+    if not dists:
+        print("no embedded articles in scope — run after some articles have embedded.")
+        return
+    dists = sorted(dists)
+    n = len(dists)
+    p = lambda frac: dists[min(n - 1, int(frac * n))]  # noqa: E731 — tiny local percentile
+    print(
+        f"n={n}  min={dists[0]:.3f}  p10={p(0.10):.3f}  p25={p(0.25):.3f}  "
+        f"p50={p(0.50):.3f}  p75={p(0.75):.3f}  max={dists[-1]:.3f}"
+    )
+    print(f"current cluster_similarity_threshold = {settings.cluster_similarity_threshold}\n")
+    print("nearest-neighbour pairs that WOULD merge at each candidate threshold:")
+    for t in CANDIDATE_THRESHOLDS:
+        c = sum(d < t for d in dists)
+        marker = "  <- current" if abs(t - settings.cluster_similarity_threshold) < 1e-9 else ""
+        print(f"  < {t:.2f} : {c:4d} / {n}  ({100 * c / n:5.1f}%){marker}")
+    band = sum(settings.cluster_similarity_threshold <= d < 0.30 for d in dists)
+    print(
+        f"\nnear-miss band [{settings.cluster_similarity_threshold:.2f}, 0.30): {band} pairs "
+        f"({100 * band / n:.1f}%) — these are candidate same-event pairs the current bar rejects."
+    )
+    print("Calibrate: set the threshold at the valley before the off-topic tail (watch p50/p75).")
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Histogram doc↔doc nearest-neighbour distances.")
+    parser.add_argument("--sample", type=int, default=300, help="how many recent articles to probe")
+    parser.add_argument(
+        "--window-hours", type=int, default=0, help="restrict the sample to the last N hours (0 = all time)"
+    )
+    args = parser.parse_args()
+    async with async_session() as session:
+        dists = await _nearest_other_distances(session, args.sample, args.window_hours or None)
+    _report(dists)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/reembed.py
+++ b/backend/scripts/reembed.py
@@ -1,0 +1,89 @@
+"""Re-embed the article corpus after an embed-recipe change (embedding_body_chars).
+
+Old vectors (title + snippet[:300]) and new vectors (title + bounded body) live in DIFFERENT spaces,
+so until the corpus is re-embedded, old↔new cosine distances are meaningless and clustering / rails /
+search stay half-broken. This marks `complete` articles back to `pending`; the running backend's
+5-min embedding backfill then re-embeds them under the current recipe — quota-aware (free-tier
+~1,000/day, 30-min cooldown after a 429), so a large corpus drains over several days. That is
+expected; nothing here bypasses the quota guard. See docs/fixes/follow-rails-identical-rootcause.md.
+
+Marking pending does NOT delete the old vector (the backfill overwrites it), so search/rails keep
+working on the old vector until each row is re-embedded. Note: already-clustered articles are NOT
+re-clustered by this (placement is permanent) — reconciling the existing split backlog needs the
+Phase-3 merge pass or a one-off re-cluster.
+
+RUN (needs DB access; no Gemini key required — this only flips status):
+    cd backend
+    DATABASE_URL=postgresql+asyncpg://... python -m scripts.reembed --dry-run
+    DATABASE_URL=postgresql+asyncpg://... python -m scripts.reembed              # all complete rows
+    DATABASE_URL=postgresql+asyncpg://... python -m scripts.reembed --limit 200  # newest 200 first (smoke test)
+"""
+import argparse
+import asyncio
+
+from sqlalchemy import func, select, update
+
+from app.database import async_session
+from app.models import Article, EmbeddingStatus
+
+
+async def _counts(session) -> dict[str, int]:
+    rows = (
+        await session.execute(
+            select(Article.embedding_status, func.count()).group_by(Article.embedding_status)
+        )
+    ).all()
+    return {str(getattr(s, "value", s)): n for s, n in rows}
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Re-embed articles after an embed-recipe change.")
+    parser.add_argument("--dry-run", action="store_true", help="report counts, change nothing")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="only re-queue the newest N complete rows (0 = all). Useful for a controlled smoke test.",
+    )
+    args = parser.parse_args()
+
+    async with async_session() as session:
+        before = await _counts(session)
+        complete = before.get(EmbeddingStatus.complete.value, 0)
+        print(f"embedding_status before: {before}")
+        target = complete if args.limit <= 0 else min(args.limit, complete)
+        print(f"would re-queue {target} 'complete' article(s) → 'pending'"
+              + ("" if args.limit <= 0 else f" (newest {args.limit})"))
+
+        if args.dry_run or target == 0:
+            print("dry-run — no changes." if args.dry_run else "nothing to do.")
+            return
+
+        if args.limit and args.limit > 0:
+            ids = (
+                await session.execute(
+                    select(Article.id)
+                    .where(Article.embedding_status == EmbeddingStatus.complete)
+                    .order_by(Article.fetched_at.desc())
+                    .limit(args.limit)
+                )
+            ).scalars().all()
+            stmt = (
+                update(Article)
+                .where(Article.id.in_(ids))
+                .values(embedding_status=EmbeddingStatus.pending)
+            )
+        else:
+            stmt = (
+                update(Article)
+                .where(Article.embedding_status == EmbeddingStatus.complete)
+                .values(embedding_status=EmbeddingStatus.pending)
+            )
+        result = await session.execute(stmt)
+        await session.commit()
+        print(f"re-queued {result.rowcount} row(s) → pending. The backfill will drain them (quota-bound).")
+        print(f"embedding_status after: {await _counts(session)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/integration/test_cluster_reconcile.py
+++ b/backend/tests/integration/test_cluster_reconcile.py
@@ -1,0 +1,181 @@
+"""Phase 3 (docs/fixes/follow-rails-identical-rootcause.md): reconcile_clusters merges same-event
+clusters that were mis-seeded as parallel singletons. Two-tier guard — a tight pure-semantic centroid
+match OR a looser match CONFIRMED by a shared entity/topic. The job is DESTRUCTIVE (reassigns
+ClusterArticle → survivor, drops the loser's edges, deletes the loser, clears the survivor's caches),
+so cover: the positive merge, the precision reject, the tight-band no-confirmation merge, and the
+kill-switch. Routes the job's own async_session() into the test transaction (like test_clustering_*).
+
+All assertions use column selects with ids captured as plain ints BEFORE running the job — never touch
+an ORM attribute afterwards, since a post-run expire would trigger a sync lazy-load (MissingGreenlet)."""
+import contextlib
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import (
+    Article,
+    ArticleEntity,
+    ClusterArticle,
+    EmbeddingStatus,
+    Entity,
+    Source,
+    SourceType,
+    StoryCluster,
+)
+
+DIM = 768
+_seq = 0
+
+
+def _vec(a: float, b: float) -> list[float]:
+    v = [0.0] * DIM
+    v[0], v[1] = a, b
+    return v
+
+
+# Unit vectors at a known cosine distance from _V_BASE = _vec(1, 0):
+_V_BASE = _vec(1.0, 0.0)
+_V_LOOSE = _vec(0.82, 0.5724)   # cos ≈ 0.82 → dist ≈ 0.18 → inside [tight 0.13, loose 0.25)
+_V_TIGHT = _vec(0.95, 0.3122)   # cos ≈ 0.95 → dist ≈ 0.05 → below tight
+
+
+async def _mk_entity(db_session) -> int:
+    global _seq
+    _seq += 1
+    e = Entity(canonical_name=f"Shared {_seq}", name_norm=f"shared-{_seq}", kind="org")
+    db_session.add(e)
+    await db_session.flush()
+    return e.id
+
+
+async def _mk_cluster(db_session, src_id: int, embedding, *, entity_id: int | None = None) -> tuple[int, int]:
+    """One article in its own cluster, seeded with a summary + source_hash so a merge can be shown to
+    CLEAR the survivor's caches. Optionally tie the article to `entity_id` (loose-band confirmation).
+    Returns (cluster_id, article_id) as plain ints."""
+    global _seq
+    _seq += 1
+    art = Article(
+        title=f"seed {_seq}", url=f"https://x.example/reconcile-{_seq}", source_id=src_id,
+        embedding_status=EmbeddingStatus.complete, embedding=embedding,
+        published_at=datetime.now(timezone.utc),
+    )
+    db_session.add(art)
+    await db_session.flush()
+    cl = StoryCluster(title=f"C{_seq}", summary="old summary", source_hash="oldhash")
+    db_session.add(cl)
+    await db_session.flush()
+    db_session.add(ClusterArticle(cluster_id=cl.id, article_id=art.id))
+    if entity_id is not None:
+        db_session.add(ArticleEntity(article_id=art.id, entity_id=entity_id, salience=0.7))
+    await db_session.flush()
+    return cl.id, art.id
+
+
+async def _src(db_session, url: str) -> int:
+    src = Source(name="R", url=url, source_type=SourceType.wire)
+    db_session.add(src)
+    await db_session.flush()
+    return src.id
+
+
+def _route(monkeypatch, db_session) -> list[int]:
+    """Route reconcile's own async_session() to the test transaction, stub schedule_summary, and arm
+    the kill-switch ON. Returns the list that captures scheduled survivor ids."""
+    from app.config import settings
+    from app.services import clustering, summarizer
+
+    @contextlib.asynccontextmanager
+    async def _fake():
+        yield db_session
+
+    monkeypatch.setattr(clustering, "async_session", _fake)
+    scheduled: list[int] = []
+    monkeypatch.setattr(summarizer, "schedule_summary", lambda cid: scheduled.append(cid))
+    monkeypatch.setattr(settings, "cluster_merge_enabled", True, raising=False)
+    return scheduled
+
+
+async def _cluster_ids(db_session) -> set[int]:
+    return set((await db_session.execute(select(StoryCluster.id))).scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_reconcile_merges_loose_band_when_entity_confirms(db_session, monkeypatch):
+    from app.services import clustering
+
+    scheduled = _route(monkeypatch, db_session)
+    src_id = await _src(db_session, "https://x.example/recon-src1")
+    ent_id = await _mk_entity(db_session)
+    a_cid, a_aid = await _mk_cluster(db_session, src_id, _V_BASE, entity_id=ent_id)
+    b_cid, b_aid = await _mk_cluster(db_session, src_id, _V_LOOSE, entity_id=ent_id)
+
+    await clustering.reconcile_clusters()
+
+    ids = await _cluster_ids(db_session)
+    assert b_cid not in ids and a_cid in ids  # survivor = lower id (tie on 1 article each)
+
+    locs = (
+        await db_session.execute(
+            select(ClusterArticle.cluster_id).where(ClusterArticle.article_id.in_([a_aid, b_aid]))
+        )
+    ).scalars().all()
+    assert set(locs) == {a_cid} and len(locs) == 2  # both articles reassigned to the survivor
+
+    row = (
+        await db_session.execute(
+            select(StoryCluster.summary, StoryCluster.source_hash).where(StoryCluster.id == a_cid)
+        )
+    ).first()
+    assert row == (None, None)          # survivor caches cleared (its article set changed)
+    assert scheduled == [a_cid]         # survivor rescheduled for a fresh summary
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_loose_band_without_confirmation(db_session, monkeypatch):
+    from app.services import clustering
+
+    scheduled = _route(monkeypatch, db_session)
+    src_id = await _src(db_session, "https://x.example/recon-src2")
+    a_cid, _ = await _mk_cluster(db_session, src_id, _V_BASE)   # no shared entity/topic
+    b_cid, _ = await _mk_cluster(db_session, src_id, _V_LOOSE)
+
+    await clustering.reconcile_clusters()
+
+    ids = await _cluster_ids(db_session)
+    assert {a_cid, b_cid} <= ids   # loose band with nothing to confirm → precision guard rejects
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_merges_tight_band_without_confirmation(db_session, monkeypatch):
+    from app.services import clustering
+
+    _route(monkeypatch, db_session)
+    src_id = await _src(db_session, "https://x.example/recon-src3")
+    a_cid, _ = await _mk_cluster(db_session, src_id, _V_BASE)    # no shared entity...
+    b_cid, _ = await _mk_cluster(db_session, src_id, _V_TIGHT)   # ...but a very tight centroid match
+
+    await clustering.reconcile_clusters()
+
+    ids = await _cluster_ids(db_session)
+    assert (a_cid in ids) ^ (b_cid in ids)  # exactly one survives (tight band auto-merges)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_disabled_is_noop(db_session, monkeypatch):
+    from app.config import settings
+    from app.services import clustering
+
+    scheduled = _route(monkeypatch, db_session)
+    monkeypatch.setattr(settings, "cluster_merge_enabled", False, raising=False)  # kill-switch OFF
+    src_id = await _src(db_session, "https://x.example/recon-src4")
+    ent_id = await _mk_entity(db_session)
+    a_cid, _ = await _mk_cluster(db_session, src_id, _V_BASE, entity_id=ent_id)   # would merge if enabled
+    b_cid, _ = await _mk_cluster(db_session, src_id, _V_LOOSE, entity_id=ent_id)
+
+    await clustering.reconcile_clusters()
+
+    ids = await _cluster_ids(db_session)
+    assert {a_cid, b_cid} <= ids   # disabled → both clusters remain untouched
+    assert scheduled == []

--- a/backend/tests/integration/test_feed.py
+++ b/backend/tests/integration/test_feed.py
@@ -1,5 +1,7 @@
-"""E0: /feed must report real source_count + cluster_id (multi-source visible)
-and serve the feed with a bounded query count (no per-article N+1)."""
+"""E0: /feed must report real source_count + cluster_id and, per Phase 4
+(docs/fixes/follow-rails-identical-rootcause.md), COLLAPSE same-cluster articles to one row (so a
+multi-source story is one row with an N-sources badge, not N near-identical rows), while still serving
+the feed with a bounded query count (no per-article N+1)."""
 import pytest
 from sqlalchemy import event
 
@@ -41,21 +43,29 @@ async def _seed(db_session):
 
 
 @pytest.mark.asyncio
-async def test_feed_reports_real_source_count_and_cluster(aclient, db_session):
+async def test_feed_collapses_cluster_and_reports_source_count(aclient, db_session):
     cl, _arts, _standalone = await _seed(db_session)
     resp = await aclient.get("/feed?per_page=50")
     assert resp.status_code == 200
-    items = {it["title"]: it for it in resp.json()["articles"]}
+    items = resp.json()["articles"]
 
-    c0 = items["Clustered 0"]
-    assert c0["source_count"] == 3
-    assert c0["cluster_id"] == cl.id
-    assert c0["has_ai_summary"] is True
+    # Phase 4: the 3 clustered articles collapse to ONE representative row (which of the three wins is
+    # order-dependent and not asserted), so the feed shows exactly two stories — the cluster + the
+    # standalone — not four article rows. The badge still reflects the true cluster size.
+    clustered = [it for it in items if it["cluster_id"] == cl.id]
+    assert len(clustered) == 1, f"cluster should collapse to one row, got {len(clustered)}"
+    rep = clustered[0]
+    assert rep["source_count"] == 3
+    assert rep["has_ai_summary"] is True
+    assert rep["title"] in {"Clustered 0", "Clustered 1", "Clustered 2"}
 
-    s = items["Standalone"]
-    assert s["source_count"] == 1
-    assert s["cluster_id"] is None
-    assert s["has_ai_summary"] is False
+    standalone = [it for it in items if it["title"] == "Standalone"]
+    assert len(standalone) == 1
+    assert standalone[0]["source_count"] == 1
+    assert standalone[0]["cluster_id"] is None
+    assert standalone[0]["has_ai_summary"] is False
+
+    assert len(items) == 2  # one row per cluster + the standalone
 
 
 @pytest.mark.asyncio
@@ -97,11 +107,12 @@ async def test_feed_no_n_plus_one(aclient, db_session, engine):
         event.remove(sync_engine, "before_cursor_execute", _before_cursor)
 
     assert resp.status_code == 200
-    assert len(resp.json()["articles"]) == 25
+    # Phase 4: the 4 clustered articles collapse to one row → 21 standalone + 1 cluster rep = 22.
+    assert len(resp.json()["articles"]) == 22
     # Endpoint issues a bounded set of queries: count, page, source selectin,
     # cluster-membership, per-cluster count, summary set, recent feedback, and WS-5's one-hop seed
     # probe (a single O(1) UER lookup — 0 rows for this zero-signal user, then expansion short-circuits).
-    # Far fewer than 1-per-article (which would be 25+). Allow generous headroom.
+    # Collapse is pure Python (adds no SELECTs). Far fewer than 1-per-article. Allow generous headroom.
     assert counter["n"] <= 13, f"feed issued {counter['n']} SELECTs (possible N+1)"
 
 

--- a/backend/tests/integration/test_feed_personalized.py
+++ b/backend/tests/integration/test_feed_personalized.py
@@ -172,5 +172,6 @@ async def test_feed_on_no_n_plus_one(aclient, db_session, engine, monkeypatch):
         event.remove(sync_engine, "before_cursor_execute", _before)
 
     assert resp.status_code == 200
-    assert len(resp.json()["articles"]) == 25
+    # Phase 4: the 4 clustered articles collapse to one row → 21 standalone + 1 cluster rep = 22.
+    assert len(resp.json()["articles"]) == 22
     assert counter["n"] <= 15, f"feed (personalized) issued {counter['n']} SELECTs (possible N+1)"

--- a/docs/fixes/follow-rails-identical-rootcause.md
+++ b/docs/fixes/follow-rails-identical-rootcause.md
@@ -1,0 +1,156 @@
+# Under-clustering & weak follow-rails share one root cause: the article vector never sees the body
+
+**Status:** Phases 1, 3, 4 implemented (this branch); Phase 2 (threshold retune) deliberately gated on the calibration data Phase 1 now produces. Phase 3 ships **dark** (`CLUSTER_MERGE_ENABLED=false`).
+**Surfaces affected:** story clustering · "News You Follow" saved-search rails · hybrid search
+**Owner:** backend
+**One-line:** `articles.embedding` is built from `title + snippet[:300]` only. The full body
+(`extracted_text`, ≤16k chars) is captured on every row but **never embedded**, so every feature
+that matches on that vector is starved of the shared signal.
+
+---
+
+## 1. Symptoms (two reports, one cause)
+
+1. **"News with different title/source but almost identical content isn't clubbed together."**
+   Same-event coverage from different outlets seeds separate singleton clusters instead of merging.
+2. **Follow rails (saved searches) miss obviously-relevant stories.** A saved search like
+   "US Iran war" fails to surface articles that are about exactly that, because the matching text the
+   rail sees (title + 300-char snippet) doesn't contain the query terms even when the body does.
+
+These look like two different bugs. They are the **same** bug seen through two different distance
+regimes (doc↔doc for clustering, query↔doc for rails/search).
+
+## 2. Root cause
+
+The article embedding — the vector all three features compare against — is computed from
+**title + card snippet only**, and the snippet is a hard 300-char slice that is nulled entirely when
+it is short or tag-bearing.
+
+| Fact | Location |
+|---|---|
+| Embed text = `title (+ " " + snippet)`; `extracted_text` is never read here | [`_article_embed_text`](../../backend/app/services/embeddings.py) `embeddings.py:318-322`; duplicate inline recipe in `embed_article` `embeddings.py:293-297`; prod batch path builds texts via `_article_embed_text` at `embeddings.py:368` |
+| `snippet = raw[:300]` | [`fetcher.py:587`](../../backend/app/services/fetcher.py); GDELT `full[:300]` at `gdelt.py:133` |
+| Snippet nulled when `< 50` chars (RSS) or short/tag-bearing (GDELT nulls snippet **and** body) | `fetcher.py:606`; `gdelt.py:80-82` |
+| Full body **is** stored (`extracted_text`, Text, ≤16k) — "Wave D1: for deep retrieval" | [`models.py:140`](../../backend/app/models.py) |
+| …but the body is read **only** by the deep-dive lenses, never on the embedding path | `retrieval.py:20` |
+
+Two independent outlets writing about the same event share the event's **body** facts (names,
+numbers, quotes, place) but almost always differ in **headline** and in the **first 300 chars** of
+their lede. The embedding sees only the part that differs and discards the part that agrees.
+
+### Why the same vector degrades all three surfaces
+
+```
+                      articles.embedding  =  vec( title + snippet[:300] )      ← body dropped here
+                               │
+        ┌──────────────────────┼───────────────────────────┐
+        ▼                      ▼                           ▼
+  CLUSTERING (doc↔doc)   SAVED-SEARCH RAILS (query↔doc)   SEARCH (query↔doc)
+  NN < 0.15              ANN + guard 0.22 / 0.35          hybrid semantic leg
+  clustering.py:151      rails.py:119-129                 routes.py /search
+```
+
+- **Clustering** — [`_find_nearest_cluster`](../../backend/app/services/clustering.py) `clustering.py:151-161`
+  joins only if cosine **distance < 0.15** (similarity > 0.85). That bar is calibrated for
+  near-duplicate paraphrase, not independent same-event coverage. The code itself flags that 0.15 is
+  a doc↔doc number that "does NOT transfer" (`config.py:180`), and the rails feature needed far looser
+  bands (0.22 / 0.35) for "semantically near."
+- **Saved-search rails** — [`evaluate_saved_search`](../../backend/app/services/rails.py) `rails.py:119-129`
+  runs `embedding <=> :v` ANN over the **same** starved `articles.embedding`. A body-rich article
+  whose title/snippet omit the query terms sits outside the top-k, so the rail never sees it.
+- **Search** — the hybrid semantic leg has the identical dependency.
+
+Fixing the embedding input lifts **all three** at once. This is why the two reports are one fix.
+
+## 3. Contributing / amplifying factors (verified)
+
+Ranked, all confirmed against source by a multi-agent adversarial pass:
+
+| # | Factor | Effect | Where |
+|---|---|---|---|
+| A | **Body never embedded** (root cause) | starves the vector | `embeddings.py:318` |
+| B | **Snippet nulled → title-only embed** | worst case: only the headline, which every outlet writes differently | `fetcher.py:606`, `gdelt.py:80` |
+| C | **0.15 clustering threshold too strict** for cross-source paraphrase | rejects genuine same-event pairs in the 0.15–0.30 band | `config.py:249` |
+| D | **Single-linkage + permanent placement + no merge job** | a near-miss becomes a permanent duplicate; `link_cluster` only adds timeline edges, never merges | `clustering.py:31-40, 99-137` |
+| E | **Runtime stall (operational)** | on a Gemini 429 the backfill parks 30 min; no key → hard stop. Unembedded articles are invisible to clustering — same symptom, different cause. **Check first.** | `embeddings.py:335, 371-378` |
+| F | **Feed renders one row per article, not per cluster** | a correctly-clustered 3-source story shows as 3 near-identical rows → *looks* un-clustered even when it isn't. Separate UX defect. | `routes.py` `get_feed` |
+
+**Diagnostic fork — before assuming an algorithm bug, hit `GET /pipeline`:**
+- Mostly `pending`/`failed`, or `last_embedding_error` = `quota`/`no_key`/`auth` → **factor E** (runtime stall). Fix keys/quota first.
+- Mostly `complete` but every cluster is a singleton → **factors A–D** (this doc's core).
+- Multi-article clusters exist but the feed still shows dupes → **factor F** (presentation).
+
+## 4. Plan (phased)
+
+Phase 1 is the root-cause fix and the observability needed to tune the rest from real data rather
+than by guessing. Phases 2–4 are gated on the calibration data Phase 1 produces.
+
+### Phase 1 — embed the body + wire up calibration  *(this change)*
+1. **Embed a bounded body window.** `_article_embed_text` folds `extracted_text[:embedding_body_chars]`
+   into the vector (fallback to `snippet`, then `title`). New config `embedding_body_chars` (default
+   2000; `0` restores legacy title+snippet). `embed_article` now reuses `_article_embed_text` so the
+   single- and batch-paths can never drift.
+2. **Log clustering near-miss distances.** `_find_nearest_cluster` now fetches the nearest clustered
+   article **without** the threshold filter, logs its distance (`cluster_distance_probe`, mirroring
+   rails' `rail_distance_histogram`), then applies the threshold. This exposes how many same-event
+   pairs sit in the 0.15–0.30 band — the data needed to set the threshold in Phase 2.
+3. **Tooling.** `scripts/reembed.py` re-embeds the existing corpus under the new recipe (quota-aware,
+   batched, `--dry-run`). `scripts/measure_cluster_distances.py` histograms doc↔doc NN distances to
+   calibrate the threshold.
+
+### Phase 2 — retune thresholds from the Phase-1 data  *(config-only, reversible)*
+- Raise `cluster_similarity_threshold` from 0.15 toward the knee in the observed distribution
+  (expected ~0.22–0.28), optionally gated by a shared-entity/keyword confirmation for the loose band
+  (mirroring the rails precision guard).
+- Re-check `rails_dist_tight` / `rails_dist_loose` against `measure_follow_distances.py` — the
+  richer embeddings shift the query↔doc distribution too.
+
+### Phase 3 — cluster merge / reconcile pass  *(LANDED, dark — safety net for factor D)*
+- `clustering.reconcile_clusters` (scheduled hourly, gated by `cluster_merge_enabled`): per-cluster
+  **L2-normalized centroid**, pairwise cosine, **union-find** so a chain A~B~C collapses to one, with
+  a **two-tier precision guard** mirroring rails — merge on a tight pure-semantic match
+  (`cluster_merge_threshold_tight=0.13`) OR a looser match (`cluster_merge_threshold_loose=0.25`)
+  **confirmed by a shared entity or topic**. Merge is one transaction per group: reassign
+  `ClusterArticle` → survivor (most articles, tie → lowest id), drop the loser's best-effort
+  `ClusterEdge` timeline links, delete the emptied `StoryCluster` (impressions CASCADE), and clear the
+  survivor's stale caches (`summary`/lens JSON/`source_hash`) + `schedule_summary`. Idempotent +
+  skip-tolerant; bounded to `cluster_merge_max=300` recent clusters (`cluster_merge_window_hours=72`).
+  Kills the "permanent parallel singletons" trap. **Enable only after Phase 2 calibration** — it
+  reassigns rows, so it's harder to reverse than a threshold bump.
+
+### Phase 4 — collapse same-cluster siblings in the feed  *(LANDED — fixes factor F)*
+- `get_feed` now collapses same-`cluster_id` articles to one representative (freshest / top-ranked, the
+  first in the current sort order) **before** the page slice, so `per_page` counts **stories**, not
+  articles, and `source_count` renders the "N sources" badge. Gated by `feed_collapse_clusters` (on).
+  When on, the feed always paginates over the bounded pool (like the personalized path); with both
+  `uer_enabled` and `feed_collapse_clusters` off, the legacy count+offset path is byte-identical.
+  `get_cluster` still returns every sibling, so deep-dive is unaffected.
+
+## 5. Rollout & validation
+
+1. **Re-embed is mandatory after Phase 1.** Old vectors (title+snippet) and new vectors (title+body)
+   live in different spaces; until the corpus is re-embedded, old↔new distances are meaningless. Run
+   `python -m scripts.reembed` (needs a Gemini key + DB). On free tier this is quota-bound
+   (~1,000 embeds/day) and drains over several days via the existing 5-min backfill — expected.
+2. **Then calibrate before Phase 2.** Run `measure_cluster_distances.py` + read the
+   `cluster_distance_probe` logs; set the threshold at the observed valley, not by guess.
+3. **Existing clusters do not retro-merge** on re-embed alone (placement is permanent). Phase 3's
+   merge pass — or a one-off re-cluster — is what reconciles the already-split backlog.
+
+## 6. Risks
+
+- **Topic dilution.** Too large a body window pulls in whole-article topic drift and can *over*-merge
+  distinct events in the same domain. 2000 chars is a deliberate middle; validate with the calibration
+  script before pushing it higher.
+- **Batch payload size.** 50 texts × ~2k chars is larger request bodies; if batch embeds start failing
+  on size, lower `embedding_batch_size` (the per-text fallback already isolates a poison text).
+- **Transitional mixed space** during the re-embed window — transient, resolved once the backfill
+  drains.
+
+## 7. Provenance
+
+Diagnosis produced by a 61-agent investigation with two-lens adversarial verification of every
+hypothesis (code-mechanism + causal-impact). Every `file:line` above was checked against source.
+Related note: the deep-dive "thinness" issue (body truncated for lenses) is the same family of
+defect — signal discarded at/after ingestion — but a **different** consumer of the body; this doc is
+specifically about the *embedding* input.


### PR DESCRIPTION
## Problem

News with **different title/source but near-identical content wasn't being clubbed together**. Root cause (verified by a 61-agent adversarial investigation): the article embedding — the vector clustering compares — is built from **`title + snippet[:300]` only**. The full body (`extracted_text`, ≤16k chars) is captured on every row but **never embedded**. Two outlets covering one event share the *body* facts but differ in headline + first-300-chars, so their vectors land past the strict `0.15` join bar and each seeds its own cluster.

The **same starved vector degrades three surfaces**: clustering (doc↔doc), the saved-search **rails**, and **search** (both query↔doc over `articles.embedding`). One fix lifts all three. Full write-up: [`docs/fixes/follow-rails-identical-rootcause.md`](docs/fixes/follow-rails-identical-rootcause.md).

## What's in this PR (phased)

**Phase 1 — root cause**
- Embed a bounded body window (`embedding_body_chars=2000`) in `_article_embed_text`; `embed_article` now reuses it so single/batch paths can't drift.
- `cluster_distance_probe` logging — records the nearest-cluster distance for every article (incl. near-misses) to calibrate the threshold from real data.
- `scripts/reembed.py` (quota-aware corpus re-embed) + `scripts/measure_cluster_distances.py` (doc↔doc distance histogram).

**Phase 3 — reconcile job (ships dark, `cluster_merge_enabled=false`)**
- `reconcile_clusters`: per-cluster centroid + union-find merge of same-event clusters mis-seeded as parallel singletons. Two-tier guard mirroring rails — tight pure-semantic **OR** loose + shared entity/topic. FK-safe reassign→survivor / drop edges / delete loser (impressions CASCADE) / clear survivor caches. Fixes the permanent-parallel-singletons trap.

**Phase 4 — feed collapse (`feed_collapse_clusters=on`)**
- `get_feed` collapses same-cluster articles to one representative row (with the `source_count` badge) **before** pagination, so `per_page` counts stories not articles. `get_cluster` still returns every sibling.

**Phase 2 (threshold retune) is intentionally deferred** — it should be set from the re-embed + probe data, not guessed.

## Behavior changes to note
- `feed_collapse_clusters=on` bounds the non-personalized feed to the ~500-article pool (same bound the personalized path already had).
- Deploy order: ship → `python -m scripts.reembed` (drains over days on free-tier quota) → read `cluster_distance_probe` / run `measure_cluster_distances.py` → bump `cluster_similarity_threshold` (Phase 2) → flip `CLUSTER_MERGE_ENABLED=true` (Phase 3). Phase 4 is live immediately.

## Tests
Full suite in Docker (pgvector): **558 passed, 1 skipped**. Feed integration tests updated to the collapse contract; new `test_cluster_reconcile.py` covers the merge, precision reject, tight-band auto-merge, and kill-switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)